### PR TITLE
Fixed getInstanceUrl() method. Added more tests.

### DIFF
--- a/mifosng-android/src/instrumentTest/java/com/mifos/mifosxdroid/tests/LoginActivityTest.java
+++ b/mifosng-android/src/instrumentTest/java/com/mifos/mifosxdroid/tests/LoginActivityTest.java
@@ -5,14 +5,21 @@
 
 package com.mifos.mifosxdroid.tests;
 
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.test.ActivityInstrumentationTestCase2;
+import android.test.UiThreadTest;
+import android.test.suitebuilder.annotation.MediumTest;
 import android.test.suitebuilder.annotation.SmallTest;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import com.mifos.exceptions.ShortOfLengthException;
 import com.mifos.mifosxdroid.LoginActivity;
 import com.mifos.mifosxdroid.R;
+import com.mifos.services.API;
+import com.mifos.utils.Constants;
 
 /**
  * Created by ishankhanna on 12/08/14.
@@ -26,7 +33,7 @@ public class LoginActivityTest extends ActivityInstrumentationTestCase2<LoginAct
     String TEST_URL_5 = "10.0.2.2";
 
     LoginActivity loginActivity;
-    EditText et_instance;
+    EditText et_mifos_domain;
     EditText et_username;
     TextView tv_constructed_instance_url;
 
@@ -39,25 +46,20 @@ public class LoginActivityTest extends ActivityInstrumentationTestCase2<LoginAct
         super.setUp();
 
         loginActivity = getActivity();
-        et_instance = (EditText) loginActivity.findViewById(R.id.et_instanceURL);
+        et_mifos_domain = (EditText) loginActivity.findViewById(R.id.et_instanceURL);
         et_username = (EditText) loginActivity.findViewById(R.id.et_username);
         tv_constructed_instance_url = (TextView) loginActivity.findViewById(R.id.tv_constructed_instance_url);
-
     }
 
     @SmallTest
     public void testEditTextsAreNotNull() {
-
-        assertNotNull(et_instance);
+        assertNotNull(et_mifos_domain);
         assertNotNull(et_username);
-
     }
 
     @SmallTest
     public void testAllEditTextsAreVisible() {
-
-        assertEquals(View.VISIBLE, et_instance.getVisibility());
-
+        assertEquals(View.VISIBLE, et_mifos_domain.getVisibility());
     }
 
     @SmallTest
@@ -66,26 +68,14 @@ public class LoginActivityTest extends ActivityInstrumentationTestCase2<LoginAct
         //Test if TextView has been instantiated
         assertNotNull(tv_constructed_instance_url);
 
-
         /*
             Set URL and check the color of the message, it turns green
             only if the URL matches the pattern specified
          */
-        getInstrumentation().runOnMainSync(new Runnable() {
-            @Override
-            public void run() {
-                et_instance.setText("");
-                et_instance.requestFocus();
-            }
-        });
+        enterMifosInstanceDomain(TEST_URL_1);
 
-        getInstrumentation().waitForIdleSync();
-        getInstrumentation().sendStringSync(TEST_URL_1);
-        getInstrumentation().waitForIdleSync();
-
-        assertEquals(TEST_URL_1, et_instance.getText().toString());
+        assertEquals(TEST_URL_1, et_mifos_domain.getText().toString());
         assertEquals(loginActivity.getResources().getColor(R.color.deposit_green), tv_constructed_instance_url.getCurrentTextColor());
-
     }
 
     @SmallTest
@@ -94,27 +84,12 @@ public class LoginActivityTest extends ActivityInstrumentationTestCase2<LoginAct
         //Test if TextView has been instantiated
         assertNotNull(tv_constructed_instance_url);
 
+        enterMifosInstanceDomain(TEST_URL_2);
 
-        /*
-            Set URL and check the color of the message, it turns green
-            only if the URL matches the pattern specified
-         */
-        getInstrumentation().runOnMainSync(new Runnable() {
-            @Override
-            public void run() {
-                et_instance.setText("");
-                et_instance.requestFocus();
-            }
-        });
-
-        getInstrumentation().waitForIdleSync();
-        getInstrumentation().sendStringSync(TEST_URL_2);
-        getInstrumentation().waitForIdleSync();
-
-        assertEquals(TEST_URL_2, et_instance.getText().toString());
+        assertEquals(TEST_URL_2, et_mifos_domain.getText().toString());
         assertEquals(loginActivity.getResources().getColor(R.color.deposit_green), tv_constructed_instance_url.getCurrentTextColor());
-
     }
+
 
     @SmallTest
     public void testURLInstance3(){
@@ -122,24 +97,13 @@ public class LoginActivityTest extends ActivityInstrumentationTestCase2<LoginAct
         //Test if TextView has been instantiated
         assertNotNull(tv_constructed_instance_url);
 
-
         /*
             Set URL and check the color of the message, it turns green
             only if the URL matches the pattern specified
          */
-        getInstrumentation().runOnMainSync(new Runnable() {
-            @Override
-            public void run() {
-                et_instance.setText("");
-                et_instance.requestFocus();
-            }
-        });
+        enterMifosInstanceDomain(TEST_URL_3);
 
-        getInstrumentation().waitForIdleSync();
-        getInstrumentation().sendStringSync(TEST_URL_3);
-        getInstrumentation().waitForIdleSync();
-
-        assertEquals(TEST_URL_3, et_instance.getText().toString());
+        assertEquals(TEST_URL_3, et_mifos_domain.getText().toString());
         assertEquals(loginActivity.getResources().getColor(R.color.deposit_green), tv_constructed_instance_url.getCurrentTextColor());
 
     }
@@ -150,26 +114,14 @@ public class LoginActivityTest extends ActivityInstrumentationTestCase2<LoginAct
         //Test if TextView has been instantiated
         assertNotNull(tv_constructed_instance_url);
 
-
         /*
             Set URL and check the color of the message, it turns green
             only if the URL matches the pattern specified
          */
-        getInstrumentation().runOnMainSync(new Runnable() {
-            @Override
-            public void run() {
-                et_instance.setText("");
-                et_instance.requestFocus();
-            }
-        });
+        enterMifosInstanceDomain(TEST_URL_4);
 
-        getInstrumentation().waitForIdleSync();
-        getInstrumentation().sendStringSync(TEST_URL_4);
-        getInstrumentation().waitForIdleSync();
-
-        assertEquals(TEST_URL_4, et_instance.getText().toString());
+        assertEquals(TEST_URL_4, et_mifos_domain.getText().toString());
         assertEquals(loginActivity.getResources().getColor(R.color.deposit_green), tv_constructed_instance_url.getCurrentTextColor());
-
     }
 
     @SmallTest
@@ -178,27 +130,90 @@ public class LoginActivityTest extends ActivityInstrumentationTestCase2<LoginAct
         //Test if TextView has been instantiated
         assertNotNull(tv_constructed_instance_url);
 
-
         /*
             Set URL and check the color of the message, it turns green
             only if the URL matches the pattern specified
          */
+        enterMifosInstanceDomain(TEST_URL_5);
+
+        assertEquals(TEST_URL_5, et_mifos_domain.getText().toString());
+        assertEquals(loginActivity.getResources().getColor(R.color.deposit_green), tv_constructed_instance_url.getCurrentTextColor());
+    }
+
+    @MediumTest
+    public void testSaveLastAccessedInstanceDomainName_savesProvidedString() {
+        SharedPreferences sharedPreferences = PreferenceManager
+                .getDefaultSharedPreferences(getInstrumentation().getTargetContext());
+
+        saveLastAccessedInstanceDomainName(TEST_URL_1);
+        assertEquals(TEST_URL_1, sharedPreferences.getString(Constants.INSTANCE_URL_KEY, "NA"));
+
+        saveLastAccessedInstanceDomainName(TEST_URL_2);
+        assertEquals(TEST_URL_2, sharedPreferences.getString(Constants.INSTANCE_URL_KEY, "NA"));
+    }
+
+    @MediumTest
+    public void testValidateUserInputs_savesValidDomainToSharedProperties() {
+        saveLastAccessedInstanceDomainName(TEST_URL_2);
+        enterMifosInstanceDomain(TEST_URL_1);
+        getActivity().runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    getActivity().validateUserInputs();
+                } catch (ShortOfLengthException e) {
+                    // ignore
+                }
+            }
+        });
+        getInstrumentation().waitForIdleSync();
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getInstrumentation().getTargetContext());
+        assertEquals(TEST_URL_1, sharedPreferences.getString(Constants.INSTANCE_URL_KEY, "NA"));
+    }
+
+    @MediumTest
+    public void testValidateUserInputs_setsAPIinstanceUrl() {
+        saveLastAccessedInstanceDomainName(TEST_URL_2);
+        enterMifosInstanceDomain(TEST_URL_1);
+        getActivity().runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    getActivity().validateUserInputs();
+                } catch (ShortOfLengthException e) {
+                    // ignore
+                }
+            }
+        });
+        getInstrumentation().waitForIdleSync();
+        assertEquals(getActivity().constructInstanceUrl(TEST_URL_1), API.getInstanceUrl());
+    }
+
+    private void enterMifosInstanceDomain(final String domain) {
+        clearMifosDomainTextInputField();
+        getInstrumentation().sendStringSync(domain);
+        getInstrumentation().waitForIdleSync();
+    }
+
+    private void clearMifosDomainTextInputField() {
+        getActivity().runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                et_mifos_domain.setText("");
+                et_mifos_domain.requestFocus();
+            }
+        });
+        getInstrumentation().waitForIdleSync();
+    }
+
+    private void saveLastAccessedInstanceDomainName(final String domain) {
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {
-                et_instance.setText("");
-                et_instance.requestFocus();
+                getActivity().saveLastAccessedInstanceDomainName(domain);
             }
         });
-
         getInstrumentation().waitForIdleSync();
-        getInstrumentation().sendStringSync(TEST_URL_5);
-        getInstrumentation().waitForIdleSync();
-
-        assertEquals(TEST_URL_5, et_instance.getText().toString());
-        assertEquals(loginActivity.getResources().getColor(R.color.deposit_green), tv_constructed_instance_url.getCurrentTextColor());
-
     }
-
 
 }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/LoginActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/LoginActivity.java
@@ -52,9 +52,9 @@ public class LoginActivity extends ActionBarActivity implements Callback<User>{
 
     private static final String DOMAIN_NAME_REGEX_PATTERN = "^[A-Za-z0-9-]+(\\.[A-Za-z0-9-]+)*(\\.[A-Za-z]{2,})$";
     private static final String IP_ADDRESS_REGEX_PATTERN = "^(\\d|[1-9]\\d|1\\d\\d|2([0-4]\\d|5[0-5]))\\.(\\d|[1-9]\\d|1\\d\\d|2([0-4]\\d|5[0-5]))\\.(\\d|[1-9]\\d|1\\d\\d|2([0-4]\\d|5[0-5]))\\.(\\d|[1-9]\\d|1\\d\\d|2([0-4]\\d|5[0-5]))$";
-    public static String PROTOCOL_HTTP = "http://";
-    public static String PROTOCOL_HTTPS = "https://";
-    public static String API_PATH = "/mifosng-provider/api/v1";
+    public static final String PROTOCOL_HTTP = "http://";
+    public static final String PROTOCOL_HTTPS = "https://";
+    public static final String API_PATH = "/mifosng-provider/api/v1";
     SharedPreferences sharedPreferences;
     @InjectView(R.id.et_instanceURL) EditText et_instanceURL;
     @InjectView(R.id.et_username) EditText et_username;
@@ -67,7 +67,7 @@ public class LoginActivity extends ActionBarActivity implements Callback<User>{
     private Context context;
     private String authenticationToken;
     private ProgressDialog progressDialog;
-    private String TAG = "LoginActivity";
+    private final static String TAG = "LoginActivity";
     private Pattern domainNamePattern;
     private Matcher domainNameMatcher;
     private Pattern ipAddressPattern;
@@ -120,7 +120,7 @@ public class LoginActivity extends ActionBarActivity implements Callback<User>{
             @Override
             public void afterTextChanged(Editable editable) {
 
-                String textUnderConstruction = PROTOCOL_HTTPS + editable.toString() + API_PATH;
+                String textUnderConstruction = constructInstanceUrl(editable.toString());
                 tv_constructed_instance_url.setText(textUnderConstruction);
 
                 if(!validateURL(editable.toString())) {
@@ -133,8 +133,7 @@ public class LoginActivity extends ActionBarActivity implements Callback<User>{
         });
     }
 
-    public void setupUI()
-    {
+    public void setupUI() {
         progressDialog = new ProgressDialog(context, ProgressDialog.STYLE_SPINNER);
         progressDialog.setMessage("Logging In");
         progressDialog.setCancelable(false);
@@ -146,14 +145,13 @@ public class LoginActivity extends ActionBarActivity implements Callback<User>{
 
         String urlInputValue = et_instanceURL.getEditableText().toString();
         try {
-
             if(!validateURL(urlInputValue)) {
+                Log.e(TAG, "The url is invalid: " + urlInputValue);
                 return false;
             }
-
             String validDomain = sanitizeDomainNameInput(urlInputValue);
             Log.d("Filtered URL", validDomain);
-            String constructedURL = PROTOCOL_HTTPS + validDomain + API_PATH;
+            String constructedURL = constructInstanceUrl(validDomain);
             tv_constructed_instance_url.setText(constructedURL);
             URL url = new URL(constructedURL);
             instanceURL = url.toURI().toString();
@@ -181,6 +179,9 @@ public class LoginActivity extends ActionBarActivity implements Callback<User>{
         return true;
     }
 
+    public String constructInstanceUrl(String validDomain) {
+        return PROTOCOL_HTTPS + validDomain + API_PATH;
+    }
 
     @Override
     public void success(User user, Response response) {

--- a/mifosng-android/src/main/java/com/mifos/services/API.java
+++ b/mifosng-android/src/main/java/com/mifos/services/API.java
@@ -74,7 +74,7 @@ import retrofit.mime.TypedFile;
 import retrofit.mime.TypedString;
 
 public class API {
-
+    public static final String TAG = API.class.getName();
     public static final String ACCEPT_JSON = "Accept: application/json";
     public static final String CONTENT_TYPE_JSON = "Content-Type: application/json";
     public static final String CONTENT_TYPE_MULTIPART_FORM_DATA = "Content-Type: multipart/form-data";
@@ -198,17 +198,7 @@ public class API {
     }
 
     public static synchronized String getInstanceUrl() {
-
-        SharedPreferences pref = PreferenceManager
-                .getDefaultSharedPreferences(Constants.applicationContext);
-        String savedInstanceUrl = pref.getString(Constants.INSTANCE_URL_KEY, "NA");
-
-        if(savedInstanceUrl.equals("NA")){
-            return mInstanceUrl;
-        }else{
-            return savedInstanceUrl;
-        }
-
+        return mInstanceUrl;
     }
 
     public static synchronized void setInstanceUrl(String url) {


### PR DESCRIPTION
The getInstanceUrl() returned a domain name if it was saved in the shared properies instead of an actual url.
That caused logging errors.
