### PR TITLE
Loan Officer terminology has been replaced with Staff

### DIFF
--- a/mifosng-android/src/main/res/layout/fragment_client_details.xml
+++ b/mifosng-android/src/main/res/layout/fragment_client_details.xml
@@ -171,7 +171,7 @@
                     android:layout_width="0dp"
                     android:layout_weight="0.5"
                     android:layout_height="wrap_content"
-                    android:text="@string/loan_officer" />
+                    android:text="@string/staff" />
 
                 <TextView
                     android:id="@+id/tv_loanOfficer"

--- a/mifosng-android/src/main/res/values-ca/strings.xml
+++ b/mifosng-android/src/main/res/values-ca/strings.xml
@@ -126,6 +126,7 @@
     <string name="spinner_staff">Selecciona un responsable de crèdits</string>
     <string name="staff_id">ID de l\'empleat</string>
     <string name="staff_name">Nom de l\'empleat</string>
+    <string name="staff">Personal</string>
     <string name="summary">Resum</string>
     <string name="sync">Sincronitzar</string>
     <string name="tap_to_select_date">Prem per seleccionar una data</string>

--- a/mifosng-android/src/main/res/values-en/strings.xml
+++ b/mifosng-android/src/main/res/values-en/strings.xml
@@ -64,6 +64,7 @@
 
     <!-- Loan Related Terminologies Begin Here -->
     <string name="loan_officer">Loan Officer</string>
+    <string name="staff">Staff</string>
     <string name="loan_cycle">Loan Cycle</string>
     <string name="loan_status">Status</string>
     <string name="loan_in_arrears">In Arrears</string>

--- a/mifosng-android/src/main/res/values-es/strings.xml
+++ b/mifosng-android/src/main/res/values-es/strings.xml
@@ -79,6 +79,7 @@
     <string name="withdrawal">Retirado</string>
     <string name="title_center_detail">Detalles del centro</string>
     <string name="staff_name">Nombre del empleado</string>
+    <string name="staff">Personal</string>
     <string name="staff_id">ID del empleado</string>
     <string name="spinner_staff">Selecciona responsable de créditos</string>
     <string name="spinner_office">Selecciona Oficina</string>

--- a/mifosng-android/src/main/res/values/strings.xml
+++ b/mifosng-android/src/main/res/values/strings.xml
@@ -69,6 +69,7 @@
 
     <!-- Loan Related Terminologies Begin Here -->
     <string name="loan_officer">Loan Officer</string>
+    <string name="staff">Staff</string>
     <string name="loan_cycle">Loan Cycle</string>
     <string name="loan_status">Status</string>
     <string name="loan_in_arrears">In Arrears</string>


### PR DESCRIPTION
The bug mentioned at
https://mifosforge.jira.com/browse/MIFOSX-2134
has been removed. Loan Officer terminology used in Client page has been replaced with Staff. Loan officer will remain same in Loan page though.