### PR TITLE
fixed bug #MIFOSAC-86

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientDetailsFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientDetailsFragment.java
@@ -405,14 +405,14 @@ public class ClientDetailsFragment extends Fragment implements GooglePlayService
         final String imagePath = pngFile.getAbsolutePath();
         pb_imageProgressBar.setVisibility(View.VISIBLE);
         ((MifosApplication)getActivity().getApplication()).api.clientService.uploadClientImage(clientId,
-                new  TypedFile("image/png", pngFile),
+                new TypedFile("image/png", pngFile),
                 new Callback<Response>() {
 
 
                     @Override
                     public void success(Response response, Response response2) {
                         Toast.makeText(activity, activity.getString(R.string.client_image_updated), Toast.LENGTH_SHORT).show();
-                        Bitmap  bitMap = BitmapFactory.decodeFile(imagePath);
+                        Bitmap bitMap = BitmapFactory.decodeFile(imagePath);
                         iv_clientImage.setImageBitmap(bitMap);
                         pb_imageProgressBar.setVisibility(View.GONE);
                     }
@@ -472,6 +472,9 @@ public class ClientDetailsFragment extends Fragment implements GooglePlayService
                         imageLoadingAsyncTask = new ImageLoadingAsyncTask();
                         imageLoadingAsyncTask.execute(client.getId());
 
+                    }else{
+                        iv_clientImage.setImageDrawable(getResources().getDrawable(R.drawable.ic_launcher));
+                        pb_imageProgressBar.setVisibility(View.GONE);
                     }
 
                     iv_clientImage.setOnClickListener(new View.OnClickListener() {
@@ -848,9 +851,8 @@ public class ClientDetailsFragment extends Fragment implements GooglePlayService
             String mInstanceUrl = pref.getString(Constants.INSTANCE_URL_KEY,
                     getString(R.string.default_instance_url));
 
-            String url = Constants.PROTOCOL_HTTPS
-                    + mInstanceUrl
-                    + Constants.API_PATH + "/"
+            String url = mInstanceUrl
+                    + "/"
                     + "clients/"
                     + integers[0]
                     + "/images?maxHeight=120&maxWidth=120";


### PR DESCRIPTION
Fixed issue as mentioned by https://mifosforge.jira.com/browse/MIFOSAC-86
The image was not getting displayed due to wrong API being called. Check for client named ra ra.
If image does not exist, Mifos logo has been displayed instead of ever revolving progress bar.
