### PR TITLE
Fixed logout, url reinitialized

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/LogoutActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/LogoutActivity.java
@@ -13,8 +13,10 @@ import android.preference.PreferenceManager;
 import android.support.v7.app.ActionBarActivity;
 import android.util.Log;
 
+import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.SplashScreenActivity;
 import com.mifos.objects.User;
+import com.mifos.utils.Constants;
 
 /**
  * Logout activity.
@@ -34,6 +36,7 @@ public class LogoutActivity extends ActionBarActivity {
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
         SharedPreferences.Editor editor = sharedPreferences.edit();
         editor.putString(User.AUTHENTICATION_KEY, NA);
+        editor.putString(Constants.INSTANCE_URL_KEY, getString(R.string.default_instance_url));
         editor.commit();
         editor.apply();
         startActivity(new Intent(LogoutActivity.this, SplashScreenActivity.class));


### PR DESCRIPTION
Earlier the instanceUrl was saved to the entire https://demo.openmf.org/mifosng-provider/api/v1 after a login which wasn't reset to demo.openmf.org on logout which was leading to repeated url and failure to login again without uninstall. Fixed by reinitializing the variable on logout.