### PR TITLE
Mifosac-114 View overlapping of fragments resolved

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientChooseFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientChooseFragment.java
@@ -6,6 +6,8 @@
 package com.mifos.mifosxdroid.online;
 
 import android.os.Bundle;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -71,6 +73,10 @@ public class ClientChooseFragment extends MifosBaseFragment implements AdapterVi
 
     @Override
     public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
-        ((MifosBaseActivity) getActivity()).replaceFragment(new SurveyListFragment(), false, R.id.container);
+        FragmentManager fragmentManager = getFragmentManager();
+        FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+        fragmentTransaction.replace(R.id.container, new SurveyListFragment(), "SurveyListFragment");
+        fragmentTransaction.addToBackStack(null);
+        fragmentTransaction.commit();
     }
 }


### PR DESCRIPTION
On clicking back button from the survey list, fragment's views were getting overlapped.
This PR is solution for the above issue.

Screenshots of the issue is attached here as well as in JIRA.

@ishan1604 as suggested by you here is the seperate PR for this issue and I find why last time two commits get combined, will not make such mistakes from the next time.

![492c83c4-dfd0-11e5-8c72-4435c8ef7f6d](https://cloud.githubusercontent.com/assets/11405622/13476212/bde77d50-e0ec-11e5-8ff6-7b3d643713fd.png)
![499f0de0-dfd0-11e5-820b-3b501514bd53](https://cloud.githubusercontent.com/assets/11405622/13476214/be451bc2-e0ec-11e5-8d78-593d90afa3d7.png)
