### PR TITLE
MIFOSX-118 Showing Progress Bar in opening Client list resolved

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/LoginActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/LoginActivity.java
@@ -26,6 +26,7 @@ import com.mifos.mifosxdroid.core.MifosBaseActivity;
 import com.mifos.mifosxdroid.core.util.Toaster;
 import com.mifos.mifosxdroid.online.DashboardFragmentActivity;
 import com.mifos.objects.User;
+import com.mifos.utils.Network;
 import com.mifos.utils.PrefManager;
 import com.mifos.utils.ValidationUtil;
 
@@ -167,7 +168,13 @@ public class LoginActivity extends MifosBaseActivity implements Callback<User> {
                 Toaster.show(findViewById(android.R.id.content), "Internal server error");
             }
         } catch (NullPointerException e) {
-            Toaster.show(findViewById(android.R.id.content), getString(R.string.error_unknown));
+            if(Network.getConnectivityStatusString(LoginActivity.this).equals("Not connected to Internet") )
+            {
+                Toaster.show(findViewById(android.R.id.content), "Not connected to Network");
+            }
+            else {
+                Toaster.show(findViewById(android.R.id.content), getString(R.string.error_unknown));
+            }
         }
     }
 

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientListFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientListFragment.java
@@ -98,11 +98,13 @@ public class ClientListFragment extends MifosBaseFragment {
         });
         // If the parent fragment is Group Fragment then the list of clients does not
         // require an infinite scroll as all the clients will be loaded at once
+        hideProgress();
         if (isInfiniteScrollEnabled)
             setInfiniteScrollListener(clientNameListAdapter);
     }
 
     public void fetchClientList() {
+        showProgress();
         if (clientList.size() > 0) {
             inflateClientList();
         } else {
@@ -120,6 +122,7 @@ public class ClientListFragment extends MifosBaseFragment {
                 public void failure(RetrofitError retrofitError) {
                     swipeRefreshLayout.setRefreshing(false);
                     Toaster.show(rootView, "There was some error fetching list.");
+                    hideProgress();
                 }
             });
         }


### PR DESCRIPTION
After clicking on client list screen appears blank for some time. Sometimes it goes upto 15 second. It would be better to show progress bar at this stage.
Now it shows a progress bar .

Before -  
![screenshot_2016-03-06-14-52-31](https://cloud.githubusercontent.com/assets/11210887/13553606/f39d0774-e3b4-11e5-8649-8891dd532a6f.png)


Now -- 


![screenshot_2016-03-06-16-16-04](https://cloud.githubusercontent.com/assets/11210887/13553621/3a3db4f8-e3b5-11e5-8aa2-ffa946f7d62f.png)


