### PR TITLE
MIFOSAC-120 create group typo fixed

### DIFF
--- a/mifosng-android/src/main/res/values/styles_text.xml
+++ b/mifosng-android/src/main/res/values/styles_text.xml
@@ -79,7 +79,7 @@
     <style name="TextView.CreateGroup" parent="TextView.Base">
         <item name="android:layout_marginTop">10dp</item>
         <item name="android:layout_marginBottom">10dp</item>
-        <item name="android:text">@string/create_center</item>
+        <item name="android:text">@string/create_group</item>
         <item name="android:textSize">24sp</item>
     </style>
     <style name="TextView.Search.Results" parent="TextView.Search">


### PR DESCRIPTION
A very minor but an important typo in the create group functionality. Heading is shown create center instead of "create group".It's a minor but a confusing typo for an application user, so I have changed it :)