### PR TITLE
ImageLoadingAsyncTask to Picasso, for image loading in different thread.

### DIFF
--- a/mifosng-android/build.gradle
+++ b/mifosng-android/build.gradle
@@ -120,8 +120,8 @@ dependencies {
     compile 'com.joanzapata.iconify:android-iconify-material:2.1.1' // (v2.0.0)
 
     compile 'com.crashlytics.android:crashlytics:1.+'
-    compile 'com.squareup.okhttp:okhttp-urlconnection:2.0.0'
-    compile 'com.squareup.okhttp:okhttp:2.0.0'
+    compile 'com.squareup.okhttp3:okhttp-urlconnection:3.0.1'
+    compile 'com.squareup.okhttp3:okhttp:3.0.1'
     compile 'com.amulyakhare:com.amulyakhare.textdrawable:1.0.1'
     // Test libraries provided by https://code.google.com/p/android-test-kit/
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.1'
@@ -130,5 +130,6 @@ dependencies {
 
     compile 'com.squareup.retrofit:retrofit:1.9.0'
     compile 'com.jakewharton:butterknife:6.1.0'
+    compile 'com.jakewharton.picasso:picasso2-okhttp3-downloader:1.0.2'
 
 }

--- a/mifosng-android/src/main/java/com/mifos/api/OauthOkHttpClient.java
+++ b/mifosng-android/src/main/java/com/mifos/api/OauthOkHttpClient.java
@@ -1,0 +1,34 @@
+package com.mifos.api;
+
+import com.mifos.utils.PrefManager;
+
+import java.io.IOException;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/**
+ * Created by rajan on 11/3/16.
+ */
+public class OauthOkHttpClient
+{
+	public OkHttpClient getOauthOkHttpClient()
+	{
+		OkHttpClient okClient = new OkHttpClient.Builder().addInterceptor(new Interceptor()
+		{
+			@Override
+			public Response intercept(Chain chain) throws IOException
+			{
+				Request newRequest = chain.request().newBuilder()
+						.addHeader(ApiRequestInterceptor.HEADER_TENANT, "default")
+						.addHeader(ApiRequestInterceptor.HEADER_AUTH, PrefManager.getToken())
+						.addHeader("Accept", "application/octet-stream")
+						.build();
+				return chain.proceed(newRequest);
+			}
+		}).build();
+		return okClient;
+	}
+}
+

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientDetailsFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientDetailsFragment.java
@@ -8,7 +8,6 @@ package com.mifos.mifosxdroid.online;
 import android.app.Activity;
 import android.content.Intent;
 import android.content.IntentSender;
-import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.location.Location;
 import android.net.Uri;
@@ -38,10 +37,11 @@ import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.location.LocationListener;
 import com.google.android.gms.location.LocationServices;
+import com.jakewharton.picasso.OkHttp3Downloader;
 import com.joanzapata.iconify.fonts.MaterialIcons;
 import com.joanzapata.iconify.widget.IconTextView;
 import com.mifos.App;
-import com.mifos.api.ApiRequestInterceptor;
+import com.mifos.api.OauthOkHttpClient;
 import com.mifos.api.model.GpsCoordinatesRequest;
 import com.mifos.api.model.GpsCoordinatesResponse;
 import com.mifos.mifosxdroid.R;
@@ -59,15 +59,11 @@ import com.mifos.utils.Constants;
 import com.mifos.utils.DateHelper;
 import com.mifos.utils.FragmentConstants;
 import com.mifos.utils.PrefManager;
+import com.squareup.picasso.Picasso;
 
 import org.apache.http.HttpStatus;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -113,8 +109,6 @@ public class ClientDetailsFragment extends MifosBaseFragment implements GoogleAp
     TextView tv_office;
     @InjectView(R.id.iv_clientImage)
     CircularImageView iv_clientImage;
-    @InjectView(R.id.pb_imageProgressBar)
-    ProgressBar pb_imageProgressBar;
 
     @InjectView(R.id.row_account)
     TableRow rowAccount;
@@ -140,8 +134,7 @@ public class ClientDetailsFragment extends MifosBaseFragment implements GoogleAp
     private AtomicBoolean locationAvailable = new AtomicBoolean(false);
 
     private AccountAccordion accountAccordion;
-    private ImageLoadingAsyncTask imageLoadingAsyncTask;
-
+	private Picasso picasso;
 
     /**
      * Use this factory method to create a new instance of
@@ -152,16 +145,14 @@ public class ClientDetailsFragment extends MifosBaseFragment implements GoogleAp
     public static ClientDetailsFragment newInstance(int clientId) {
         ClientDetailsFragment fragment = new ClientDetailsFragment();
         Bundle args = new Bundle();
-        args.putInt(Constants.CLIENT_ID, clientId);
+	    args.putInt(Constants.CLIENT_ID, clientId);
         fragment.setArguments(args);
         return fragment;
     }
 
     @Override
     public void onDetach() {
-        if (imageLoadingAsyncTask != null && !imageLoadingAsyncTask.getStatus().equals(AsyncTask.Status.FINISHED))
-            imageLoadingAsyncTask.cancel(true);
-        super.onDetach();
+	    super.onDetach();
     }
 
     @Override
@@ -178,6 +169,9 @@ public class ClientDetailsFragment extends MifosBaseFragment implements GoogleAp
         rootView = inflater.inflate(R.layout.fragment_client_details, container, false);
         ButterKnife.inject(this, rootView);
         inflateClientInformation();
+	    picasso = new Picasso.Builder(getActivity())
+			    .downloader(new OkHttp3Downloader(new OauthOkHttpClient().getOauthOkHttpClient()))
+			    .build();
         return rootView;
     }
 
@@ -224,12 +218,12 @@ public class ClientDetailsFragment extends MifosBaseFragment implements GoogleAp
     }
 
     public void inflateClientInformation() {
-        getClientDetails();
+	    getClientDetails();
     }
 
     public void captureClientImage() {
         Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
-        intent.putExtra(MediaStore.EXTRA_OUTPUT, Uri.fromFile(capturedClientImageFile));
+	    intent.putExtra(MediaStore.EXTRA_OUTPUT, Uri.fromFile(capturedClientImageFile));
         startActivityForResult(intent, CAPTURE_IMAGE_ACTIVITY_REQUEST_CODE);
     }
 
@@ -255,7 +249,6 @@ public class ClientDetailsFragment extends MifosBaseFragment implements GoogleAp
      */
     private void uploadImage(File pngFile) {
         final String imagePath = pngFile.getAbsolutePath();
-        pb_imageProgressBar.setVisibility(VISIBLE);
         App.apiManager.uploadClientImage(clientId,
                 new TypedFile("image/png", pngFile),
                 new Callback<Response>() {
@@ -263,14 +256,12 @@ public class ClientDetailsFragment extends MifosBaseFragment implements GoogleAp
                     public void success(Response response, Response response2) {
                         Toaster.show(rootView, R.string.client_image_updated);
                         iv_clientImage.setImageBitmap(BitmapFactory.decodeFile(imagePath));
-                        pb_imageProgressBar.setVisibility(GONE);
                     }
 
                     @Override
                     public void failure(RetrofitError retrofitError) {
                         Toaster.show(rootView, "Failed to update image");
-                        imageLoadingAsyncTask = new ImageLoadingAsyncTask();
-                        imageLoadingAsyncTask.execute(clientId);
+                        picasso_image_loader(clientId);
                     }
                 }
         );
@@ -321,11 +312,9 @@ public class ClientDetailsFragment extends MifosBaseFragment implements GoogleAp
                         rowOffice.setVisibility(GONE);
 
                     if (client.isImagePresent()) {
-                        imageLoadingAsyncTask = new ImageLoadingAsyncTask();
-                        imageLoadingAsyncTask.execute(client.getId());
+	                    picasso_image_loader(client.getId());
                     } else {
                         iv_clientImage.setImageDrawable(getResources().getDrawable(R.drawable.ic_launcher));
-                        pb_imageProgressBar.setVisibility(GONE);
                     }
 
                     iv_clientImage.setOnClickListener(new OnClickListener() {
@@ -734,47 +723,14 @@ public class ClientDetailsFragment extends MifosBaseFragment implements GoogleAp
         }
     }
 
-    public class ImageLoadingAsyncTask extends AsyncTask<Integer, Void, Void> {
-        Bitmap bmp;
-
-        @Override
-        protected void onPreExecute() {
-            super.onPreExecute();
-            pb_imageProgressBar.setVisibility(VISIBLE);
-        }
-
-        @Override
-        protected Void doInBackground(Integer... integers) {
-            String url = PrefManager.getInstanceUrl()
-                    + "/"
-                    + "clients/"
-                    + integers[0]
-                    + "/images?maxHeight=120&maxWidth=120";
-
-            try {
-                HttpURLConnection httpURLConnection = (HttpURLConnection) (new URL(url)).openConnection();
-                httpURLConnection.setRequestMethod("GET");
-                httpURLConnection.setRequestProperty(ApiRequestInterceptor.HEADER_TENANT, "default");
-                httpURLConnection.setRequestProperty(ApiRequestInterceptor.HEADER_AUTH, PrefManager.getToken());
-                httpURLConnection.setRequestProperty("Accept", "application/octet-stream");
-                httpURLConnection.setDoInput(true);
-                httpURLConnection.connect();
-                InputStream inputStream = httpURLConnection.getInputStream();
-                bmp = BitmapFactory.decodeStream(inputStream);
-                httpURLConnection.disconnect();
-            } catch (MalformedURLException e) {
-            } catch (IOException ioe) {
-            }
-            return null;
-        }
-
-        @Override
-        protected void onPostExecute(Void aVoid) {
-            if (bmp != null) iv_clientImage.setImageBitmap(bmp);
-            else
-                iv_clientImage.setImageDrawable(getResources().getDrawable(R.drawable.ic_launcher));
-            pb_imageProgressBar.setVisibility(GONE);
-        }
-    }
+	public void picasso_image_loader(int clientId)
+	{
+		picasso.load(PrefManager.getInstanceUrl()
+				+ "/" + "clients/" + clientId + "/images?maxHeight=120&maxWidth=120")
+				.error(R.drawable.ic_launcher)
+				.resize(96, 96)
+				.centerCrop()
+				.into(iv_clientImage);
+	}
 
 }

--- a/mifosng-android/src/main/res/layout/fragment_client_details.xml
+++ b/mifosng-android/src/main/res/layout/fragment_client_details.xml
@@ -14,11 +14,6 @@
                 android:layout_width="75dp"
                 android:layout_height="75dp">
 
-                <ProgressBar
-                    android:id="@+id/pb_imageProgressBar"
-                    style="@style/ProgressBar.Base"
-                    android:layout_gravity="center" />
-
                 <com.mifos.mifosxdroid.views.CircularImageView
                     android:id="@+id/iv_clientImage"
                     style="@style/ClientImage"


### PR DESCRIPTION
Earlier, there was image loading using ImageLoadingAsyncTask in main Thread in `ClientDetailsFragment` that makes the application glitchy. I have updated the project to use okhttp3 and also Picasso for image loading in different thread and remove unnecessary Progress Bar and Image loading much faster  than ImageLoadingAsyncTask . This removes a lot of unnecessary AsyncTask code.

For future image loading any where in application just do in few lines of code 

`private Picasso picasso;`

initialize in onCreate or onCreateView 
```java
picasso = new Picasso.Builder(getActivity())
			    .downloader(new OkHttp3Downloader(new OauthOkHttpClient().getOauthOkHttpClient()))
			    .build();
```
and load the image in ImageView 

```java
picasso.load(imageUrl)
			.error(R.drawable.ic_launcher)
			.centerCrop()
			.into(iv_clientImage);
```


#OauthOkHttpClient.class

```java
public class OauthOkHttpClient
{
	public OkHttpClient getOauthOkHttpClient()
	{
		OkHttpClient okClient = new OkHttpClient.Builder().addInterceptor(new Interceptor()
		{
			@Override
			public Response intercept(Chain chain) throws IOException
			{
				Request newRequest = chain.request().newBuilder()
						.addHeader(ApiRequestInterceptor.HEADER_TENANT, "default")
						.addHeader(ApiRequestInterceptor.HEADER_AUTH, PrefManager.getToken())
						.addHeader("Accept", "application/octet-stream")
						.build();
				return chain.proceed(newRequest);
			}
		}).build();
		return okClient;
	}
}
```
