### PR TITLE
fix screen fusing on back press

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientListFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientListFragment.java
@@ -85,6 +85,12 @@ public class ClientListFragment extends MifosBaseFragment {
         return rootView;
     }
 
+    @Override
+    public void onDestroyView() {
+        lv_clients.setVisibility(View.GONE);
+        super.onDestroyView();
+    }
+
     public void inflateClientList() {
         ClientNameListAdapter clientNameListAdapter = new ClientNameListAdapter(getContext(), clientList);
         lv_clients.setAdapter(clientNameListAdapter);


### PR DESCRIPTION
Client List fusing on back press

Steps to reproduce 
1. Open Client List from 3 dot menu
2. Swipe to bottom 
3. As soon as refresh button appears press back
 
This causes the contents of the client list to still remain displayed on top of everything

![screenshot_20160313-020916](https://cloud.githubusercontent.com/assets/17800984/13727661/1ddb7a54-e921-11e5-8695-f0d637e44a32.png)
