### PR TITLE
MIFOSAC -123  Activity goes blank if there is no question in survey resolved

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,19 @@
+## Project-wide Gradle settings.
+#
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+#
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx10248m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+#Sat Mar 05 17:50:15 IST 2016
+systemProp.https.proxyPort=8080
+systemProp.http.proxyHost=10.3.100.207
+systemProp.https.proxyHost=10.3.100.207
+systemProp.http.proxyPort=8080

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SurveyQuestion.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SurveyQuestion.java
@@ -87,6 +87,11 @@ public class SurveyQuestion extends MifosBaseActivity implements SurveyQuestionF
                     String answer[] = new String[10];
 
                     ArrayList<String> answerList = new ArrayList<String>();
+                    if(survey.getQuestionDatas() != null && survey.getQuestionDatas().size() == 0)
+                    {
+                        Toast.makeText(SurveyQuestion.this,"No questions available for this survey.Please Try another Survey",Toast.LENGTH_LONG).show();
+                        finish();
+                    }
 
                     if (survey.getQuestionDatas() != null && survey.getQuestionDatas().size() > 0) {
                         for (int i = 0; i < survey.getQuestionDatas().size(); i++) {


### PR DESCRIPTION
If there is no question in any survey activity goes blank and user is confused whether the questions are uploading or what?
So there should be a toast giving information about empty survey.

![screenshot_2016-03-17-22-06-20](https://cloud.githubusercontent.com/assets/11210887/13853132/58878cb6-ec8b-11e5-8e6c-f8a3c76adce2.png)

