### PR TITLE
MIFOSAC-141 Unnecessary search option from menubar removed

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/LoanAccountSummaryFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/LoanAccountSummaryFragment.java
@@ -52,7 +52,6 @@ import retrofit.client.Response;
 public class LoanAccountSummaryFragment extends MifosBaseFragment {
 
 
-    public static final int MENU_ITEM_SEARCH = 2000;
     public static final int MENU_ITEM_DATA_TABLES = 1001;
     public static final int MENU_ITEM_REPAYMENT_SCHEDULE = 1002;
     public static final int MENU_ITEM_LOAN_TRANSACTIONS = 1003;
@@ -247,9 +246,6 @@ public class LoanAccountSummaryFragment extends MifosBaseFragment {
     @Override
     public void onPrepareOptionsMenu(Menu menu) {
         menu.clear();
-        MenuItem mItemSearchClient = menu.add(Menu.NONE, MENU_ITEM_SEARCH, Menu.NONE, getString(R.string.search));
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB)
-            mItemSearchClient.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM);
         menu.addSubMenu(Menu.NONE, MENU_ITEM_DATA_TABLES, Menu.NONE, Constants.DATA_TABLE_LOAN_NAME);
         menu.add(Menu.NONE, MENU_ITEM_LOAN_TRANSACTIONS, Menu.NONE, getResources().getString(R.string.transactions));
         menu.add(Menu.NONE, MENU_ITEM_REPAYMENT_SCHEDULE, Menu.NONE, getResources().getString(R.string.loan_repayment_schedule));
@@ -290,12 +286,7 @@ public class LoanAccountSummaryFragment extends MifosBaseFragment {
             loadDocuments();
         }
         if (item.getItemId() == MENU_ITEM_CHARGES) {
-
             loadloanCharges();
-
-        } else if (item.getItemId() == MENU_ITEM_SEARCH) {
-
-            getActivity().finish();
         }
             return super.onOptionsItemSelected(item);
         }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SavingsAccountSummaryFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SavingsAccountSummaryFragment.java
@@ -58,7 +58,6 @@ import retrofit.client.Response;
 
 public class SavingsAccountSummaryFragment extends MifosBaseFragment {
 
-    public static final int MENU_ITEM_SEARCH = 2000;
     public static final int MENU_ITEM_DATA_TABLES = 1001;
     public static final int MENU_ITEM_DOCUMENTS = 1004;
     public static int savingsAccountNumber;
@@ -275,9 +274,6 @@ public class SavingsAccountSummaryFragment extends MifosBaseFragment {
     @Override
     public void onPrepareOptionsMenu(Menu menu) {
         menu.clear();
-        MenuItem mItemSearch = menu.add(Menu.NONE, MENU_ITEM_SEARCH, Menu.NONE, getString(R.string.search));
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB)
-            mItemSearch.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM);
         menu.addSubMenu(Menu.NONE, MENU_ITEM_DATA_TABLES, Menu.NONE, Constants.DATA_TABLE_SAVINGS_ACCOUNTS_NAME);
         menu.add(Menu.NONE, MENU_ITEM_DOCUMENTS, Menu.NONE, getResources().getString(R.string.documents));
 
@@ -309,9 +305,6 @@ public class SavingsAccountSummaryFragment extends MifosBaseFragment {
 
         if (item.getItemId() == MENU_ITEM_DOCUMENTS)
             loadDocuments();
-
-        else if (id == MENU_ITEM_SEARCH)
-            getActivity().finish();
         return super.onOptionsItemSelected(item);
     }
 


### PR DESCRIPTION
There is "SEARCH" option given on the Loan Account Summary, Savings Account Summary and Recurring Account Summary which takes user to back screen. There is already a back button to do this function so I have removed this option from all the above-mentioned screens.

@ishan1604 if there is any other use of this "SEARCH" option then please let me know.