### PR TITLE
MIFOSAC-139: Improve network operation progress indication

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/core/ProgressableDialogFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/core/ProgressableDialogFragment.java
@@ -1,0 +1,48 @@
+package com.mifos.mifosxdroid.core;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.DialogFragment;
+import android.util.Log;
+import android.view.View;
+import android.widget.ProgressBar;
+import android.widget.ViewFlipper;
+
+import com.mifos.mifosxdroid.R;
+
+/**
+ * A {@link android.support.v4.app.DialogFragment} that provides progress viewing functionality with a ViewFlipper.
+ */
+public class ProgressableDialogFragment extends DialogFragment {
+    public static final int VIEW_FLIPPER_PROGRESS = 0;
+    public static final int VIEW_FLIPPER_CONTENT = 1;
+
+    private ViewFlipper viewFlipper;
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        viewFlipper = (ViewFlipper) view.findViewById(R.id.view_flipper);
+
+        if (viewFlipper == null) {
+            throw new NullPointerException("Are you sure your Fragment has a ViewFlipper with id \"view_flipper\"?");
+        }
+    }
+
+    /**
+     * Switches the {@link ViewFlipper} either to the {@link ProgressBar} or to the content.
+     *
+     * @param show true to show {@link ProgressBar}, false for content.
+     */
+    public void showProgress(boolean show) {
+        try {
+            int childToFlipTo = show ? VIEW_FLIPPER_PROGRESS : VIEW_FLIPPER_CONTENT;
+            if (viewFlipper.getDisplayedChild() != childToFlipTo) {
+                viewFlipper.setDisplayedChild(childToFlipTo);
+            }
+        } catch (NullPointerException e) {
+            Log.w(getClass().getSimpleName(), "Couldn't show/hide progress bar. Are you sure your Fragment contains a ViewFlipper with ID \"view_flipper\"?");
+        }
+    }
+}

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/core/ProgressableFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/core/ProgressableFragment.java
@@ -1,0 +1,49 @@
+package com.mifos.mifosxdroid.core;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.util.Log;
+import android.view.View;
+import android.widget.ProgressBar;
+import android.widget.ViewFlipper;
+
+import com.mifos.mifosxdroid.R;
+
+import butterknife.InjectView;
+
+/**
+ * A {@link MifosBaseFragment} that provides progress viewing functionality with a ViewFlipper.
+ */
+public class ProgressableFragment extends MifosBaseFragment {
+    public static final int VIEW_FLIPPER_PROGRESS = 0;
+    public static final int VIEW_FLIPPER_CONTENT = 1;
+
+    private ViewFlipper viewFlipper;
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        viewFlipper = (ViewFlipper) view.findViewById(R.id.view_flipper);
+
+        if (viewFlipper == null) {
+            throw new NullPointerException("Are you sure your Fragment has a ViewFlipper with id \"view_flipper\"?");
+        }
+    }
+
+    /**
+     * Switches the {@link ViewFlipper} either to the {@link ProgressBar} or to the content.
+     *
+     * @param show true to show {@link ProgressBar}, false for content.
+     */
+    public void showProgress(boolean show) {
+        try {
+            int childToFlipTo = show ? VIEW_FLIPPER_PROGRESS : VIEW_FLIPPER_CONTENT;
+            if (viewFlipper.getDisplayedChild() != childToFlipTo) {
+                viewFlipper.setDisplayedChild(childToFlipTo);
+            }
+        } catch (NullPointerException e) {
+            Log.w(getClass().getSimpleName(), "Couldn't show/hide progress bar. Are you sure your Fragment contains a ViewFlipper with ID \"view_flipper\"?");
+        }
+    }
+}

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/dialogfragments/ChargeDialogFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/dialogfragments/ChargeDialogFragment.java
@@ -21,6 +21,7 @@ import android.widget.Toast;
 
 import com.mifos.App;
 import com.mifos.mifosxdroid.R;
+import com.mifos.mifosxdroid.core.ProgressableDialogFragment;
 import com.mifos.mifosxdroid.uihelpers.MFDatePicker;
 import com.mifos.objects.Changes;
 import com.mifos.objects.accounts.savings.Charge;
@@ -51,7 +52,7 @@ import retrofit.client.Response;
  * <p/>
  * Use this Dialog Fragment to Create and/or Update charges
  */
-public class ChargeDialogFragment extends DialogFragment implements MFDatePicker.OnDatePickListener {
+public class ChargeDialogFragment extends ProgressableDialogFragment implements MFDatePicker.OnDatePickListener {
 
     public static final String TAG = "ChargeDialogFragment";
     private View rootView;
@@ -133,8 +134,7 @@ public class ChargeDialogFragment extends DialogFragment implements MFDatePicker
     }
 
     private void inflateChargesSpinner() {
-        safeUIBlockingUtility = new SafeUIBlockingUtility(getActivity());
-        safeUIBlockingUtility.safelyBlockUI();
+        showProgress(true);
         App.apiManager.getAllChargesV2(clientId,new Callback<Response>() {
 
             @Override
@@ -197,7 +197,7 @@ public class ChargeDialogFragment extends DialogFragment implements MFDatePicker
                     }
                 });
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
 
             }
 
@@ -206,12 +206,13 @@ public class ChargeDialogFragment extends DialogFragment implements MFDatePicker
 
                 System.out.println(retrofitError.getLocalizedMessage());
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
             }
         });
     }
 
     private void initiateChargesCreation(ChargesPayload chargesPayload) {
+        safeUIBlockingUtility = new SafeUIBlockingUtility(getActivity());
         safeUIBlockingUtility.safelyBlockUI();
         App.apiManager.createCharges(clientId, chargesPayload, new Callback<Charges>() {
             @Override

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/dialogfragments/ChargeDialogFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/dialogfragments/ChargeDialogFragment.java
@@ -139,6 +139,9 @@ public class ChargeDialogFragment extends ProgressableDialogFragment implements 
 
             @Override
             public void success(final Response result, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 Log.d(TAG, "");
 
                 final List<Charges> charges = new ArrayList<>();

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/dialogfragments/LoanChargeDialogFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/dialogfragments/LoanChargeDialogFragment.java
@@ -150,6 +150,9 @@ public class LoanChargeDialogFragment extends ProgressableDialogFragment impleme
 
             @Override
             public void success(final Response result, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 Log.d(TAG, "");
 
                 final List<Charges> charges = new ArrayList<>();

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/dialogfragments/LoanChargeDialogFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/dialogfragments/LoanChargeDialogFragment.java
@@ -21,6 +21,7 @@ import android.widget.Toast;
 
 import com.mifos.App;
 import com.mifos.mifosxdroid.R;
+import com.mifos.mifosxdroid.core.ProgressableDialogFragment;
 import com.mifos.mifosxdroid.uihelpers.MFDatePicker;
 import com.mifos.objects.client.Charges;
 import com.mifos.services.data.ChargesPayload;
@@ -49,7 +50,7 @@ import retrofit.client.Response;
  *
  * Use this Dialog Fragment to Create and/or Update charges
  */
-public class LoanChargeDialogFragment extends DialogFragment implements MFDatePicker.OnDatePickListener {
+public class LoanChargeDialogFragment extends ProgressableDialogFragment implements MFDatePicker.OnDatePickListener {
 
     public static final String TAG = "LoanChargeFragment";
     View rootView;
@@ -144,8 +145,7 @@ public class LoanChargeDialogFragment extends DialogFragment implements MFDatePi
     }
 
     private void inflateChargesSpinner() {
-        safeUIBlockingUtility = new SafeUIBlockingUtility(getActivity());
-        safeUIBlockingUtility.safelyBlockUI();
+        showProgress(true);
         App.apiManager.getAllChargesV3(loanAccountNumber,new Callback<Response>() {
 
             @Override
@@ -208,7 +208,7 @@ public class LoanChargeDialogFragment extends DialogFragment implements MFDatePi
                     }
                 });
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
 
             }
 
@@ -217,13 +217,13 @@ public class LoanChargeDialogFragment extends DialogFragment implements MFDatePi
 
                 System.out.println(retrofitError.getLocalizedMessage());
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
             }
         });
     }
 
     private void initiateChargesCreation(ChargesPayload chargesPayload) {
-
+        safeUIBlockingUtility = new SafeUIBlockingUtility(getActivity());
         safeUIBlockingUtility.safelyBlockUI();
 
         App.apiManager.createLoanCharges(loanAccountNumber, chargesPayload, new Callback<Charges>() {

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/CenterListFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/CenterListFragment.java
@@ -18,6 +18,7 @@ import com.mifos.App;
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.adapters.CentersListAdapter;
 import com.mifos.mifosxdroid.core.MifosBaseFragment;
+import com.mifos.mifosxdroid.core.ProgressableFragment;
 import com.mifos.mifosxdroid.core.util.Toaster;
 import com.mifos.mifosxdroid.uihelpers.MFDatePicker;
 import com.mifos.objects.group.Center;
@@ -32,7 +33,7 @@ import retrofit.client.Response;
 /**
  * Created by ishankhanna on 11/03/14.
  */
-public class CenterListFragment extends MifosBaseFragment {
+public class CenterListFragment extends ProgressableFragment {
 
     private View rootView;
     private ListView lv_centers_list;
@@ -50,7 +51,7 @@ public class CenterListFragment extends MifosBaseFragment {
         rootView = inflater.inflate(R.layout.fragment_centers_list, container, false);
         lv_centers_list = (ListView) rootView.findViewById(R.id.lv_center_list);
 
-        showProgress();
+        showProgress(true);
         App.apiManager.getCenters(new Callback<List<Center>>() {
             @Override
             public void success(final List<Center> centers, Response response) {
@@ -66,11 +67,11 @@ public class CenterListFragment extends MifosBaseFragment {
                 lv_centers_list.setOnItemLongClickListener(new AdapterView.OnItemLongClickListener() {
                     @Override
                     public boolean onItemLongClick(AdapterView<?> parent, View view, final int position, long id) {
-                        showProgress();
+                        showProgress(true);
                         App.apiManager.getCentersGroupAndMeeting(centers.get(position).getId(), new Callback<CenterWithAssociations>() {
                             @Override
                             public void success(final CenterWithAssociations centerWithAssociations, Response response) {
-                                hideProgress();
+                                showProgress(false);
                                 MFDatePicker mfDatePicker = new MFDatePicker();
                                 mfDatePicker.setOnDatePickListener(new MFDatePicker.OnDatePickListener() {
                                     @Override
@@ -83,19 +84,19 @@ public class CenterListFragment extends MifosBaseFragment {
 
                             @Override
                             public void failure(RetrofitError retrofitError) {
-                                hideProgress();
+                                showProgress(false);
                                 Toaster.show(rootView, "Cannot Generate Collection Sheet, There was some problem!");
                             }
                         });
                         return true;
                     }
                 });
-                hideProgress();
+                showProgress(false);
             }
 
             @Override
             public void failure(RetrofitError retrofitError) {
-                hideProgress();
+                showProgress(false);
             }
         });
         return rootView;

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/CenterListFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/CenterListFragment.java
@@ -55,6 +55,9 @@ public class CenterListFragment extends ProgressableFragment {
         App.apiManager.getCenters(new Callback<List<Center>>() {
             @Override
             public void success(final List<Center> centers, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 centersListAdapter = new CentersListAdapter(getActivity(), centers);
                 lv_centers_list.setAdapter(centersListAdapter);
                 lv_centers_list.setOnItemClickListener(new AdapterView.OnItemClickListener() {

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientChooseFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientChooseFragment.java
@@ -18,8 +18,7 @@ import android.widget.ListView;
 import com.mifos.App;
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.adapters.ClientChooseAdapter;
-import com.mifos.mifosxdroid.core.MifosBaseActivity;
-import com.mifos.mifosxdroid.core.MifosBaseFragment;
+import com.mifos.mifosxdroid.core.ProgressableFragment;
 import com.mifos.mifosxdroid.core.util.Toaster;
 import com.mifos.objects.client.Client;
 import com.mifos.objects.client.Page;
@@ -37,7 +36,7 @@ import retrofit.client.Response;
 /**
  * Created by Nasim Banu on 27,January,2016.
  */
-public class ClientChooseFragment extends MifosBaseFragment implements AdapterView.OnItemClickListener {
+public class ClientChooseFragment extends ProgressableFragment implements AdapterView.OnItemClickListener {
 
     @InjectView(R.id.lv_clients)
     ListView results;
@@ -70,7 +69,7 @@ public class ClientChooseFragment extends MifosBaseFragment implements AdapterVi
     }
 
     public void loadClients() {
-        showProgress();
+        showProgress(true);
         shouldCheckForMoreClients = false;
         areMoreClientsAvailable = true;
         totalFilteredRecords = 0;
@@ -80,7 +79,7 @@ public class ClientChooseFragment extends MifosBaseFragment implements AdapterVi
                 clients = page.getPageItems();
                 adapter.setList(clients);
                 adapter.notifyDataSetChanged();
-                hideProgress();
+                showProgress(false);
                 totalFilteredRecords = page.getTotalFilteredRecords();
                 if (isInfiniteScrollEnabled)
                     setInfiniteScrollListener(adapter);
@@ -89,7 +88,7 @@ public class ClientChooseFragment extends MifosBaseFragment implements AdapterVi
             @Override
             public void failure(RetrofitError retrofitError) {
                 Toaster.show(root, "Cannot get clients, There might be some problem!");
-                hideProgress();
+                showProgress(false);
             }
         });
     }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientDetailsFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientDetailsFragment.java
@@ -289,6 +289,8 @@ public class ClientDetailsFragment extends ProgressableFragment implements Googl
         App.apiManager.getClient(clientId, new Callback<Client>() {
             @Override
             public void success(final Client client, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
 
                 if (client != null) {
                     setToolbarTitle(getString(R.string.client) + " - " + client.getLastname());

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientDetailsFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientDetailsFragment.java
@@ -47,6 +47,7 @@ import com.mifos.mifosxdroid.activity.PinpointClientActivity;
 import com.mifos.mifosxdroid.adapters.LoanAccountsListAdapter;
 import com.mifos.mifosxdroid.adapters.SavingsAccountsListAdapter;
 import com.mifos.mifosxdroid.core.MifosBaseFragment;
+import com.mifos.mifosxdroid.core.ProgressableFragment;
 import com.mifos.mifosxdroid.core.util.Toaster;
 import com.mifos.mifosxdroid.views.CircularImageView;
 import com.mifos.objects.accounts.ClientAccounts;
@@ -88,7 +89,7 @@ import static android.view.View.OnTouchListener;
 import static android.view.View.VISIBLE;
 
 
-public class ClientDetailsFragment extends MifosBaseFragment implements GoogleApiClient.ConnectionCallbacks, GoogleApiClient.OnConnectionFailedListener, LocationListener {
+public class ClientDetailsFragment extends ProgressableFragment implements GoogleApiClient.ConnectionCallbacks, GoogleApiClient.OnConnectionFailedListener, LocationListener {
 
     private final String TAG = ClientDetailsFragment.class.getSimpleName();
     public final static int CONNECTION_FAILURE_RESOLUTION_REQUEST = 9000;
@@ -284,7 +285,7 @@ public class ClientDetailsFragment extends MifosBaseFragment implements GoogleAp
      * in the fragment
      */
     public void getClientDetails() {
-        showProgress("Working...");
+        showProgress(true);
         App.apiManager.getClient(clientId, new Callback<Client>() {
             @Override
             public void success(final Client client, Response response) {
@@ -355,7 +356,7 @@ public class ClientDetailsFragment extends MifosBaseFragment implements GoogleAp
                             menu.show();
                         }
                     });
-                    hideProgress();
+                    showProgress(false);
                     inflateClientsAccounts();
                 }
             }
@@ -363,7 +364,7 @@ public class ClientDetailsFragment extends MifosBaseFragment implements GoogleAp
             @Override
             public void failure(RetrofitError retrofitError) {
                 Toaster.show(rootView, "Client not found.");
-                hideProgress();
+                showProgress(false);
             }
         });
     }
@@ -373,7 +374,7 @@ public class ClientDetailsFragment extends MifosBaseFragment implements GoogleAp
      * of the client and inflate them in the fragment
      */
     public void inflateClientsAccounts() {
-        showProgress();
+        showProgress(true);
         App.apiManager.getClientAccounts(clientId, new Callback<ClientAccounts>() {
             @Override
             public void success(final ClientAccounts clientAccounts, Response response) {
@@ -414,14 +415,14 @@ public class ClientDetailsFragment extends MifosBaseFragment implements GoogleAp
                         }
                     });
                 }
-                hideProgress();
+                showProgress(false);
                 inflateDataTablesList();
             }
 
             @Override
             public void failure(RetrofitError retrofitError) {
                 Toaster.show(rootView, "Accounts not found.");
-                hideProgress();
+                showProgress(false);
             }
         });
     }
@@ -431,7 +432,7 @@ public class ClientDetailsFragment extends MifosBaseFragment implements GoogleAp
      * menu options
      */
     public void inflateDataTablesList() {
-        showProgress();
+        showProgress(true);
         App.apiManager.getClientDataTable(new Callback<List<DataTable>>() {
             @Override
             public void success(List<DataTable> dataTables, Response response) {
@@ -441,12 +442,12 @@ public class ClientDetailsFragment extends MifosBaseFragment implements GoogleAp
                     while (dataTableIterator.hasNext())
                         clientDataTables.add(dataTableIterator.next());
                 }
-                hideProgress();
+                showProgress(false);
             }
 
             @Override
             public void failure(RetrofitError retrofitError) {
-                hideProgress();
+                showProgress(false);
             }
         });
     }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientIdentifiersFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientIdentifiersFragment.java
@@ -15,7 +15,7 @@ import android.widget.Toast;
 import com.mifos.App;
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.adapters.IdentifierListAdapter;
-import com.mifos.mifosxdroid.core.MifosBaseFragment;
+import com.mifos.mifosxdroid.core.ProgressableFragment;
 import com.mifos.objects.noncore.Identifier;
 import com.mifos.utils.Constants;
 
@@ -28,7 +28,7 @@ import retrofit.RetrofitError;
 import retrofit.client.Response;
 
 
-public class ClientIdentifiersFragment extends MifosBaseFragment {
+public class ClientIdentifiersFragment extends ProgressableFragment {
 
     @InjectView(R.id.lv_identifiers)
     ListView lv_identifiers;
@@ -60,9 +60,8 @@ public class ClientIdentifiersFragment extends MifosBaseFragment {
         return rootView;
     }
 
-
     public void loadIdentifiers() {
-        showProgress();
+        showProgress(true);
         App.apiManager.getIdentifiers(clientId, new Callback<List<Identifier>>() {
             @Override
             public void success(List<Identifier> identifiers, Response response) {
@@ -72,12 +71,12 @@ public class ClientIdentifiersFragment extends MifosBaseFragment {
                 } else {
                     Toast.makeText(getActivity(), getString(R.string.message_no_identifiers_available), Toast.LENGTH_SHORT).show();
                 }
-                hideProgress();
+                showProgress(false);
             }
 
             @Override
             public void failure(RetrofitError retrofitError) {
-                hideProgress();
+                showProgress(false);
             }
         });
     }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientIdentifiersFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientIdentifiersFragment.java
@@ -65,6 +65,9 @@ public class ClientIdentifiersFragment extends ProgressableFragment {
         App.apiManager.getIdentifiers(clientId, new Callback<List<Identifier>>() {
             @Override
             public void success(List<Identifier> identifiers, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 if (identifiers != null && identifiers.size() > 0) {
                     IdentifierListAdapter identifierListAdapter = new IdentifierListAdapter(getActivity(), identifiers, clientId);
                     lv_identifiers.setAdapter(identifierListAdapter);

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/CreateNewClientFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/CreateNewClientFragment.java
@@ -29,7 +29,7 @@ import com.mifos.exceptions.InvalidTextInputException;
 import com.mifos.exceptions.RequiredFieldException;
 import com.mifos.exceptions.ShortOfLengthException;
 import com.mifos.mifosxdroid.R;
-import com.mifos.mifosxdroid.core.MifosBaseFragment;
+import com.mifos.mifosxdroid.core.ProgressableFragment;
 import com.mifos.mifosxdroid.core.util.Toaster;
 import com.mifos.mifosxdroid.uihelpers.MFDatePicker;
 import com.mifos.objects.client.Client;
@@ -62,7 +62,7 @@ import retrofit.RetrofitError;
 import retrofit.client.Response;
 
 
-public class CreateNewClientFragment extends MifosBaseFragment implements MFDatePicker.OnDatePickListener {
+public class CreateNewClientFragment extends ProgressableFragment implements MFDatePicker.OnDatePickListener {
 
     private static final String TAG = "CreateNewClient";
 
@@ -264,7 +264,7 @@ public class CreateNewClientFragment extends MifosBaseFragment implements MFDate
     }
 
     private void getClientTemplate() {
-        showProgress();
+        showProgress(true);
         App.apiManager.getClientTemplate(new Callback<ClientsTemplate>() {
             @Override
             public void success(ClientsTemplate clientsTemplate, Response response) {
@@ -275,19 +275,19 @@ public class CreateNewClientFragment extends MifosBaseFragment implements MFDate
                     inflateClientTypeOptions();
                     inflateClientClassificationOptions();
                 }
-                hideProgress();
+                showProgress(false);
             }
 
             @Override
             public void failure(RetrofitError error) {
-                hideProgress();
+                showProgress(false);
             }
         });
     }
 
     //inflating office list spinner
     private void inflateOfficeSpinner() {
-        showProgress();
+        showProgress(true);
         App.apiManager.getOffices(new Callback<List<Office>>() {
             @Override
             public void success(List<Office> offices, Response response) {
@@ -392,17 +392,17 @@ public class CreateNewClientFragment extends MifosBaseFragment implements MFDate
         }
         if (isValidLastName()) {
 
-                showProgress();
+                showProgress(true);
                 App.apiManager.createClient(clientPayload, new Callback<Client>() {
                     @Override
                     public void success(Client client, Response response) {
-                        hideProgress();
+                        showProgress(false);
                         Toaster.show(rootView, "Client created successfully");
                     }
 
                     @Override
                     public void failure(RetrofitError error) {
-                        hideProgress();
+                        showProgress(false);
                         Toaster.show(rootView, "Error creating client");
                     }
                 });

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/CreateNewClientFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/CreateNewClientFragment.java
@@ -268,6 +268,8 @@ public class CreateNewClientFragment extends ProgressableFragment implements MFD
         App.apiManager.getClientTemplate(new Callback<ClientsTemplate>() {
             @Override
             public void success(ClientsTemplate clientsTemplate, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
 
                 if (response.getStatus() == 200) {
                     clientstemplate = clientsTemplate;
@@ -291,6 +293,9 @@ public class CreateNewClientFragment extends ProgressableFragment implements MFD
         App.apiManager.getOffices(new Callback<List<Office>>() {
             @Override
             public void success(List<Office> offices, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 final List<String> officeList = new ArrayList<String>();
 
                 for (Office office : offices) {

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/CreateNewGroupFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/CreateNewGroupFragment.java
@@ -32,14 +32,13 @@ import com.mifos.exceptions.InvalidTextInputException;
 import com.mifos.exceptions.RequiredFieldException;
 import com.mifos.exceptions.ShortOfLengthException;
 import com.mifos.mifosxdroid.R;
-import com.mifos.mifosxdroid.core.MifosBaseFragment;
+import com.mifos.mifosxdroid.core.ProgressableFragment;
 import com.mifos.mifosxdroid.uihelpers.MFDatePicker;
 import com.mifos.objects.group.Group;
 import com.mifos.objects.organisation.Office;
 import com.mifos.services.data.GroupPayload;
 import com.mifos.utils.DateHelper;
 import com.mifos.utils.FragmentConstants;
-import com.mifos.utils.SafeUIBlockingUtility;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -52,7 +51,7 @@ import retrofit.RetrofitError;
 import retrofit.client.Response;
 
 
-public class CreateNewGroupFragment extends MifosBaseFragment implements MFDatePicker.OnDatePickListener {
+public class CreateNewGroupFragment extends ProgressableFragment implements MFDatePicker.OnDatePickListener {
 
 
     private static final String TAG = "CreateNewGroup";
@@ -75,7 +74,6 @@ public class CreateNewGroupFragment extends MifosBaseFragment implements MFDateP
     Boolean result = true;
     View rootView;
     String dateofsubmissionstring;
-    SafeUIBlockingUtility safeUIBlockingUtility;
     private DialogFragment mfDatePicker;
     private DialogFragment newDatePicker;
     private HashMap<String, Integer> officeNameIdHashMap = new HashMap<String, Integer>();
@@ -145,8 +143,7 @@ public class CreateNewGroupFragment extends MifosBaseFragment implements MFDateP
 
     //inflating office list spinner
     private void inflateOfficeSpinner() {
-        safeUIBlockingUtility = new SafeUIBlockingUtility(getActivity());
-        safeUIBlockingUtility.safelyBlockUI();
+        showProgress(true);
         App.apiManager.getOffices(new Callback<List<Office>>() {
 
             @Override
@@ -184,7 +181,7 @@ public class CreateNewGroupFragment extends MifosBaseFragment implements MFDateP
                     }
                 });
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
 
             }
 
@@ -207,14 +204,14 @@ public class CreateNewGroupFragment extends MifosBaseFragment implements MFDateP
         App.apiManager.createGroup(groupPayload, new Callback<Group>() {
             @Override
             public void success(Group group, Response response) {
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
                 Toast.makeText(getActivity(), "Group created successfully", Toast.LENGTH_LONG).show();
 
             }
 
             @Override
             public void failure(RetrofitError error) {
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
                 Toast.makeText(getActivity(), "Try again", Toast.LENGTH_LONG).show();
             }
         });

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/CreateNewGroupFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/CreateNewGroupFragment.java
@@ -148,6 +148,9 @@ public class CreateNewGroupFragment extends ProgressableFragment implements MFDa
 
             @Override
             public void success(List<Office> offices, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 final ArrayList<String> officeList = new ArrayList<String>();
 
                 for (Office office : offices) {

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DataTableDataFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DataTableDataFragment.java
@@ -92,6 +92,9 @@ public class DataTableDataFragment extends ProgressableFragment implements DataT
         App.apiManager.getDataTableInfo(dataTable.getRegisteredTableName(), entityId, new Callback<JsonArray>() {
             @Override
             public void success(JsonArray jsonElements, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 if (jsonElements != null) {
                     linearLayout.invalidate();
                     DataTableUIBuilder.DataTableActionListener mListener = (DataTableUIBuilder.DataTableActionListener) getActivity().getSupportFragmentManager().findFragmentByTag(FragmentConstants.FRAG_DATA_TABLE);

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DataTableDataFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DataTableDataFragment.java
@@ -21,6 +21,7 @@ import com.google.gson.JsonElement;
 import com.mifos.App;
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.core.MifosBaseFragment;
+import com.mifos.mifosxdroid.core.ProgressableFragment;
 import com.mifos.mifosxdroid.dialogfragments.DataTableRowDialogFragment;
 import com.mifos.objects.noncore.DataTable;
 import com.mifos.utils.DataTableUIBuilder;
@@ -31,7 +32,7 @@ import retrofit.RetrofitError;
 import retrofit.client.Response;
 
 
-public class DataTableDataFragment extends MifosBaseFragment implements DataTableUIBuilder.DataTableActionListener {
+public class DataTableDataFragment extends ProgressableFragment implements DataTableUIBuilder.DataTableActionListener {
     public static final int MEUN_ITEM_ADD_NEW_ENTRY = 1000;
 
     private DataTable dataTable;
@@ -87,7 +88,7 @@ public class DataTableDataFragment extends MifosBaseFragment implements DataTabl
     }
 
     public void inflateView() {
-        showProgress();
+        showProgress(true);
         App.apiManager.getDataTableInfo(dataTable.getRegisteredTableName(), entityId, new Callback<JsonArray>() {
             @Override
             public void success(JsonArray jsonElements, Response response) {
@@ -96,13 +97,13 @@ public class DataTableDataFragment extends MifosBaseFragment implements DataTabl
                     DataTableUIBuilder.DataTableActionListener mListener = (DataTableUIBuilder.DataTableActionListener) getActivity().getSupportFragmentManager().findFragmentByTag(FragmentConstants.FRAG_DATA_TABLE);
                     linearLayout = new DataTableUIBuilder().getDataTableLayout(dataTable, jsonElements, linearLayout, getActivity(), entityId, mListener);
                 }
-                hideProgress();
+                showProgress(false);
             }
 
             @Override
             public void failure(RetrofitError retrofitError) {
                 Log.i(getActivity().getLocalClassName(), retrofitError.getLocalizedMessage());
-                hideProgress();
+                showProgress(false);
             }
         });
     }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DocumentListFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DocumentListFragment.java
@@ -105,6 +105,9 @@ public class DocumentListFragment extends ProgressableFragment {
         App.apiManager.getDocumentsList(entityType, entityId, new Callback<List<Document>>() {
             @Override
             public void success(final List<Document> documents, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 if (documents != null) {
                     for (Document document : documents) {
                         Log.w(document.getFileName(), document.getSize() + " bytes");

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DocumentListFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DocumentListFragment.java
@@ -21,7 +21,7 @@ import android.widget.ListView;
 import com.mifos.App;
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.adapters.DocumentListAdapter;
-import com.mifos.mifosxdroid.core.MifosBaseFragment;
+import com.mifos.mifosxdroid.core.ProgressableFragment;
 import com.mifos.mifosxdroid.dialogfragments.DocumentDialogFragment;
 import com.mifos.objects.noncore.Document;
 import com.mifos.utils.AsyncFileDownloader;
@@ -36,7 +36,7 @@ import retrofit.Callback;
 import retrofit.RetrofitError;
 import retrofit.client.Response;
 
-public class DocumentListFragment extends MifosBaseFragment {
+public class DocumentListFragment extends ProgressableFragment {
 
     public static final int MENU_ITEM_ADD_NEW_DOCUMENT = 1000;
 
@@ -101,7 +101,7 @@ public class DocumentListFragment extends MifosBaseFragment {
     }
 
     public void inflateDocumentList() {
-        showProgress();
+        showProgress(true);
         App.apiManager.getDocumentsList(entityType, entityId, new Callback<List<Document>>() {
             @Override
             public void success(final List<Document> documents, Response response) {
@@ -120,13 +120,13 @@ public class DocumentListFragment extends MifosBaseFragment {
                         }
                     });
                 }
-                hideProgress();
+                showProgress(false);
             }
 
             @Override
             public void failure(RetrofitError retrofitError) {
                 Log.d("Error", retrofitError.getLocalizedMessage());
-                hideProgress();
+                showProgress(false);
             }
         });
     }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/GenerateCollectionSheetFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/GenerateCollectionSheetFragment.java
@@ -91,6 +91,9 @@ public class GenerateCollectionSheetFragment extends ProgressableFragment {
         App.apiManager.getOffices(new Callback<List<Office>>() {
             @Override
             public void success(List<Office> offices, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 final List<String> officeNames = new ArrayList<String>();
                 officeNames.add(getString(R.string.spinner_office));
                 officeNameIdHashMap.put(getString(R.string.spinner_office), -1);

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/GenerateCollectionSheetFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/GenerateCollectionSheetFragment.java
@@ -18,6 +18,7 @@ import android.widget.Spinner;
 import com.mifos.App;
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.core.MifosBaseFragment;
+import com.mifos.mifosxdroid.core.ProgressableFragment;
 import com.mifos.mifosxdroid.core.util.Toaster;
 import com.mifos.objects.group.Center;
 import com.mifos.objects.group.CenterWithAssociations;
@@ -36,7 +37,7 @@ import retrofit.Callback;
 import retrofit.RetrofitError;
 import retrofit.client.Response;
 
-public class GenerateCollectionSheetFragment extends MifosBaseFragment {
+public class GenerateCollectionSheetFragment extends ProgressableFragment {
 
     public static final String LIMIT = "limit";
     public static final String ORDER_BY = "orderBy";
@@ -86,7 +87,7 @@ public class GenerateCollectionSheetFragment extends MifosBaseFragment {
     }
 
     public void inflateOfficeSpinner() {
-        showProgress();
+        showProgress(true);
         App.apiManager.getOffices(new Callback<List<Office>>() {
             @Override
             public void success(List<Office> offices, Response response) {
@@ -118,13 +119,13 @@ public class GenerateCollectionSheetFragment extends MifosBaseFragment {
 
                     }
                 });
-                hideProgress();
+                showProgress(false);
             }
 
             @Override
             public void failure(RetrofitError retrofitError) {
                 Toaster.show(rootView, "Error loading offices");
-                hideProgress();
+                showProgress(false);
             }
         });
     }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/GroupDetailsFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/GroupDetailsFragment.java
@@ -155,6 +155,8 @@ public class GroupDetailsFragment extends ProgressableFragment {
         App.apiManager.getGroup(groupId, new Callback<Group>() {
             @Override
             public void success(final Group group, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
 
                 if (group != null) {
                     setToolbarTitle(getString(R.string.group) + " - " + group.getName());

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/GroupDetailsFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/GroupDetailsFragment.java
@@ -26,7 +26,7 @@ import com.mifos.App;
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.adapters.LoanAccountsListAdapter;
 import com.mifos.mifosxdroid.adapters.SavingsAccountsListAdapter;
-import com.mifos.mifosxdroid.core.MifosBaseFragment;
+import com.mifos.mifosxdroid.core.ProgressableFragment;
 import com.mifos.mifosxdroid.core.util.Toaster;
 import com.mifos.objects.accounts.GroupAccounts;
 import com.mifos.objects.accounts.savings.DepositType;
@@ -57,7 +57,7 @@ import static android.view.View.VISIBLE;
 /**
  * Created by nellyk on 2/27/2016.
  */
-public class GroupDetailsFragment extends MifosBaseFragment {
+public class GroupDetailsFragment extends ProgressableFragment {
 
     private final String TAG = GroupDetailsFragment.class.getSimpleName();
     public static int groupId;
@@ -151,7 +151,7 @@ public class GroupDetailsFragment extends MifosBaseFragment {
     }
 
     public void getGroupDetails() {
-        showProgress("Working...");
+        showProgress(true);
         App.apiManager.getGroup(groupId, new Callback<Group>() {
             @Override
             public void success(final Group group, Response response) {
@@ -184,7 +184,7 @@ public class GroupDetailsFragment extends MifosBaseFragment {
                     if (TextUtils.isEmpty(group.getOfficeName()))
                         rowOffice.setVisibility(GONE);
 
-                    hideProgress();
+                    showProgress(false);
                     inflateClientsAccounts();
                 }
             }
@@ -192,14 +192,14 @@ public class GroupDetailsFragment extends MifosBaseFragment {
             @Override
             public void failure(RetrofitError retrofitError) {
                 Toaster.show(rootView, "Client not found.");
-                hideProgress();
+                showProgress(false);
             }
         });
     }
 
     public void inflateClientsAccounts() {
 
-        showProgress("Working...");
+        showProgress(true);
 
         App.apiManager.getAllGroupsOfClient(groupId, new Callback<GroupAccounts>() {
             @Override
@@ -241,14 +241,14 @@ public class GroupDetailsFragment extends MifosBaseFragment {
                         }
                     });
                 }
-                hideProgress();
+                showProgress(false);
                 inflateDataTablesList();
             }
 
             @Override
             public void failure(RetrofitError retrofitError) {
                 Toaster.show(rootView, "Accounts not found.");
-                hideProgress();
+                showProgress(false);
             }
         });
     }
@@ -258,7 +258,7 @@ public class GroupDetailsFragment extends MifosBaseFragment {
      * menu options
      */
     public void inflateDataTablesList() {
-        showProgress("Working...");
+        showProgress(true);
         App.apiManager.getClientDataTable(new Callback<List<DataTable>>() {
             @Override
             public void success(List<DataTable> dataTables, Response response) {
@@ -268,12 +268,12 @@ public class GroupDetailsFragment extends MifosBaseFragment {
                     while (dataTableIterator.hasNext())
                         clientDataTables.add(dataTableIterator.next());
                 }
-                hideProgress();
+                showProgress(false);
             }
 
             @Override
             public void failure(RetrofitError retrofitError) {
-                hideProgress();
+                showProgress(false);
             }
         });
     }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/GroupListFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/GroupListFragment.java
@@ -17,6 +17,7 @@ import com.mifos.App;
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.adapters.GroupListAdapter;
 import com.mifos.mifosxdroid.core.MifosBaseFragment;
+import com.mifos.mifosxdroid.core.ProgressableFragment;
 import com.mifos.objects.client.Client;
 import com.mifos.objects.group.CenterWithAssociations;
 import com.mifos.objects.group.GroupWithAssociations;
@@ -31,7 +32,7 @@ import retrofit.RetrofitError;
 import retrofit.client.Response;
 
 
-public class GroupListFragment extends MifosBaseFragment {
+public class GroupListFragment extends ProgressableFragment {
 
     @InjectView(R.id.lv_group_list)
     ListView lv_groupList;
@@ -87,7 +88,7 @@ public class GroupListFragment extends MifosBaseFragment {
     }
 
     public void inflateGroupList() {
-        showProgress();
+        showProgress(true);
         App.apiManager.getGroupsByCenter(centerId, new Callback<CenterWithAssociations>() {
             @Override
             public void success(final CenterWithAssociations centerWithAssociations, Response response) {
@@ -113,13 +114,13 @@ public class GroupListFragment extends MifosBaseFragment {
                             });
                         }
                     });
-                    hideProgress();
+                    showProgress(false);
                 }
             }
 
             @Override
             public void failure(RetrofitError retrofitError) {
-                hideProgress();
+                showProgress(false);
             }
         });
     }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/GroupLoanAccountFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/GroupLoanAccountFragment.java
@@ -194,6 +194,9 @@ public class GroupLoanAccountFragment extends ProgressableDialogFragment impleme
 
             @Override
             public void success(List<ProductLoans> loans, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 final List<String> loansList = new ArrayList<String>();
                 for (ProductLoans loansname : loans) {
                     loansList.add(loansname.getName());
@@ -252,6 +255,9 @@ public class GroupLoanAccountFragment extends ProgressableDialogFragment impleme
             @Override
 
             public void success(final Response result, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 Log.d(TAG, "");
 
                 final List<AmortizationType> amortizationType = new ArrayList<>();
@@ -328,6 +334,9 @@ public class GroupLoanAccountFragment extends ProgressableDialogFragment impleme
         App.apiManager.getGroupLoansAccountTemplate(groupId,productId,new Callback<Response>() {
             @Override
             public void success(final Response result, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 Log.d(TAG, "");
 
                 final List<LoanPurposeOptions> loanPurposeOptionsType = new ArrayList<>();
@@ -404,6 +413,9 @@ public class GroupLoanAccountFragment extends ProgressableDialogFragment impleme
         App.apiManager.getGroupLoansAccountTemplate(groupId,productId,new Callback<Response>() {
             @Override
             public void success(final Response result, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 Log.d(TAG, "");
 
                 final List<InterestCalculationPeriodType> interestCalculationPeriodType = new ArrayList<>();
@@ -480,6 +492,9 @@ public class GroupLoanAccountFragment extends ProgressableDialogFragment impleme
         App.apiManager.getGroupLoansAccountTemplate(groupId,productId,new Callback<Response>() {
             @Override
             public void success(final Response result, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 Log.d(TAG, "");
 
                 final List<TransactionProcessingStrategy> transactionProcessingStrategyType = new ArrayList<>();
@@ -557,6 +572,9 @@ public class GroupLoanAccountFragment extends ProgressableDialogFragment impleme
         App.apiManager.getGroupLoansAccountTemplate(groupId,productId,new Callback<Response>() {
             @Override
             public void success(final Response result, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 Log.d(TAG, "");
 
                 final List<TermFrequencyTypeOptions> termFrequencyType = new ArrayList<>();

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/GroupLoanAccountFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/GroupLoanAccountFragment.java
@@ -23,6 +23,7 @@ import android.widget.Toast;
 
 import com.mifos.App;
 import com.mifos.mifosxdroid.R;
+import com.mifos.mifosxdroid.core.ProgressableDialogFragment;
 import com.mifos.mifosxdroid.uihelpers.MFDatePicker;
 import com.mifos.objects.accounts.loan.AmortizationType;
 import com.mifos.objects.accounts.loan.InterestCalculationPeriodType;
@@ -35,7 +36,6 @@ import com.mifos.services.data.GroupLoanPayload;
 import com.mifos.utils.Constants;
 import com.mifos.utils.DateHelper;
 import com.mifos.utils.FragmentConstants;
-import com.mifos.utils.SafeUIBlockingUtility;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -57,12 +57,11 @@ import retrofit.client.Response;
  *
  * Use this  Fragment to Create and/or Update loan
  */
-public class GroupLoanAccountFragment extends DialogFragment implements MFDatePicker.OnDatePickListener {
+public class GroupLoanAccountFragment extends ProgressableDialogFragment implements MFDatePicker.OnDatePickListener {
 
     public static final String TAG = "LoanAccountFragment";
     View rootView;
 
-    SafeUIBlockingUtility safeUIBlockingUtility;
     @InjectView(R.id.sp_lproduct)
     Spinner sp_lproduct;
     @InjectView(R.id.sp_loan_purpose)
@@ -190,8 +189,7 @@ public class GroupLoanAccountFragment extends DialogFragment implements MFDatePi
 
     }
     private void inflateLoansProductSpinner() {
-        safeUIBlockingUtility = new SafeUIBlockingUtility(getActivity());
-        safeUIBlockingUtility.safelyBlockUI();
+        showProgress(true);
         App.apiManager.getAllLoans(new Callback<List<ProductLoans>>() {
 
             @Override
@@ -232,7 +230,7 @@ public class GroupLoanAccountFragment extends DialogFragment implements MFDatePi
                     }
                 });
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
 
             }
 
@@ -241,7 +239,7 @@ public class GroupLoanAccountFragment extends DialogFragment implements MFDatePi
 
                 System.out.println(retrofitError.getLocalizedMessage());
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
             }
         });
 
@@ -249,6 +247,7 @@ public class GroupLoanAccountFragment extends DialogFragment implements MFDatePi
 
 
     private void inflateAmortizationSpinner() {
+        showProgress(true);
         App.apiManager.getGroupLoansAccountTemplate(groupId,productId,new Callback<Response>() {
             @Override
 
@@ -311,7 +310,7 @@ public class GroupLoanAccountFragment extends DialogFragment implements MFDatePi
                     }
                 });
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
 
             }
 
@@ -320,12 +319,13 @@ public class GroupLoanAccountFragment extends DialogFragment implements MFDatePi
 
                 System.out.println(retrofitError.getLocalizedMessage());
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
             }
         });
     }
     private void inflateLoanPurposeSpinner() {
-     App.apiManager.getGroupLoansAccountTemplate(groupId,productId,new Callback<Response>() {
+        showProgress(true);
+        App.apiManager.getGroupLoansAccountTemplate(groupId,productId,new Callback<Response>() {
             @Override
             public void success(final Response result, Response response) {
                 Log.d(TAG, "");
@@ -386,7 +386,7 @@ public class GroupLoanAccountFragment extends DialogFragment implements MFDatePi
                     }
                 });
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
 
             }
 
@@ -395,11 +395,12 @@ public class GroupLoanAccountFragment extends DialogFragment implements MFDatePi
 
                 System.out.println(retrofitError.getLocalizedMessage());
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
             }
         });
     }
     private void inflateInterestCalculationPeriodSpinner() {
+        showProgress(true);
         App.apiManager.getGroupLoansAccountTemplate(groupId,productId,new Callback<Response>() {
             @Override
             public void success(final Response result, Response response) {
@@ -461,7 +462,7 @@ public class GroupLoanAccountFragment extends DialogFragment implements MFDatePi
                     }
                 });
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
 
             }
 
@@ -470,11 +471,12 @@ public class GroupLoanAccountFragment extends DialogFragment implements MFDatePi
 
                 System.out.println(retrofitError.getLocalizedMessage());
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
             }
         });
     }
     private void inflatetransactionProcessingStrategySpinner() {
+        showProgress(true);
         App.apiManager.getGroupLoansAccountTemplate(groupId,productId,new Callback<Response>() {
             @Override
             public void success(final Response result, Response response) {
@@ -536,7 +538,7 @@ public class GroupLoanAccountFragment extends DialogFragment implements MFDatePi
                     }
                 });
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
 
             }
 
@@ -545,12 +547,13 @@ public class GroupLoanAccountFragment extends DialogFragment implements MFDatePi
 
                 System.out.println(retrofitError.getLocalizedMessage());
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
             }
         });
     }
 
     private void inflateFrequencyPeriodSpinner() {
+        showProgress(true);
         App.apiManager.getGroupLoansAccountTemplate(groupId,productId,new Callback<Response>() {
             @Override
             public void success(final Response result, Response response) {
@@ -612,7 +615,7 @@ public class GroupLoanAccountFragment extends DialogFragment implements MFDatePi
                     }
                 });
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
 
             }
 
@@ -621,7 +624,7 @@ public class GroupLoanAccountFragment extends DialogFragment implements MFDatePi
 
                 System.out.println(retrofitError.getLocalizedMessage());
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
             }
         });
     }
@@ -630,13 +633,13 @@ public class GroupLoanAccountFragment extends DialogFragment implements MFDatePi
        App.apiManager.createGroupLoansAccount(loansPayload, new Callback<Loans>() {
             @Override
             public void success(Loans loans, Response response) {
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
                 Toast.makeText(getActivity(), "The Loan has been submitted for Approval", Toast.LENGTH_LONG).show();
             }
 
             @Override
             public void failure(RetrofitError error) {
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
                 Toast.makeText(getActivity(), "Try again", Toast.LENGTH_LONG).show();
             }
         });

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/LoanAccountFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/LoanAccountFragment.java
@@ -197,6 +197,9 @@ public class LoanAccountFragment extends ProgressableDialogFragment implements M
 
             @Override
             public void success(List<ProductLoans> loans, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 final List<String> loansList = new ArrayList<String>();
                 for (ProductLoans loansname : loans) {
                     loansList.add(loansname.getName());
@@ -254,6 +257,9 @@ public class LoanAccountFragment extends ProgressableDialogFragment implements M
             @Override
 
             public void success(final Response result, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 Log.d(TAG, "");
 
                 final List<AmortizationType> amortizationType = new ArrayList<>();
@@ -332,6 +338,9 @@ public class LoanAccountFragment extends ProgressableDialogFragment implements M
             @Override
 
             public void success(final Response result, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 Log.d(TAG, "");
 
                 final List<LoanPurposeOptions> loanPurposeOptionsType = new ArrayList<>();
@@ -410,6 +419,9 @@ public class LoanAccountFragment extends ProgressableDialogFragment implements M
             @Override
 
             public void success(final Response result, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 Log.d(TAG, "");
 
                 final List<InterestCalculationPeriodType> interestCalculationPeriodType = new ArrayList<>();
@@ -488,6 +500,9 @@ public class LoanAccountFragment extends ProgressableDialogFragment implements M
             @Override
 
             public void success(final Response result, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 Log.d(TAG, "");
 
                 final List<TransactionProcessingStrategy> transactionProcessingStrategyType = new ArrayList<>();
@@ -566,6 +581,9 @@ public class LoanAccountFragment extends ProgressableDialogFragment implements M
             @Override
 
             public void success(final Response result, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 Log.d(TAG, "");
 
                 final List<TermFrequencyTypeOptions> termFrequencyType = new ArrayList<>();

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/LoanAccountFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/LoanAccountFragment.java
@@ -23,6 +23,7 @@ import android.widget.Toast;
 
 import com.mifos.App;
 import com.mifos.mifosxdroid.R;
+import com.mifos.mifosxdroid.core.ProgressableDialogFragment;
 import com.mifos.mifosxdroid.uihelpers.MFDatePicker;
 import com.mifos.objects.accounts.loan.AmortizationType;
 import com.mifos.objects.accounts.loan.InterestCalculationPeriodType;
@@ -57,12 +58,11 @@ import retrofit.client.Response;
  * <p>
  * Use this  Fragment to Create and/or Update loan
  */
-public class LoanAccountFragment extends DialogFragment implements MFDatePicker.OnDatePickListener {
+public class LoanAccountFragment extends ProgressableDialogFragment implements MFDatePicker.OnDatePickListener {
 
     public static final String TAG = "LoanAccountFragment";
     View rootView;
 
-    SafeUIBlockingUtility safeUIBlockingUtility;
     @InjectView(R.id.sp_lproduct)
     Spinner sp_lproduct;
     @InjectView(R.id.sp_loan_purpose)
@@ -192,8 +192,7 @@ public class LoanAccountFragment extends DialogFragment implements MFDatePicker.
     }
 
     private void inflateLoansProductSpinner() {
-        safeUIBlockingUtility = new SafeUIBlockingUtility(getActivity());
-        safeUIBlockingUtility.safelyBlockUI();
+        showProgress(true);
         App.apiManager.getAllLoans(new Callback<List<ProductLoans>>() {
 
             @Override
@@ -233,7 +232,7 @@ public class LoanAccountFragment extends DialogFragment implements MFDatePicker.
                     }
                 });
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
 
             }
 
@@ -242,7 +241,7 @@ public class LoanAccountFragment extends DialogFragment implements MFDatePicker.
 
                 System.out.println(retrofitError.getLocalizedMessage());
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
             }
         });
 
@@ -250,6 +249,7 @@ public class LoanAccountFragment extends DialogFragment implements MFDatePicker.
 
 
     private void inflateAmortizationSpinner() {
+        showProgress(true);
         App.apiManager.getLoansAccountTemplate(clientId, productId, new Callback<Response>() {
             @Override
 
@@ -312,7 +312,7 @@ public class LoanAccountFragment extends DialogFragment implements MFDatePicker.
                     }
                 });
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
 
             }
 
@@ -321,12 +321,13 @@ public class LoanAccountFragment extends DialogFragment implements MFDatePicker.
 
                 System.out.println(retrofitError.getLocalizedMessage());
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
             }
         });
     }
 
     private void inflateLoanPurposeSpinner() {
+        showProgress(true);
         App.apiManager.getLoansAccountTemplate(clientId, productId, new Callback<Response>() {
             @Override
 
@@ -389,7 +390,7 @@ public class LoanAccountFragment extends DialogFragment implements MFDatePicker.
                     }
                 });
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
 
             }
 
@@ -398,12 +399,13 @@ public class LoanAccountFragment extends DialogFragment implements MFDatePicker.
 
                 System.out.println(retrofitError.getLocalizedMessage());
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
             }
         });
     }
 
     private void inflateInterestCalculationPeriodSpinner() {
+        showProgress(true);
         App.apiManager.getLoansAccountTemplate(clientId, productId, new Callback<Response>() {
             @Override
 
@@ -466,7 +468,7 @@ public class LoanAccountFragment extends DialogFragment implements MFDatePicker.
                     }
                 });
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
 
             }
 
@@ -475,12 +477,13 @@ public class LoanAccountFragment extends DialogFragment implements MFDatePicker.
 
                 System.out.println(retrofitError.getLocalizedMessage());
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
             }
         });
     }
 
     private void inflatetransactionProcessingStrategySpinner() {
+        showProgress(true);
         App.apiManager.getLoansAccountTemplate(clientId, productId, new Callback<Response>() {
             @Override
 
@@ -543,7 +546,7 @@ public class LoanAccountFragment extends DialogFragment implements MFDatePicker.
                     }
                 });
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
 
             }
 
@@ -552,12 +555,13 @@ public class LoanAccountFragment extends DialogFragment implements MFDatePicker.
 
                 System.out.println(retrofitError.getLocalizedMessage());
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
             }
         });
     }
 
     private void inflateFrequencyPeriodSpinner() {
+        showProgress(true);
         App.apiManager.getLoansAccountTemplate(clientId, productId, new Callback<Response>() {
             @Override
 
@@ -620,7 +624,7 @@ public class LoanAccountFragment extends DialogFragment implements MFDatePicker.
                     }
                 });
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
 
             }
 
@@ -629,22 +633,23 @@ public class LoanAccountFragment extends DialogFragment implements MFDatePicker.
 
                 System.out.println(retrofitError.getLocalizedMessage());
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
             }
         });
     }
 
     private void initiateLoanCreation(LoansPayload loansPayload) {
+        showProgress(true);
         App.apiManager.createLoansAccount(loansPayload, new Callback<Loans>() {
             @Override
             public void success(Loans loans, Response response) {
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
                 Toast.makeText(getActivity(), "The Loan has been submitted for Approval", Toast.LENGTH_LONG).show();
             }
 
             @Override
             public void failure(RetrofitError error) {
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
                 Toast.makeText(getActivity(), "Try again", Toast.LENGTH_LONG).show();
             }
         });

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/LoanAccountSummaryFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/LoanAccountSummaryFragment.java
@@ -166,6 +166,9 @@ public class LoanAccountSummaryFragment extends ProgressableFragment {
 
             @Override
             public void success(LoanWithAssociations loanWithAssociations, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 clientLoanWithAssociations = loanWithAssociations;
                 tv_clientName.setText(loanWithAssociations.getClientName());
                 tv_loan_product_short_name.setText(loanWithAssociations.getLoanProductName());

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/LoanAccountSummaryFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/LoanAccountSummaryFragment.java
@@ -23,7 +23,7 @@ import android.widget.Toast;
 
 import com.mifos.App;
 import com.mifos.mifosxdroid.R;
-import com.mifos.mifosxdroid.core.MifosBaseFragment;
+import com.mifos.mifosxdroid.core.ProgressableFragment;
 import com.mifos.mifosxdroid.core.util.Toaster;
 import com.mifos.mifosxdroid.dialogfragments.LoanAccountApproval;
 import com.mifos.mifosxdroid.dialogfragments.LoanAccountDisbursement;;
@@ -49,7 +49,7 @@ import retrofit.client.Response;
 /**
  * Created by ishankhanna on 09/05/14.
  */
-public class LoanAccountSummaryFragment extends MifosBaseFragment {
+public class LoanAccountSummaryFragment extends ProgressableFragment {
 
 
     public static final int MENU_ITEM_SEARCH = 2000;
@@ -157,7 +157,7 @@ public class LoanAccountSummaryFragment extends MifosBaseFragment {
     }
 
     private void inflateLoanAccountSummary() {
-        showProgress();
+        showProgress(true);
         setToolbarTitle(getResources().getString(R.string.loanAccountSummary));
         //TODO Implement cases to enable/disable repayment button
         bt_processLoanTransaction.setEnabled(false);
@@ -208,14 +208,14 @@ public class LoanAccountSummaryFragment extends MifosBaseFragment {
                     bt_processLoanTransaction.setEnabled(false);
                     bt_processLoanTransaction.setText("Loan Closed");
                 }
-                hideProgress();
+                showProgress(false);
                 inflateDataTablesList();
             }
 
             @Override
             public void failure(RetrofitError retrofitError) {
                 Toaster.show(rootView, "Loan Account not found.");
-                hideProgress();
+                showProgress(false);
             }
         });
 
@@ -305,7 +305,7 @@ public class LoanAccountSummaryFragment extends MifosBaseFragment {
      * menu options
      */
     public void inflateDataTablesList() {
-        showProgress();
+        showProgress(true);
         App.apiManager.getLoanDataTable(new Callback<List<DataTable>>() {
             @Override
             public void success(List<DataTable> dataTables, Response response) {
@@ -317,12 +317,12 @@ public class LoanAccountSummaryFragment extends MifosBaseFragment {
                         loanDataTables.add(dataTable);
                     }
                 }
-                hideProgress();
+                showProgress(false);
             }
 
             @Override
             public void failure(RetrofitError retrofitError) {
-                hideProgress();
+                showProgress(false);
             }
         });
     }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/LoanRepaymentFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/LoanRepaymentFragment.java
@@ -230,6 +230,8 @@ public class LoanRepaymentFragment extends ProgressableFragment implements MFDat
 
             @Override
             public void success(LoanRepaymentTemplate loanRepaymentTemplate, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
 
                 if (loanRepaymentTemplate != null) {
                     tv_amountDue.setText(String.valueOf(loanRepaymentTemplate.getAmount()));

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/LoanRepaymentFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/LoanRepaymentFragment.java
@@ -26,6 +26,7 @@ import com.jakewharton.fliptables.FlipTable;
 import com.mifos.App;
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.core.MifosBaseFragment;
+import com.mifos.mifosxdroid.core.ProgressableFragment;
 import com.mifos.mifosxdroid.core.util.Toaster;
 import com.mifos.mifosxdroid.uihelpers.MFDatePicker;
 import com.mifos.objects.PaymentTypeOption;
@@ -49,7 +50,7 @@ import retrofit.RetrofitError;
 import retrofit.client.Response;
 
 
-public class LoanRepaymentFragment extends MifosBaseFragment implements MFDatePicker.OnDatePickListener {
+public class LoanRepaymentFragment extends ProgressableFragment implements MFDatePicker.OnDatePickListener {
 
     private View rootView;
 
@@ -130,7 +131,7 @@ public class LoanRepaymentFragment extends MifosBaseFragment implements MFDatePi
 
 
     public void inflateUI() {
-        hideProgress();
+        showProgress(false);
         tv_clientName.setText(clientName);
         tv_loanProductShortName.setText(loanProductName);
         tv_loanAccountNumber.setText(loanAccountNumber);
@@ -254,12 +255,12 @@ public class LoanRepaymentFragment extends MifosBaseFragment implements MFDatePi
                     et_fees.setText(String.valueOf(loanRepaymentTemplate.getFeeChargesPortion()));
 
                 }
-                hideProgress();
+                showProgress(false);
             }
 
             @Override
             public void failure(RetrofitError retrofitError) {
-                hideProgress();
+                showProgress(false);
             }
         });
 
@@ -351,21 +352,21 @@ public class LoanRepaymentFragment extends MifosBaseFragment implements MFDatePi
         String builtRequest = new Gson().toJson(request);
         Log.i("TAG", builtRequest);
 
-        showProgress();
+        showProgress(true);
 
         App.apiManager.submitPayment(Integer.parseInt(loanAccountNumber), request, new Callback<LoanRepaymentResponse>() {
             @Override
             public void success(LoanRepaymentResponse resp, Response response) {
                 if (resp != null)
                     Toaster.show(rootView, "Payment Successful, Transaction ID = " + resp.getResourceId());
-                hideProgress();
+                showProgress(false);
                 getActivity().getSupportFragmentManager().popBackStackImmediate();
             }
 
             @Override
             public void failure(RetrofitError retrofitError) {
                 Toaster.show(rootView, "Payment Failed");
-                hideProgress();
+                showProgress(false);
             }
         });
     }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/LoanRepaymentScheduleFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/LoanRepaymentScheduleFragment.java
@@ -18,6 +18,7 @@ import com.mifos.App;
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.adapters.LoanRepaymentScheduleAdapter;
 import com.mifos.mifosxdroid.core.MifosBaseFragment;
+import com.mifos.mifosxdroid.core.ProgressableFragment;
 import com.mifos.objects.accounts.loan.LoanWithAssociations;
 import com.mifos.objects.accounts.loan.Period;
 import com.mifos.objects.accounts.loan.RepaymentSchedule;
@@ -32,7 +33,7 @@ import retrofit.RetrofitError;
 import retrofit.client.Response;
 
 
-public class LoanRepaymentScheduleFragment extends MifosBaseFragment {
+public class LoanRepaymentScheduleFragment extends ProgressableFragment {
 
 
     @InjectView(R.id.lv_repayment_schedule)
@@ -78,7 +79,7 @@ public class LoanRepaymentScheduleFragment extends MifosBaseFragment {
     }
 
     public void inflateRepaymentSchedule() {
-        showProgress();
+        showProgress(true);
         App.apiManager.getLoanRepaySchedule(loanAccountNumber, new Callback<LoanWithAssociations>() {
             @Override
             public void success(LoanWithAssociations loanWithAssociations, Response response) {
@@ -101,13 +102,13 @@ public class LoanRepaymentScheduleFragment extends MifosBaseFragment {
                 tv_totalUpcoming.setText(totalRepaymentsPending + String.valueOf(
                         RepaymentSchedule.getNumberOfRepaymentsPending(listOfActualPeriods)
                 ));
-                hideProgress();
+                showProgress(false);
             }
 
             @Override
             public void failure(RetrofitError retrofitError) {
                 Log.i(getActivity().getLocalClassName(), retrofitError.getLocalizedMessage());
-                hideProgress();
+                showProgress(false);
             }
         });
     }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/LoanRepaymentScheduleFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/LoanRepaymentScheduleFragment.java
@@ -83,6 +83,8 @@ public class LoanRepaymentScheduleFragment extends ProgressableFragment {
         App.apiManager.getLoanRepaySchedule(loanAccountNumber, new Callback<LoanWithAssociations>() {
             @Override
             public void success(LoanWithAssociations loanWithAssociations, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
 
                 List<Period> listOfActualPeriods = loanWithAssociations.getRepaymentSchedule().getlistOfActualPeriods();
 

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SavingsAccountFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SavingsAccountFragment.java
@@ -53,7 +53,6 @@ public class SavingsAccountFragment extends ProgressableDialogFragment implement
 
     public static final String TAG = "SavingsAccountFragment";
     private View rootView;
-    private Context context;
     private SafeUIBlockingUtility safeUIBlockingUtility;
 
     @InjectView(R.id.sp_product)
@@ -96,7 +95,6 @@ public class SavingsAccountFragment extends ProgressableDialogFragment implement
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        context = getActivity();
         if (getArguments() != null)
             clientId = getArguments().getInt(Constants.CLIENT_ID);
     }
@@ -147,13 +145,16 @@ public class SavingsAccountFragment extends ProgressableDialogFragment implement
 
             @Override
             public void success(List<ProductSavings> savings, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 final List<String> savingsList = new ArrayList<String>();
 
                 for (ProductSavings savingsname : savings) {
                     savingsList.add(savingsname.getName());
                     savingsNameIdHashMap.put(savingsname.getName(), savingsname.getId());
                 }
-                ArrayAdapter<String> savingsAdapter = new ArrayAdapter<String>(context, android.R.layout.simple_spinner_item, savingsList);
+                ArrayAdapter<String> savingsAdapter = new ArrayAdapter<String>(getActivity(), android.R.layout.simple_spinner_item, savingsList);
                 savingsAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
                 sp_product.setAdapter(savingsAdapter);
                 sp_product.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
@@ -360,6 +361,9 @@ public class SavingsAccountFragment extends ProgressableDialogFragment implement
         App.apiManager.getSavingsAccountTemplate(new Callback<SavingProductsTemplate>() {
             @Override
             public void success(SavingProductsTemplate savingProductsTemplate, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 if (response.getStatus() == 200) {
                     savingproductstemplate = savingProductsTemplate;
                     InterestCompoundingPeriodType();

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SavingsAccountFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SavingsAccountFragment.java
@@ -22,6 +22,7 @@ import android.widget.Toast;
 
 import com.mifos.App;
 import com.mifos.mifosxdroid.R;
+import com.mifos.mifosxdroid.core.ProgressableDialogFragment;
 import com.mifos.mifosxdroid.uihelpers.MFDatePicker;
 import com.mifos.objects.InterestType;
 import com.mifos.objects.client.Savings;
@@ -48,7 +49,7 @@ import retrofit.client.Response;
  * <p/>
  * Use this Dialog Fragment to Create and/or Update charges
  */
-public class SavingsAccountFragment extends DialogFragment implements MFDatePicker.OnDatePickListener {
+public class SavingsAccountFragment extends ProgressableDialogFragment implements MFDatePicker.OnDatePickListener {
 
     public static final String TAG = "SavingsAccountFragment";
     private View rootView;
@@ -141,8 +142,7 @@ public class SavingsAccountFragment extends DialogFragment implements MFDatePick
     }
 
     private void inflateSavingsSpinner() {
-        safeUIBlockingUtility = new SafeUIBlockingUtility(getActivity());
-        safeUIBlockingUtility.safelyBlockUI();
+        showProgress(true);
         App.apiManager.getSavingsAccounts(new Callback<List<ProductSavings>>() {
 
             @Override
@@ -173,12 +173,12 @@ public class SavingsAccountFragment extends DialogFragment implements MFDatePick
 
                     }
                 });
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
             }
 
             @Override
             public void failure(RetrofitError retrofitError) {
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
             }
         });
     }
@@ -322,7 +322,7 @@ public class SavingsAccountFragment extends DialogFragment implements MFDatePick
     }
 
     private void initiateSavingCreation(SavingsPayload savingsPayload) {
-
+        safeUIBlockingUtility = new SafeUIBlockingUtility(getActivity());
         safeUIBlockingUtility.safelyBlockUI();
 
         App.apiManager.createSavingsAccount(savingsPayload, new Callback<Savings>() {
@@ -356,7 +356,7 @@ public class SavingsAccountFragment extends DialogFragment implements MFDatePick
     }
 
     private void getSavingsAccountTemplateAPI() {
-
+        showProgress(true);
         App.apiManager.getSavingsAccountTemplate(new Callback<SavingProductsTemplate>() {
             @Override
             public void success(SavingProductsTemplate savingProductsTemplate, Response response) {
@@ -368,7 +368,7 @@ public class SavingsAccountFragment extends DialogFragment implements MFDatePick
                     inflateInterestPostingPeriodType();
                 }
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                    showProgress(false);
             }
 
 
@@ -376,7 +376,7 @@ public class SavingsAccountFragment extends DialogFragment implements MFDatePick
             public void failure(RetrofitError error) {
                 System.out.println(error.getLocalizedMessage());
 
-                safeUIBlockingUtility.safelyUnBlockUI();
+                showProgress(false);
             }
         });
 

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SavingsAccountSummaryFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SavingsAccountSummaryFragment.java
@@ -155,6 +155,8 @@ public class SavingsAccountSummaryFragment extends ProgressableFragment {
 
                     @Override
                     public void success(SavingsAccountWithAssociations savingsAccountWithAssociations, Response response) {
+                        /* Activity is null - Fragment has been detached; no need to do anything. */
+                        if (getActivity() == null) return;
 
                         if (savingsAccountWithAssociations != null) {
 

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SavingsAccountSummaryFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SavingsAccountSummaryFragment.java
@@ -31,6 +31,7 @@ import com.mifos.api.GenericResponse;
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.adapters.SavingsAccountTransactionsListAdapter;
 import com.mifos.mifosxdroid.core.MifosBaseFragment;
+import com.mifos.mifosxdroid.core.ProgressableFragment;
 import com.mifos.mifosxdroid.core.util.Toaster;
 import com.mifos.mifosxdroid.dialogfragments.SavingsAccountApproval;
 import com.mifos.objects.accounts.savings.DepositType;
@@ -56,7 +57,7 @@ import retrofit.RetrofitError;
 import retrofit.client.Response;
 
 
-public class SavingsAccountSummaryFragment extends MifosBaseFragment {
+public class SavingsAccountSummaryFragment extends ProgressableFragment {
 
     public static final int MENU_ITEM_SEARCH = 2000;
     public static final int MENU_ITEM_DATA_TABLES = 1001;
@@ -138,7 +139,7 @@ public class SavingsAccountSummaryFragment extends MifosBaseFragment {
     }
 
     public void inflateSavingsAccountSummary() {
-        hideProgress();
+        showProgress(true);
         switch (savingsAccountType.getServerType()) {
             case RECURRING:
                 setToolbarTitle(getResources().getString(R.string.recurringAccountSummary));
@@ -240,7 +241,7 @@ public class SavingsAccountSummaryFragment extends MifosBaseFragment {
                             }
 
                             inflateDataTablesList();
-                            hideProgress();
+                            showProgress(false);
                             enableInfiniteScrollOfTransactions();
                         }
                     }
@@ -248,7 +249,7 @@ public class SavingsAccountSummaryFragment extends MifosBaseFragment {
                     @Override
                     public void failure(RetrofitError retrofitError) {
                         Toaster.show(rootView, "Internal Server Error");
-                        hideProgress();
+                        showProgress(false);
                         getFragmentManager().popBackStackImmediate();
                     }
                 }
@@ -342,7 +343,7 @@ public class SavingsAccountSummaryFragment extends MifosBaseFragment {
      * menu options
      */
     public void inflateDataTablesList() {
-        showProgress();
+        showProgress(true);
         //TODO change loan service to savings account service
         App.apiManager.getSavingsDataTable(new Callback<List<DataTable>>() {
             @Override
@@ -355,12 +356,12 @@ public class SavingsAccountSummaryFragment extends MifosBaseFragment {
                         savingsAccountDataTables.add(dataTable);
                     }
                 }
-                hideProgress();
+                showProgress(false);
             }
 
             @Override
             public void failure(RetrofitError retrofitError) {
-                hideProgress();
+                showProgress(false);
             }
         });
     }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SavingsAccountTransactionFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SavingsAccountTransactionFragment.java
@@ -127,6 +127,9 @@ public class SavingsAccountTransactionFragment extends ProgressableFragment impl
         App.apiManager.getSavingsAccountTemplate(savingsAccountType.getEndpoint(), Integer.parseInt(savingsAccountNumber), transactionType, new Callback<SavingsAccountTransactionTemplate>() {
             @Override
             public void success(SavingsAccountTransactionTemplate savingsAccountTransactionTemplate, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 if (savingsAccountTransactionTemplate != null) {
                     List<String> listOfPaymentTypes = new ArrayList<>();
                     paymentTypeOptionList = savingsAccountTransactionTemplate.getPaymentTypeOptions();
@@ -211,6 +214,9 @@ public class SavingsAccountTransactionFragment extends ProgressableFragment impl
         App.apiManager.processTransaction(savingsAccountType.getEndpoint(), Integer.parseInt(savingsAccountNumber), transactionType, savingsAccountTransactionRequest, new Callback<SavingsAccountTransactionResponse>() {
                     @Override
                     public void success(SavingsAccountTransactionResponse savingsAccountTransactionResponse, Response response) {
+                        /* Activity is null - Fragment has been detached; no need to do anything. */
+                        if (getActivity() == null) return;
+
                         if (savingsAccountTransactionResponse != null) {
                             if (transactionType.equals(Constants.SAVINGS_ACCOUNT_TRANSACTION_DEPOSIT)) {
                                 Toaster.show(rootView, "Deposit Successful, Transaction ID = " + savingsAccountTransactionResponse.getResourceId());

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SavingsAccountTransactionFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SavingsAccountTransactionFragment.java
@@ -23,7 +23,7 @@ import com.jakewharton.fliptables.FlipTable;
 import com.mifos.App;
 import com.mifos.exceptions.RequiredFieldException;
 import com.mifos.mifosxdroid.R;
-import com.mifos.mifosxdroid.core.MifosBaseFragment;
+import com.mifos.mifosxdroid.core.ProgressableFragment;
 import com.mifos.mifosxdroid.core.util.Toaster;
 import com.mifos.mifosxdroid.uihelpers.MFDatePicker;
 import com.mifos.objects.PaymentTypeOption;
@@ -49,7 +49,7 @@ import retrofit.RetrofitError;
 import retrofit.client.Response;
 
 
-public class SavingsAccountTransactionFragment extends MifosBaseFragment implements MFDatePicker.OnDatePickListener {
+public class SavingsAccountTransactionFragment extends ProgressableFragment implements MFDatePicker.OnDatePickListener {
 
     @InjectView(R.id.tv_clientName)
     TextView tv_clientName;
@@ -115,7 +115,7 @@ public class SavingsAccountTransactionFragment extends MifosBaseFragment impleme
     }
 
     public void inflateUI() {
-        showProgress();
+        showProgress(true);
         tv_clientName.setText(clientName);
         tv_accountNumber.setText(savingsAccountNumber);
         //TODO Implement QuickContactBadge here
@@ -144,12 +144,12 @@ public class SavingsAccountTransactionFragment extends MifosBaseFragment impleme
                     paymentTypeAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
                     sp_paymentType.setAdapter(paymentTypeAdapter);
                 }
-                hideProgress();
+                showProgress(false);
             }
 
             @Override
             public void failure(RetrofitError retrofitError) {
-                hideProgress();
+                showProgress(false);
             }
         });
     }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SurveyListFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SurveyListFragment.java
@@ -61,6 +61,9 @@ public class SurveyListFragment extends ProgressableFragment {
         App.apiManager.getAllSurveys(new Callback<List<Survey>>() {
             @Override
             public void success(final List<Survey> surveys, Response response) {
+                /* Activity is null - Fragment has been detached; no need to do anything. */
+                if (getActivity() == null) return;
+
                 surveyListAdapter = new SurveyListAdapter(getActivity(), surveys);
                 lv_surveys_list.setAdapter(surveyListAdapter);
                 lv_surveys_list.setOnItemClickListener(new AdapterView.OnItemClickListener() {

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SurveyListFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SurveyListFragment.java
@@ -18,7 +18,7 @@ import android.widget.ListView;
 import com.mifos.App;
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.adapters.SurveyListAdapter;
-import com.mifos.mifosxdroid.core.MifosBaseFragment;
+import com.mifos.mifosxdroid.core.ProgressableFragment;
 import com.mifos.mifosxdroid.core.util.Toaster;
 import com.mifos.objects.survey.Survey;
 
@@ -33,7 +33,7 @@ import retrofit.client.Response;
 /**
  * Created by Nasim Banu on 27,January,2016.
  */
-public class SurveyListFragment extends MifosBaseFragment {
+public class SurveyListFragment extends ProgressableFragment {
 
     private static final String CLIENTID = "ClientID";
     @InjectView(R.id.lv_surveys_list) ListView lv_surveys_list;
@@ -57,7 +57,7 @@ public class SurveyListFragment extends MifosBaseFragment {
 
         clientId = getArguments().getInt(CLIENTID);
 
-        showProgress();
+        showProgress(true);
         App.apiManager.getAllSurveys(new Callback<List<Survey>>() {
             @Override
             public void success(final List<Survey> surveys, Response response) {
@@ -69,13 +69,13 @@ public class SurveyListFragment extends MifosBaseFragment {
                         mListener.loadSurveyQuestion(surveys.get(i),clientId);
                     }
                 });
-                hideProgress();
+                showProgress(false);
             }
 
             @Override
             public void failure(RetrofitError retrofitError) {
                 Toaster.show(rootView, "Couldn't Fetch List of Surveys");
-                hideProgress();
+                showProgress(false);
             }
         });
         return rootView;

--- a/mifosng-android/src/main/res/layout/dialog_fragment_charge.xml
+++ b/mifosng-android/src/main/res/layout/dialog_fragment_charge.xml
@@ -4,122 +4,133 @@
   ~ This project is licensed under the open source MPL V2.
   ~ See https://github.com/openMF/android-client/blob/master/LICENSE.md
   -->
-
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/view_flipper"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:inAnimation="@android:anim/fade_in"
+    android:outAnimation="@android:anim/fade_out">
 
-
-    <TableLayout
-        android:layout_width="match_parent"
+    <!-- Comment this out when editing the actual content -->
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
-        android:layout_centerHorizontal="true"
-        android:padding="8dp"
-        android:id="@+id/tableLayout">
+        android:layout_gravity="center" />
 
-        <TableRow
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:id="@+id/tableRow1">
-
-            <TextView
-                android:layout_width="0dp"
-                android:layout_weight="1"
-                android:layout_height="wrap_content"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:text="@string/name"
-                android:id="@+id/textView2" />
-
-            <Spinner
-                android:layout_width="0dp"
-                android:layout_weight="1"
-                android:layout_height="wrap_content"
-                android:id="@+id/sp_charge_name"
-                android:background="@color/light_grey"/>
-        </TableRow>
-
-        <TableRow
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:id="@+id/tableRow2"
-            android:layout_marginTop="16dp">
+    <!-- Actual content -->
+    <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
 
-            <TextView
-                android:layout_width="0dp"
-                android:layout_weight="1"
-                android:layout_height="wrap_content"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:text="@string/amount"
-                android:id="@+id/tv_amount_due_charge"
-                />
-
-            <EditText
-                android:layout_width="0dp"
-                android:layout_weight="1"
-                android:layout_height="wrap_content"
-                android:id="@+id/amount_due_charge"
-                android:background="@color/light_grey"/>
-        </TableRow>
-        <TableRow
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
-        android:id="@+id/tableRow3"
-        android:layout_marginTop="16dp">
-
-        <TextView
-            android:layout_width="0dp"
-            android:layout_weight="1"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            android:text="@string/due_date"
-            android:id="@+id/charge_due_date" />
-
-        <EditText
-            android:layout_width="0dp"
-            android:layout_weight="1"
-            android:layout_height="wrap_content"
-            android:id="@+id/et_date"
-            android:background="@color/light_grey"/>
-
-    </TableRow>
-        <TableRow
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:id="@+id/tableRow4"
-            android:layout_marginTop="16dp">
-
-            <TextView
-                android:layout_width="0dp"
-                android:layout_weight="1"
-                android:layout_height="wrap_content"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:text="@string/locale"
-                android:id="@+id/tv_charge_locale" />
-
-            <EditText
-                android:layout_width="0dp"
-                android:layout_weight="1"
-                android:layout_height="wrap_content"
-                android:id="@+id/et_charge_locale"
-                android:background="@color/light_grey"
-                android:text="en"
-                android:focusable="false"/>
-
-        </TableRow>
-        <Button
+        <TableLayout
+            android:id="@+id/tableLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/save"
-            android:id="@+id/bt_save_charge"
-            android:layout_marginTop="26dp"
-            android:background="@color/blue"/>
-    </TableLayout>
+            android:layout_alignParentTop="true"
+            android:layout_centerHorizontal="true"
+            android:padding="8dp">
+
+            <TableRow
+                android:id="@+id/tableRow1"
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent">
+
+                <TextView
+                    android:id="@+id/textView2"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/name"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                <Spinner
+                    android:id="@+id/sp_charge_name"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:background="@color/light_grey" />
+            </TableRow>
+
+            <TableRow
+                android:id="@+id/tableRow2"
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent"
+                android:layout_marginTop="16dp">
 
 
+                <TextView
+                    android:id="@+id/tv_amount_due_charge"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/amount"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
 
+                <EditText
+                    android:id="@+id/amount_due_charge"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:background="@color/light_grey" />
+            </TableRow>
 
+            <TableRow
+                android:id="@+id/tableRow3"
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent"
+                android:layout_marginTop="16dp">
 
-</RelativeLayout>
+                <TextView
+                    android:id="@+id/charge_due_date"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/due_date"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                <EditText
+                    android:id="@+id/et_date"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:background="@color/light_grey" />
+
+            </TableRow>
+
+            <TableRow
+                android:id="@+id/tableRow4"
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent"
+                android:layout_marginTop="16dp">
+
+                <TextView
+                    android:id="@+id/tv_charge_locale"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/locale"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                <EditText
+                    android:id="@+id/et_charge_locale"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:background="@color/light_grey"
+                    android:focusable="false"
+                    android:text="en" />
+
+            </TableRow>
+
+            <Button
+                android:id="@+id/bt_save_charge"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="26dp"
+                android:background="@color/blue"
+                android:text="@string/save" />
+        </TableLayout>
+    </RelativeLayout>
+</ViewFlipper>

--- a/mifosng-android/src/main/res/layout/fragment_add_loan.xml
+++ b/mifosng-android/src/main/res/layout/fragment_add_loan.xml
@@ -1,228 +1,267 @@
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent">
+<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/view_flipper"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:inAnimation="@android:anim/fade_in"
+    android:outAnimation="@android:anim/fade_out">
 
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        style="@style/LinearLayout.Base">
+    <!-- Comment this out when editing the actual content -->
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
 
-        <TextView style="@style/TextView.CreateLoanAccount"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
-        <TextView
-            android:id="@+id/tv_lproduct"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="16dp"
-            android:text="@string/loanproduct"
-            android:textSize="16sp"
-            />
-        <Spinner
-            android:id="@+id/sp_lproduct"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:spinnerMode="dropdown"
-            android:background="@color/light_grey"/>
+    <!-- Actual content -->
+    <ScrollView
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent">
 
-        <TextView
-            android:id="@+id/tv_loan_purpose"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="16dp"
-            android:text="Purpose"
-            android:textSize="16sp"
-            />
-        <Spinner
-            android:id="@+id/sp_loan_purpose"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:spinnerMode="dropdown"
-            android:background="@color/light_grey"/>
+        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            style="@style/LinearLayout.Base">
 
-        <TextView
-            android:id="@+id/tv_submittedon_date"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="Submission Date:"
-            android:imeOptions="actionNext"
-            android:paddingBottom="16dp"
-            android:paddingTop="10dp"
-            android:textSize="20sp"
-            />
-        <TextView
-            android:id="@+id/disbursementon_date"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint=" Disbursement on:"
-            android:imeOptions="actionNext"
-            android:paddingBottom="16dp"
-            android:paddingTop="10dp"
-            android:textSize="20sp"
-            />
-        <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
-            <EditText
-                android:id="@+id/et_client_external_id"
-                style="@style/EditText.BaseWidth"
-                android:gravity="start"
-                android:hint="@string/external_id"
+            <TextView
+                style="@style/TextView.CreateLoanAccount"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:id="@+id/tv_lproduct"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="16dp"
+                android:text="@string/loanproduct"
+                android:textSize="16sp" />
+
+            <Spinner
+                android:id="@+id/sp_lproduct"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/light_grey"
+                android:paddingTop="10dp"
+                android:spinnerMode="dropdown" />
+
+            <TextView
+                android:id="@+id/tv_loan_purpose"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="16dp"
+                android:text="Purpose"
+                android:textSize="16sp" />
+
+            <Spinner
+                android:id="@+id/sp_loan_purpose"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/light_grey"
+                android:paddingTop="10dp"
+                android:spinnerMode="dropdown" />
+
+            <TextView
+                android:id="@+id/tv_submittedon_date"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Submission Date:"
                 android:imeOptions="actionNext"
-                android:inputType="text"
                 android:paddingBottom="16dp"
-                android:singleLine="true"/>
-        </android.support.design.widget.TextInputLayout>
-        <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
-            <EditText
-                android:id="@+id/et_nominal_annual"
-                style="@style/EditText.BaseWidth"
-                android:gravity="start"
-                android:hint="@string/nominal"
+                android:paddingTop="10dp"
+                android:textSize="20sp" />
+
+            <TextView
+                android:id="@+id/disbursementon_date"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint=" Disbursement on:"
                 android:imeOptions="actionNext"
-                android:inputType="number"
                 android:paddingBottom="16dp"
-                android:singleLine="true"/>
-        </android.support.design.widget.TextInputLayout>
-        <TextView style="@style/TextView.CreateLoanTerms"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textStyle="bold"/>
-        <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
-            <EditText
-                android:id="@+id/et_principal"
-                style="@style/EditText.BaseWidth"
-                android:gravity="start"
-                android:hint="@string/principal"
-                android:imeOptions="actionNext"
-                android:inputType="number"
-                android:paddingBottom="16dp"
-                android:singleLine="true"/>
-        </android.support.design.widget.TextInputLayout>
-        <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
-            <EditText
-                android:id="@+id/et_loanterm"
-                style="@style/EditText.BaseWidth"
-                android:gravity="start"
-                android:hint="@string/loanterm"
-                android:imeOptions="actionNext"
-                android:inputType="number"
-                android:paddingBottom="16dp"
-                android:singleLine="true"/>
-        </android.support.design.widget.TextInputLayout>
-        <Spinner
-            android:id="@+id/sp_loan_term"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:spinnerMode="dropdown"
-            android:background="@color/light_grey"/>
-        <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
-            <EditText
-                android:id="@+id/et_numberofrepayments"
-                style="@style/EditText.BaseWidth"
-                android:gravity="start"
-                android:hint="@string/numberofrepayments"
-                android:imeOptions="actionNext"
-                android:inputType="number"
-                android:paddingBottom="16dp"
-                android:singleLine="true"/>
-        </android.support.design.widget.TextInputLayout>
-        <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
-            <EditText
-                android:id="@+id/et_repaidevery"
-                style="@style/EditText.BaseWidth"
-                android:gravity="start"
-                android:hint="@string/repaidevery"
-                android:imeOptions="actionNext"
-                android:inputType="number"
-                android:paddingBottom="16dp"
-                android:singleLine="true"/>
-        </android.support.design.widget.TextInputLayout>
-        <Spinner
-            android:id="@+id/sp_payment_periods"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:spinnerMode="dropdown"
-            android:background="@color/light_grey"/>
-        <Spinner
-            android:id="@+id/sp_payment_periods_seconds"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:spinnerMode="dropdown"
-            android:background="@color/light_grey"
-            android:visibility="gone"/>
-        <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
-            <EditText
-                android:id="@+id/et_nominal_interest_rate"
-                style="@style/EditText.BaseWidth"
-                android:gravity="start"
-                android:hint="@string/nominal_interest_rate"
-                android:imeOptions="actionNext"
-                android:inputType="number"
-                android:paddingBottom="16dp"
-                android:singleLine="true"/>
-        </android.support.design.widget.TextInputLayout>
-        <TextView
-            android:id="@+id/tv_amortization"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:text="@string/amortization"
-            android:textSize="16sp"
-            />
-        <Spinner
-            android:id="@+id/sp_amortization"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:spinnerMode="dropdown"
-            android:background="@color/light_grey"/>
-        <TextView
-            android:id="@+id/tv_interestcalculationperiod"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:text="@string/interestcalculationperiod"
-            android:textSize="16sp"
-            />
-        <Spinner
-            android:id="@+id/sp_interestcalculationperiod"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:spinnerMode="dropdown"
-            android:background="@color/light_grey"/>
-        <TextView
-            android:id="@+id/tv_repaymentstrategy"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:text="@string/repaymentstrategy"
-            android:textSize="16sp"
-            />
-        <Spinner
-            android:id="@+id/sp_repaymentstrategy"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:spinnerMode="dropdown"
-            android:background="@color/light_grey"/>
-     <android.support.v7.widget.AppCompatCheckBox
-         android:id="@+id/ck_calculateinterest"
-         android:layout_width="match_parent"
-         android:layout_height="wrap_content"
-         android:paddingTop="10dp"
-         android:text="@string/calculateinterest"
-         android:textSize="16sp"/>
-        <Button
-            android:id="@+id/bt_loan_submit"
-            style="@style/Button.Base"
-            android:layout_marginTop="10dp"
-            android:text="@string/submit"
-            />
+                android:paddingTop="10dp"
+                android:textSize="20sp" />
+
+            <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
+
+                <EditText
+                    android:id="@+id/et_client_external_id"
+                    style="@style/EditText.BaseWidth"
+                    android:gravity="start"
+                    android:hint="@string/external_id"
+                    android:imeOptions="actionNext"
+                    android:inputType="text"
+                    android:paddingBottom="16dp"
+                    android:singleLine="true" />
+            </android.support.design.widget.TextInputLayout>
+
+            <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
+
+                <EditText
+                    android:id="@+id/et_nominal_annual"
+                    style="@style/EditText.BaseWidth"
+                    android:gravity="start"
+                    android:hint="@string/nominal"
+                    android:imeOptions="actionNext"
+                    android:inputType="number"
+                    android:paddingBottom="16dp"
+                    android:singleLine="true" />
+            </android.support.design.widget.TextInputLayout>
+
+            <TextView
+                style="@style/TextView.CreateLoanTerms"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textStyle="bold" />
+
+            <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
+
+                <EditText
+                    android:id="@+id/et_principal"
+                    style="@style/EditText.BaseWidth"
+                    android:gravity="start"
+                    android:hint="@string/principal"
+                    android:imeOptions="actionNext"
+                    android:inputType="number"
+                    android:paddingBottom="16dp"
+                    android:singleLine="true" />
+            </android.support.design.widget.TextInputLayout>
+
+            <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
+
+                <EditText
+                    android:id="@+id/et_loanterm"
+                    style="@style/EditText.BaseWidth"
+                    android:gravity="start"
+                    android:hint="@string/loanterm"
+                    android:imeOptions="actionNext"
+                    android:inputType="number"
+                    android:paddingBottom="16dp"
+                    android:singleLine="true" />
+            </android.support.design.widget.TextInputLayout>
+
+            <Spinner
+                android:id="@+id/sp_loan_term"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/light_grey"
+                android:paddingTop="10dp"
+                android:spinnerMode="dropdown" />
+
+            <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
+
+                <EditText
+                    android:id="@+id/et_numberofrepayments"
+                    style="@style/EditText.BaseWidth"
+                    android:gravity="start"
+                    android:hint="@string/numberofrepayments"
+                    android:imeOptions="actionNext"
+                    android:inputType="number"
+                    android:paddingBottom="16dp"
+                    android:singleLine="true" />
+            </android.support.design.widget.TextInputLayout>
+
+            <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
+
+                <EditText
+                    android:id="@+id/et_repaidevery"
+                    style="@style/EditText.BaseWidth"
+                    android:gravity="start"
+                    android:hint="@string/repaidevery"
+                    android:imeOptions="actionNext"
+                    android:inputType="number"
+                    android:paddingBottom="16dp"
+                    android:singleLine="true" />
+            </android.support.design.widget.TextInputLayout>
+
+            <Spinner
+                android:id="@+id/sp_payment_periods"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/light_grey"
+                android:paddingTop="10dp"
+                android:spinnerMode="dropdown" />
+
+            <Spinner
+                android:id="@+id/sp_payment_periods_seconds"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/light_grey"
+                android:paddingTop="10dp"
+                android:spinnerMode="dropdown"
+                android:visibility="gone" />
+
+            <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
+
+                <EditText
+                    android:id="@+id/et_nominal_interest_rate"
+                    style="@style/EditText.BaseWidth"
+                    android:gravity="start"
+                    android:hint="@string/nominal_interest_rate"
+                    android:imeOptions="actionNext"
+                    android:inputType="number"
+                    android:paddingBottom="16dp"
+                    android:singleLine="true" />
+            </android.support.design.widget.TextInputLayout>
+
+            <TextView
+                android:id="@+id/tv_amortization"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="10dp"
+                android:text="@string/amortization"
+                android:textSize="16sp" />
+
+            <Spinner
+                android:id="@+id/sp_amortization"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/light_grey"
+                android:paddingTop="10dp"
+                android:spinnerMode="dropdown" />
+
+            <TextView
+                android:id="@+id/tv_interestcalculationperiod"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="10dp"
+                android:text="@string/interestcalculationperiod"
+                android:textSize="16sp" />
+
+            <Spinner
+                android:id="@+id/sp_interestcalculationperiod"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/light_grey"
+                android:paddingTop="10dp"
+                android:spinnerMode="dropdown" />
+
+            <TextView
+                android:id="@+id/tv_repaymentstrategy"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="10dp"
+                android:text="@string/repaymentstrategy"
+                android:textSize="16sp" />
+
+            <Spinner
+                android:id="@+id/sp_repaymentstrategy"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/light_grey"
+                android:paddingTop="10dp"
+                android:spinnerMode="dropdown" />
+
+            <android.support.v7.widget.AppCompatCheckBox
+                android:id="@+id/ck_calculateinterest"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="10dp"
+                android:text="@string/calculateinterest"
+                android:textSize="16sp" />
+
+            <Button
+                android:id="@+id/bt_loan_submit"
+                style="@style/Button.Base"
+                android:layout_marginTop="10dp"
+                android:text="@string/submit" />
 
 
-    </LinearLayout>
-</ScrollView>
+        </LinearLayout>
+    </ScrollView>
+</ViewFlipper>

--- a/mifosng-android/src/main/res/layout/fragment_add_savings_account.xml
+++ b/mifosng-android/src/main/res/layout/fragment_add_savings_account.xml
@@ -1,141 +1,160 @@
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent">
+<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/view_flipper"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:inAnimation="@android:anim/fade_in"
+    android:outAnimation="@android:anim/fade_out">
 
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        style="@style/LinearLayout.Base">
+    <!-- Comment this out when editing the actual content -->
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
 
-        <TextView style="@style/TextView.CreateSavingsAccount"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
-        <TextView
-            android:id="@+id/tv_product"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="16dp"
-            android:text="@string/product"
-            android:textSize="16sp"
-            />
-        <Spinner
-            android:id="@+id/sp_product"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:spinnerMode="dropdown"
-            android:background="@color/light_grey"/>
-        <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
-            <EditText
-                android:id="@+id/et_client_external_id"
-                style="@style/EditText.BaseWidth"
-                android:gravity="start"
-                android:hint="@string/external_id"
+    <!-- Actual content -->
+    <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent">
+
+        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            style="@style/LinearLayout.Base">
+
+            <TextView
+                style="@style/TextView.CreateSavingsAccount"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:id="@+id/tv_product"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="16dp"
+                android:text="@string/product"
+                android:textSize="16sp" />
+
+            <Spinner
+                android:id="@+id/sp_product"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/light_grey"
+                android:paddingTop="10dp"
+                android:spinnerMode="dropdown" />
+
+            <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
+
+                <EditText
+                    android:id="@+id/et_client_external_id"
+                    style="@style/EditText.BaseWidth"
+                    android:gravity="start"
+                    android:hint="@string/external_id"
+                    android:imeOptions="actionNext"
+                    android:inputType="text"
+                    android:paddingBottom="16dp"
+                    android:singleLine="true" />
+            </android.support.design.widget.TextInputLayout>
+
+            <TextView
+                android:id="@+id/tv_submittedon"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingBottom="10dp"
+                android:paddingTop="16dp"
+                android:text="@string/submittedon"
+                android:textSize="16sp" />
+
+            <TextView
+                android:id="@+id/tv_submittedon_date"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Submission Date :"
                 android:imeOptions="actionNext"
-                android:inputType="text"
                 android:paddingBottom="16dp"
-                android:singleLine="true"/>
-        </android.support.design.widget.TextInputLayout>
+                android:paddingTop="10dp"
+                android:textSize="20sp" />
 
-        <TextView
-            android:id="@+id/tv_submittedon"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingBottom="10dp"
-            android:paddingTop="16dp"
-            android:text="@string/submittedon"
-            android:textSize="16sp"/>
-        <TextView
-            android:id="@+id/tv_submittedon_date"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="Submission Date :"
-            android:imeOptions="actionNext"
-            android:paddingBottom="16dp"
-            android:paddingTop="10dp"
-            android:textSize="20sp"
-            />
+            <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
 
-        <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
-            <EditText
-                android:id="@+id/et_nominal_annual"
-                style="@style/EditText.BaseWidth"
-                android:gravity="start"
-                android:hint="@string/nominal"
-                android:imeOptions="actionNext"
-                android:inputType="number"
-                android:paddingBottom="16dp"
-                android:singleLine="true"/>
-        </android.support.design.widget.TextInputLayout>
+                <EditText
+                    android:id="@+id/et_nominal_annual"
+                    style="@style/EditText.BaseWidth"
+                    android:gravity="start"
+                    android:hint="@string/nominal"
+                    android:imeOptions="actionNext"
+                    android:inputType="number"
+                    android:paddingBottom="16dp"
+                    android:singleLine="true" />
+            </android.support.design.widget.TextInputLayout>
 
-        <TextView
-            android:id="@+id/tv_interest_calc"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="16dp"
-            android:text="@string/interest_calc"
-            android:textSize="16sp"
-            />
+            <TextView
+                android:id="@+id/tv_interest_calc"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="16dp"
+                android:text="@string/interest_calc"
+                android:textSize="16sp" />
 
-        <Spinner
-            android:id="@+id/sp_interest_calc"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:spinnerMode="dropdown"
-            android:background="@color/light_grey"/>
-        <TextView
-            android:id="@+id/tv_interest_comp"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:text="@string/interest_comp"
-            android:textSize="16sp"
-            />
-        <Spinner
-            android:id="@+id/sp_interest_comp"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:spinnerMode="dropdown"
-            android:background="@color/light_grey"/>
-        <TextView
-            android:id="@+id/tv_interest_p_period"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:text="@string/interest_p_period"
-            android:textSize="16sp"
-            />
-        <Spinner
-            android:id="@+id/sp_interest_p_period"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:spinnerMode="dropdown"
-            android:background="@color/light_grey"/>
-        <TextView
-            android:id="@+id/tv_days_in_year"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:text="@string/days_in_year"
-            android:textSize="16sp"
-            />
-        <Spinner
-            android:id="@+id/sp_days_in_year"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:spinnerMode="dropdown"
-            android:background="@color/light_grey"/>
+            <Spinner
+                android:id="@+id/sp_interest_calc"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/light_grey"
+                android:paddingTop="10dp"
+                android:spinnerMode="dropdown" />
 
-        <Button
-            android:id="@+id/bt_submit"
-            style="@style/Button.Base"
-            android:layout_marginTop="10dp"
-            android:text="@string/submit"
-            />
+            <TextView
+                android:id="@+id/tv_interest_comp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="10dp"
+                android:text="@string/interest_comp"
+                android:textSize="16sp" />
 
+            <Spinner
+                android:id="@+id/sp_interest_comp"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/light_grey"
+                android:paddingTop="10dp"
+                android:spinnerMode="dropdown" />
 
-    </LinearLayout>
-</ScrollView>
+            <TextView
+                android:id="@+id/tv_interest_p_period"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="10dp"
+                android:text="@string/interest_p_period"
+                android:textSize="16sp" />
+
+            <Spinner
+                android:id="@+id/sp_interest_p_period"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/light_grey"
+                android:paddingTop="10dp"
+                android:spinnerMode="dropdown" />
+
+            <TextView
+                android:id="@+id/tv_days_in_year"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="10dp"
+                android:text="@string/days_in_year"
+                android:textSize="16sp" />
+
+            <Spinner
+                android:id="@+id/sp_days_in_year"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/light_grey"
+                android:paddingTop="10dp"
+                android:spinnerMode="dropdown" />
+
+            <Button
+                android:id="@+id/bt_submit"
+                style="@style/Button.Base"
+                android:layout_marginTop="10dp"
+                android:text="@string/submit" />
+        </LinearLayout>
+    </ScrollView>
+</ViewFlipper>

--- a/mifosng-android/src/main/res/layout/fragment_centers_list.xml
+++ b/mifosng-android/src/main/res/layout/fragment_centers_list.xml
@@ -6,12 +6,25 @@
   -->
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent" android:layout_height="match_parent">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-    <ListView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/lv_center_list"
-        android:layout_centerVertical="true"
-        android:layout_centerHorizontal="true" />
+    <ViewFlipper
+        android:id="@+id/view_flipper"
+        android:layout_width="match_parent"
+        android:inAnimation="@android:anim/fade_in"
+        android:outAnimation="@android:anim/fade_out"
+        android:layout_height="match_parent">
+
+        <ProgressBar
+            android:id="@+id/progress_bar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center" />
+
+        <ListView
+            android:id="@+id/lv_center_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </ViewFlipper>
 </RelativeLayout>

--- a/mifosng-android/src/main/res/layout/fragment_client_choose.xml
+++ b/mifosng-android/src/main/res/layout/fragment_client_choose.xml
@@ -1,22 +1,35 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ This project is licensed under the open source MPL V2.
   ~ See https://github.com/openMF/android-client/blob/master/LICENSE.md
   -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    style="@style/LinearLayout.Base">
+<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/view_flipper"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:inAnimation="@android:anim/fade_in"
+    android:outAnimation="@android:anim/fade_out">
 
-
-    <TextView
-        android:id="@+id/tv_title"
-        style="@style/TextView.Search.Results"
-        android:textSize="20sp"
-        android:text="Select a Client from the list" />
-
-    <ListView
-        android:id="@+id/lv_clients"
-        android:layout_width="match_parent"
+    <!-- Comment out to edit actual content -->
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:clickable="true" />
-</LinearLayout>
+        android:layout_gravity="center" />
+
+    <!-- Content -->
+    <LinearLayout style="@style/LinearLayout.Base">
+
+        <TextView
+            android:id="@+id/tv_title"
+            style="@style/TextView.Search.Results"
+            android:text="Select a Client from the list"
+            android:textSize="20sp" />
+
+        <ListView
+            android:id="@+id/lv_clients"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:clickable="true" />
+    </LinearLayout>
+</ViewFlipper>

--- a/mifosng-android/src/main/res/layout/fragment_client_details.xml
+++ b/mifosng-android/src/main/res/layout/fragment_client_details.xml
@@ -2,159 +2,173 @@
   ~ This project is licensed under the open source MPL V2.
   ~ See https://github.com/openMF/android-client/blob/master/LICENSE.md
   -->
+<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/view_flipper"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:inAnimation="@android:anim/fade_in"
+    android:outAnimation="@android:anim/fade_out">
 
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    style="@style/ScrollView.Base">
+    <!-- Comment this out when editing the actual content -->
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
 
-    <LinearLayout style="@style/LinearLayout.Base">
+    <!-- Actual content -->
+    <ScrollView style="@style/ScrollView.Base">
 
-        <LinearLayout style="@style/LinearLayout.Width">
+        <LinearLayout style="@style/LinearLayout.Base">
 
-            <FrameLayout
-                android:layout_width="75dp"
-                android:layout_height="75dp">
+            <LinearLayout style="@style/LinearLayout.Width">
 
-                <ProgressBar
-                    android:id="@+id/pb_imageProgressBar"
-                    style="@style/ProgressBar.Base"
-                    android:layout_gravity="center" />
+                <FrameLayout
+                    android:layout_width="75dp"
+                    android:layout_height="75dp">
 
-                <com.mifos.mifosxdroid.views.CircularImageView
-                    android:id="@+id/iv_clientImage"
-                    style="@style/ClientImage"
-                    android:layout_gravity="center" />
+                    <ProgressBar
+                        android:id="@+id/pb_imageProgressBar"
+                        style="@style/ProgressBar.Base"
+                        android:layout_gravity="center" />
 
-            </FrameLayout>
+                    <com.mifos.mifosxdroid.views.CircularImageView
+                        android:id="@+id/iv_clientImage"
+                        style="@style/ClientImage"
+                        android:layout_gravity="center" />
 
-            <TextView
-                android:id="@+id/tv_fullName"
-                style="@style/TextView.Client" />
+                </FrameLayout>
+
+                <TextView
+                    android:id="@+id/tv_fullName"
+                    style="@style/TextView.Client" />
+
+            </LinearLayout>
+
+
+            <TableLayout
+                android:id="@+id/tbl_clientDetails"
+                style="@style/Table">
+
+                <TableRow
+                    android:id="@+id/row_account"
+                    style="@style/TableRow">
+
+                    <TextView
+                        style="@style/TextView.Row"
+                        android:text="@string/account_number" />
+
+                    <TextView
+                        android:id="@+id/tv_accountNumber"
+                        style="@style/TextView.Row.Value" />
+                </TableRow>
+
+                <TableRow
+                    android:id="@+id/row_external"
+                    style="@style/TableRow">
+
+                    <TextView
+                        style="@style/TextView.Row"
+                        android:text="@string/external_id" />
+
+                    <TextView
+                        android:id="@+id/tv_externalId"
+                        style="@style/TextView.Row.Value" />
+                </TableRow>
+
+                <TableRow
+                    android:id="@+id/row_activation"
+                    style="@style/TableRow">
+
+                    <TextView
+                        style="@style/TextView.Row"
+                        android:text="@string/activation_date" />
+
+                    <TextView
+                        android:id="@+id/tv_activationDate"
+                        style="@style/TextView.Row.Value" />
+                </TableRow>
+
+                <TableRow
+                    android:id="@+id/row_office"
+                    style="@style/TableRow">
+
+                    <TextView
+                        style="@style/TextView.Row"
+                        android:text="@string/office" />
+
+                    <TextView
+                        android:id="@+id/tv_office"
+                        style="@style/TextView.Row.Value" />
+                </TableRow>
+
+                <TableRow
+                    android:id="@+id/row_group"
+                    style="@style/TableRow"
+                    android:visibility="gone">
+
+                    <TextView
+                        style="@style/TextView.Row"
+                        android:text="@string/group" />
+
+                    <TextView
+                        android:id="@+id/tv_group"
+                        style="@style/TextView.Row.Value" />
+                </TableRow>
+
+                <TableRow
+                    android:id="@+id/row_staff"
+                    style="@style/TableRow"
+                    android:visibility="gone">
+
+                    <TextView
+                        style="@style/TextView.Row"
+                        android:text="@string/staff" />
+
+                    <TextView
+                        android:id="@+id/tv_loanOfficer"
+                        style="@style/TextView.Row"
+                        android:gravity="right"
+                        android:text="" />
+                </TableRow>
+
+                <TableRow
+                    android:id="@+id/row_loan"
+                    style="@style/TableRow"
+                    android:visibility="gone">
+
+                    <TextView
+                        style="@style/TextView.Row"
+                        android:text="@string/loan_cycle" />
+
+                    <TextView
+                        android:id="@+id/tv_loanCycle"
+                        style="@style/TextView.Row"
+                        android:gravity="right"
+                        android:text="" />
+                </TableRow>
+
+            </TableLayout>
+
+            <include
+                android:id="@+id/account_accordion_section_loans"
+                layout="@layout/view_account_accordion_section"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp" />
+
+            <include
+                android:id="@+id/account_accordion_section_savings"
+                layout="@layout/view_account_accordion_section"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <include
+                android:id="@+id/account_accordion_section_recurring"
+                layout="@layout/view_account_accordion_section"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
 
         </LinearLayout>
-
-
-        <TableLayout
-            android:id="@+id/tbl_clientDetails"
-            style="@style/Table">
-
-            <TableRow
-                android:id="@+id/row_account"
-                style="@style/TableRow">
-
-                <TextView
-                    style="@style/TextView.Row"
-                    android:text="@string/account_number" />
-
-                <TextView
-                    android:id="@+id/tv_accountNumber"
-                    style="@style/TextView.Row.Value" />
-            </TableRow>
-
-            <TableRow
-                android:id="@+id/row_external"
-                style="@style/TableRow">
-
-                <TextView
-                    style="@style/TextView.Row"
-                    android:text="@string/external_id" />
-
-                <TextView
-                    android:id="@+id/tv_externalId"
-                    style="@style/TextView.Row.Value" />
-            </TableRow>
-
-            <TableRow
-                android:id="@+id/row_activation"
-                style="@style/TableRow">
-
-                <TextView
-                    style="@style/TextView.Row"
-                    android:text="@string/activation_date" />
-
-                <TextView
-                    android:id="@+id/tv_activationDate"
-                    style="@style/TextView.Row.Value" />
-            </TableRow>
-
-            <TableRow
-                android:id="@+id/row_office"
-                style="@style/TableRow">
-
-                <TextView
-                    style="@style/TextView.Row"
-                    android:text="@string/office" />
-
-                <TextView
-                    android:id="@+id/tv_office"
-                    style="@style/TextView.Row.Value" />
-            </TableRow>
-
-            <TableRow
-                android:id="@+id/row_group"
-                style="@style/TableRow"
-                android:visibility="gone">
-
-                <TextView
-                    style="@style/TextView.Row"
-                    android:text="@string/group" />
-
-                <TextView
-                    android:id="@+id/tv_group"
-                    style="@style/TextView.Row.Value" />
-            </TableRow>
-
-            <TableRow
-                android:id="@+id/row_staff"
-                style="@style/TableRow"
-                android:visibility="gone">
-
-                <TextView
-                    style="@style/TextView.Row"
-                    android:text="@string/staff" />
-
-                <TextView
-                    android:id="@+id/tv_loanOfficer"
-                    style="@style/TextView.Row"
-                    android:gravity="right"
-                    android:text="" />
-            </TableRow>
-
-            <TableRow
-                android:id="@+id/row_loan"
-                android:visibility="gone"
-                style="@style/TableRow">
-
-                <TextView
-                    style="@style/TextView.Row"
-                    android:text="@string/loan_cycle" />
-
-                <TextView
-                    android:id="@+id/tv_loanCycle"
-                    style="@style/TextView.Row"
-                    android:gravity="right"
-                    android:text="" />
-            </TableRow>
-
-        </TableLayout>
-
-        <include
-            android:layout_marginTop="10dp"
-            android:id="@+id/account_accordion_section_loans"
-            layout="@layout/view_account_accordion_section"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-
-        <include
-            android:id="@+id/account_accordion_section_savings"
-            layout="@layout/view_account_accordion_section"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-
-        <include
-            android:id="@+id/account_accordion_section_recurring"
-            layout="@layout/view_account_accordion_section"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-
-    </LinearLayout>
-</ScrollView>
+    </ScrollView>
+</ViewFlipper>

--- a/mifosng-android/src/main/res/layout/fragment_client_identifiers.xml
+++ b/mifosng-android/src/main/res/layout/fragment_client_identifiers.xml
@@ -2,18 +2,32 @@
   ~ This project is licensed under the open source MPL V2.
   ~ See https://github.com/openMF/android-client/blob/master/LICENSE.md
   -->
-
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/view_flipper"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".online.ClientIdentifiersFragment">
+    android:inAnimation="@android:anim/fade_in"
+    android:outAnimation="@android:anim/fade_out">
 
-
-    <ListView
+    <!-- Comment out to see actual content -->
+    <ProgressBar
+        android:id="@+id/progress_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:id="@+id/lv_identifiers"
-        android:layout_alignParentTop="true"
-        android:layout_centerHorizontal="true" />
-</RelativeLayout>
+        android:layout_gravity="center" />
+
+    <!-- Actual content -->
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".online.ClientIdentifiersFragment">
+
+        <ListView
+            android:id="@+id/lv_identifiers"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentTop="true"
+            android:layout_centerHorizontal="true" />
+    </RelativeLayout>
+</ViewFlipper>

--- a/mifosng-android/src/main/res/layout/fragment_create_new_client.xml
+++ b/mifosng-android/src/main/res/layout/fragment_create_new_client.xml
@@ -1,206 +1,231 @@
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent">
+<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/view_flipper"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:inAnimation="@android:anim/fade_in"
+    android:outAnimation="@android:anim/fade_out">
 
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        style="@style/LinearLayout.Base">
+    <!-- Comment this out when editing the actual content -->
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
 
-        <TextView style="@style/TextView.CreateClient" />
+    <!-- Actual content -->
+    <ScrollView
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent">
 
-        <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
+        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            style="@style/LinearLayout.Base">
 
-            <EditText
-                android:id="@+id/et_client_first_name"
-                style="@style/EditText.BaseWidth"
-                android:gravity="start"
-                android:hint="@string/fname"
-                android:imeOptions="actionNext"
-                android:inputType="text"
-                android:paddingBottom="16dp"
-                android:singleLine="true"/>
+            <TextView style="@style/TextView.CreateClient" />
+
+            <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
+
+                <EditText
+                    android:id="@+id/et_client_first_name"
+                    style="@style/EditText.BaseWidth"
+                    android:gravity="start"
+                    android:hint="@string/fname"
+                    android:imeOptions="actionNext"
+                    android:inputType="text"
+                    android:paddingBottom="16dp"
+                    android:singleLine="true" />
+
                 <requestFocus />
             </android.support.design.widget.TextInputLayout>
 
 
+            <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
 
-        <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
+                <EditText
+                    android:id="@+id/et_client_middle_name"
+                    style="@style/EditText.BaseWidth"
+                    android:gravity="start"
+                    android:hint="@string/mname"
+                    android:imeOptions="actionNext"
+                    android:inputType="text"
+                    android:paddingBottom="16dp"
+                    android:singleLine="true" />
+            </android.support.design.widget.TextInputLayout>
 
-            <EditText
-                android:id="@+id/et_client_middle_name"
-                style="@style/EditText.BaseWidth"
-                android:gravity="start"
-                android:hint="@string/mname"
+            <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
+
+                <EditText
+                    android:id="@+id/et_client_last_name"
+                    style="@style/EditText.BaseWidth"
+                    android:gravity="start"
+                    android:hint="@string/lname"
+                    android:imeOptions="actionNext"
+                    android:inputType="text"
+                    android:paddingBottom="16dp"
+                    android:singleLine="true" />
+            </android.support.design.widget.TextInputLayout>
+
+            <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
+
+                <EditText
+                    android:id="@+id/et_client_mobile_no"
+                    style="@style/EditText.BaseWidth"
+                    android:gravity="start"
+                    android:hint="@string/mobile_no"
+                    android:imeOptions="actionNext"
+                    android:inputType="phone"
+                    android:paddingBottom="16dp"
+                    android:singleLine="true" />
+            </android.support.design.widget.TextInputLayout>
+
+            <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
+
+                <EditText
+                    android:id="@+id/et_client_external_id"
+                    style="@style/EditText.BaseWidth"
+                    android:gravity="start"
+                    android:hint="@string/external_id"
+                    android:imeOptions="actionNext"
+                    android:inputType="text"
+                    android:paddingBottom="16dp"
+                    android:singleLine="true" />
+            </android.support.design.widget.TextInputLayout>
+
+            <TextView
+                android:id="@+id/tv_client_gender"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="16dp"
+                android:text="@string/gender"
+                android:textSize="16sp" />
+
+            <Spinner
+                android:id="@+id/sp_gender"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/light_grey"
+                android:paddingTop="10dp"
+                android:spinnerMode="dropdown" />
+
+            <TextView
+                android:id="@+id/tv_client_dateofbirth"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingBottom="10dp"
+                android:paddingTop="16dp"
+                android:text="@string/dob"
+                android:textSize="16sp" />
+
+            <TextView
+                android:id="@+id/tv_dateofbirth"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/light_grey"
+                android:hint="select client's date of birth :"
                 android:imeOptions="actionNext"
-                android:inputType="text"
                 android:paddingBottom="16dp"
-                android:singleLine="true"/>
-        </android.support.design.widget.TextInputLayout>
+                android:paddingTop="10dp"
+                android:textSize="20sp" />
 
-        <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
+            <TextView
+                android:id="@+id/tv_client_type"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="16dp"
+                android:text="@string/client_type"
+                android:textSize="16sp"
 
-            <EditText
-                android:id="@+id/et_client_last_name"
-                style="@style/EditText.BaseWidth"
-                android:gravity="start"
-                android:hint="@string/lname"
-                android:imeOptions="actionNext"
-                android:inputType="text"
-                android:paddingBottom="16dp"
-                android:singleLine="true"/>
-        </android.support.design.widget.TextInputLayout>
-        <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
-            <EditText
-                android:id="@+id/et_client_mobile_no"
-                style="@style/EditText.BaseWidth"
-                android:gravity="start"
-                android:hint="@string/mobile_no"
-                android:imeOptions="actionNext"
-                android:inputType="phone"
-                android:paddingBottom="16dp"
-                android:singleLine="true"/>
-        </android.support.design.widget.TextInputLayout>
-        <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
-            <EditText
-                android:id="@+id/et_client_external_id"
-                style="@style/EditText.BaseWidth"
-                android:gravity="start"
-                android:hint="@string/external_id"
-                android:imeOptions="actionNext"
-                android:inputType="text"
-                android:paddingBottom="16dp"
-                android:singleLine="true"/>
-        </android.support.design.widget.TextInputLayout>
-    <TextView
-        android:id="@+id/tv_client_gender"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingTop="16dp"
-        android:text="@string/gender"
-        android:textSize="16sp"/>
-    <Spinner
-        android:id="@+id/sp_gender"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:paddingTop="10dp"
-        android:spinnerMode="dropdown"
-        android:background="@color/light_grey"/>
+                />
 
-    <TextView
-        android:id="@+id/tv_client_dateofbirth"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingBottom="10dp"
-        android:paddingTop="16dp"
-        android:text="@string/dob"
-        android:textSize="16sp"/>
-    <TextView
-        android:id="@+id/tv_dateofbirth"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="select client's date of birth :"
-        android:imeOptions="actionNext"
-        android:paddingBottom="16dp"
-        android:paddingTop="10dp"
-        android:textSize="20sp"
-        android:background="@color/light_grey" />
-    <TextView
-        android:id="@+id/tv_client_type"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingTop="16dp"
-        android:text="@string/client_type"
-        android:textSize="16sp"
+            <Spinner
+                android:id="@+id/sp_client_type"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/light_grey"
+                android:paddingTop="10dp"
+                android:spinnerMode="dropdown" />
 
-        />
+            <TextView
+                android:id="@+id/tv_client_classification"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="10dp"
+                android:text="@string/client_classification"
+                android:textSize="16sp"
 
-    <Spinner
-        android:id="@+id/sp_client_type"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:paddingTop="10dp"
-        android:spinnerMode="dropdown"
-        android:background="@color/light_grey"/>
-    <TextView
-        android:id="@+id/tv_client_classification"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingTop="10dp"
-        android:text="@string/client_classification"
-        android:textSize="16sp"
+                />
 
-        />
+            <Spinner
+                android:id="@+id/sp_client_classification"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/light_grey"
+                android:paddingTop="10dp"
+                android:spinnerMode="dropdown" />
 
-    <Spinner
-        android:id="@+id/sp_client_classification"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:paddingTop="10dp"
-        android:spinnerMode="dropdown"
-        android:background="@color/light_grey"/>
-    <TextView
-        android:id="@+id/tv_office"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingTop="10dp"
-        android:text="@string/office_name"
-        android:textSize="16sp"
+            <TextView
+                android:id="@+id/tv_office"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="10dp"
+                android:text="@string/office_name"
+                android:textSize="16sp"
 
-        />
+                />
 
-    <Spinner
-        android:id="@+id/sp_offices"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:paddingTop="10dp"
-        android:spinnerMode="dropdown"
-        android:background="@color/light_grey"/>
-    <TextView
-        android:id="@+id/tv_staff"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingTop="10dp"
-        android:text="@string/staff_names"
-        android:textSize="16sp"
+            <Spinner
+                android:id="@+id/sp_offices"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/light_grey"
+                android:paddingTop="10dp"
+                android:spinnerMode="dropdown" />
 
-        />
+            <TextView
+                android:id="@+id/tv_staff"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="10dp"
+                android:text="@string/staff_names"
+                android:textSize="16sp"
 
-    <Spinner
-        android:id="@+id/sp_staff"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:paddingTop="10dp"
-        android:spinnerMode="dropdown"
-        android:background="@color/light_grey"/>
-    <CheckBox
-        android:id="@+id/cb_client_active_status"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
-        android:checked="false"
-        android:paddingTop="10dp"
-        android:text="@string/client_active"
-        />
+                />
 
-    <TextView
-        android:id="@+id/tv_submission_date"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingTop="10dp"
-        android:textSize="20sp"
-        android:visibility="gone"
-        android:background="@color/light_grey"
+            <Spinner
+                android:id="@+id/sp_staff"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/light_grey"
+                android:paddingTop="10dp"
+                android:spinnerMode="dropdown" />
 
-        />
+            <CheckBox
+                android:id="@+id/cb_client_active_status"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:checked="false"
+                android:paddingTop="10dp"
+                android:text="@string/client_active" />
+
+            <TextView
+                android:id="@+id/tv_submission_date"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/light_grey"
+                android:paddingTop="10dp"
+                android:textSize="20sp"
+                android:visibility="gone"
+
+                />
 
 
-    <Button
-        android:id="@+id/bt_submit"
-        style="@style/Button.Base"
-        android:layout_marginTop="10dp"
-        android:text="@string/submit"
-        />
+            <Button
+                android:id="@+id/bt_submit"
+                style="@style/Button.Base"
+                android:layout_marginTop="10dp"
+                android:text="@string/submit" />
 
 
-</LinearLayout>
+        </LinearLayout>
     </ScrollView>
+</ViewFlipper>

--- a/mifosng-android/src/main/res/layout/fragment_create_new_group.xml
+++ b/mifosng-android/src/main/res/layout/fragment_create_new_group.xml
@@ -1,100 +1,121 @@
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent">
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        style="@style/LinearLayout.Base">
-        <TextView style="@style/TextView.CreateGroup" />
-        <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
-            <EditText
-                android:id="@+id/et_group_name"
-                style="@style/EditText.BaseWidth"
-                android:gravity="start"
-                android:hint="@string/groupname"
-                android:imeOptions="actionNext"
-                android:inputType="text"
-                android:paddingBottom="16dp"
-                android:singleLine="true"/>
-            <requestFocus />
-        </android.support.design.widget.TextInputLayout>
-        <TextView
-            android:id="@+id/tv_office"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:text="@string/office_name"
-            android:textSize="16sp"
+<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/view_flipper"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:inAnimation="@android:anim/fade_in"
+    android:outAnimation="@android:anim/fade_out">
 
-            />
+    <!-- Comment this out when editing the actual content -->
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
 
-        <Spinner
-            android:id="@+id/sp_group_offices"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:spinnerMode="dropdown"
-            android:background="@color/light_grey"/>
+    <!-- Actual content -->
+    <ScrollView
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent">
 
-        <TextView
-            android:id="@+id/tv_group_submission_date"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingBottom="10dp"
-            android:paddingTop="16dp"
-            android:text="@string/center_submission_date"
-            android:textSize="16sp"/>
-        <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
-            <EditText
-                android:id="@+id/et_group_external_id"
-                style="@style/EditText.BaseWidth"
-                android:gravity="start"
-                android:hint="@string/external_id"
-                android:imeOptions="actionNext"
-                android:inputType="text"
-                android:paddingBottom="16dp"
-                android:singleLine="true"/>
-        </android.support.design.widget.TextInputLayout>
+        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            style="@style/LinearLayout.Base">
 
-        <CheckBox
-            android:id="@+id/cb_group_active_status"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
-            android:checked="false"
-            android:paddingTop="10dp"
-            android:text="@string/center_active"
-            />
+            <TextView style="@style/TextView.CreateGroup" />
 
-        <TextView
-            android:id="@+id/tv_group_activationDate"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:inputType="date"
-            android:paddingBottom="10dp"
-            android:textSize="20sp"
-            android:text="@string/center_activation_date"
-            android:visibility="gone"
+            <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
 
-            />
+                <EditText
+                    android:id="@+id/et_group_name"
+                    style="@style/EditText.BaseWidth"
+                    android:gravity="start"
+                    android:hint="@string/groupname"
+                    android:imeOptions="actionNext"
+                    android:inputType="text"
+                    android:paddingBottom="16dp"
+                    android:singleLine="true" />
+
+                <requestFocus />
+            </android.support.design.widget.TextInputLayout>
+
+            <TextView
+                android:id="@+id/tv_office"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="10dp"
+                android:text="@string/office_name"
+                android:textSize="16sp"
+
+                />
+
+            <Spinner
+                android:id="@+id/sp_group_offices"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/light_grey"
+                android:paddingTop="10dp"
+                android:spinnerMode="dropdown" />
+
+            <TextView
+                android:id="@+id/tv_group_submission_date"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingBottom="10dp"
+                android:paddingTop="16dp"
+                android:text="@string/center_submission_date"
+                android:textSize="16sp" />
+
+            <android.support.design.widget.TextInputLayout style="@style/TextInput.Base">
+
+                <EditText
+                    android:id="@+id/et_group_external_id"
+                    style="@style/EditText.BaseWidth"
+                    android:gravity="start"
+                    android:hint="@string/external_id"
+                    android:imeOptions="actionNext"
+                    android:inputType="text"
+                    android:paddingBottom="16dp"
+                    android:singleLine="true" />
+            </android.support.design.widget.TextInputLayout>
+
+            <CheckBox
+                android:id="@+id/cb_group_active_status"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:checked="false"
+                android:paddingTop="10dp"
+                android:text="@string/center_active" />
+
+            <TextView
+                android:id="@+id/tv_group_activationDate"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="date"
+                android:paddingBottom="10dp"
+                android:text="@string/center_activation_date"
+                android:textSize="20sp"
+                android:visibility="gone"
+
+                />
 
 
-        <TextView
-            android:id="@+id/tv_center_active_date"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:textSize="20sp"
-            android:visibility="gone"
+            <TextView
+                android:id="@+id/tv_center_active_date"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="10dp"
+                android:textSize="20sp"
+                android:visibility="gone"
 
-            />
+                />
 
-        <Button
-            android:id="@+id/bt_submit"
-            style="@style/Button.Base"
-            android:layout_marginTop="10dp"
-            android:text="@string/submit"
-            />
+            <Button
+                android:id="@+id/bt_submit"
+                style="@style/Button.Base"
+                android:layout_marginTop="10dp"
+                android:text="@string/submit" />
 
 
-    </LinearLayout>
-</ScrollView>
+        </LinearLayout>
+    </ScrollView>
+</ViewFlipper>

--- a/mifosng-android/src/main/res/layout/fragment_datatable.xml
+++ b/mifosng-android/src/main/res/layout/fragment_datatable.xml
@@ -2,29 +2,29 @@
   ~ This project is licensed under the open source MPL V2.
   ~ See https://github.com/openMF/android-client/blob/master/LICENSE.md
   -->
-
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/view_flipper"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".online.DatatableFragment"
-    android:orientation="vertical">
+    android:inAnimation="@android:anim/fade_in"
+    android:outAnimation="@android:anim/fade_out">
 
+    <!-- Comment this out when editing the actual content -->
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
+
+    <!-- Actual content -->
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
         <LinearLayout
+            android:id="@+id/linear_layout_datatables"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:id="@+id/linear_layout_datatables"
-            android:orientation="vertical">
-
-
-
-        </LinearLayout>
-
+            android:orientation="vertical" />
     </ScrollView>
-
-
-</LinearLayout>
+</ViewFlipper>

--- a/mifosng-android/src/main/res/layout/fragment_document_list.xml
+++ b/mifosng-android/src/main/res/layout/fragment_document_list.xml
@@ -3,55 +3,71 @@
   ~ See https://github.com/openMF/android-client/blob/master/LICENSE.md
   -->
 
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/view_flipper"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".online.DocumentListFragment">
+    android:inAnimation="@android:anim/fade_in"
+    android:outAnimation="@android:anim/fade_out">
 
-    <TableLayout
-        android:id="@+id/tbl_header"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentTop="true">
-
-
-        <TableRow
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:background="#ffd1d1d1"
-            android:paddingTop="8dp"
-            android:paddingBottom="8dp"
-            android:paddingLeft="8dp"
-            android:paddingRight="8dp">
-
-            <TextView
-                android:id="@+id/name"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="@string/name"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/textView2"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="@string/description"
-                android:textStyle="bold"
-                android:layout_marginRight="24dp"/>
-
-        </TableRow>
-
-    </TableLayout>
-
-    <ListView
-        android:id="@+id/lv_documents"
+    <!-- Comment this out when editing the actual content -->
+    <ProgressBar
+        android:id="@+id/progress_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@id/tbl_header"
-        android:layout_centerHorizontal="true" />
-</RelativeLayout>
+        android:layout_gravity="center" />
+
+    <!-- Actual content -->
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".online.DocumentListFragment">
+
+        <TableLayout
+            android:id="@+id/tbl_header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentTop="true">
+
+
+            <TableRow
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="#ffd1d1d1"
+                android:paddingBottom="8dp"
+                android:paddingLeft="8dp"
+                android:paddingRight="8dp"
+                android:paddingTop="8dp">
+
+                <TextView
+                    android:id="@+id/name"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/name"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/textView2"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginRight="24dp"
+                    android:layout_weight="1"
+                    android:text="@string/description"
+                    android:textStyle="bold" />
+
+            </TableRow>
+
+        </TableLayout>
+
+        <ListView
+            android:id="@+id/lv_documents"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/tbl_header"
+            android:layout_centerHorizontal="true" />
+    </RelativeLayout>
+</ViewFlipper>

--- a/mifosng-android/src/main/res/layout/fragment_generate_collection_sheet.xml
+++ b/mifosng-android/src/main/res/layout/fragment_generate_collection_sheet.xml
@@ -2,149 +2,158 @@
   ~ This project is licensed under the open source MPL V2.
   ~ See https://github.com/openMF/android-client/blob/master/LICENSE.md
   -->
-
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/view_flipper"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:orientation="vertical"
-    tools:context="com.mifos.mifosxdroid.online.GenerateCollectionSheet$PlaceholderFragment">
+    android:inAnimation="@android:anim/fade_in"
+    android:outAnimation="@android:anim/fade_out">
 
+    <!-- Comment this out when editing the actual content -->
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
 
+    <!-- Actual content -->
     <LinearLayout
-        android:orientation="horizontal"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:layout_marginBottom="8dp"
-        android:layout_marginTop="8dp"
-        >
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        tools:context="com.mifos.mifosxdroid.online.GenerateCollectionSheet$PlaceholderFragment">
 
-        <TextView
-            android:layout_width="0dp"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceSmall"
-            android:text="@string/office"
-            android:id="@+id/label_branch_office"
-            android:layout_weight="1"
-            />
+            android:layout_marginBottom="8dp"
+            android:layout_marginTop="8dp"
+            android:gravity="center"
+            android:orientation="horizontal">
 
-        <Spinner
-            android:layout_width="0dp"
+            <TextView
+                android:id="@+id/label_branch_office"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/office"
+                android:textAppearance="?android:attr/textAppearanceSmall" />
+
+            <Spinner
+                android:id="@+id/sp_branch_offices"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:id="@+id/sp_branch_offices"
-            android:layout_weight="1"
-            />
+            android:layout_marginBottom="8dp"
+            android:layout_marginTop="8dp"
+            android:gravity="center"
+            android:orientation="horizontal">
 
+            <TextView
+                android:id="@+id/label_meeting_date"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/meeting_date"
+                android:textAppearance="?android:attr/textAppearanceSmall" />
+
+            <TextView
+                android:id="@+id/tv_meeting_date"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="14 July 2014"
+                android:textAppearance="?android:attr/textAppearanceSmall" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:layout_marginTop="8dp"
+            android:gravity="center"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/label_staff"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/staff_name"
+                android:textAppearance="?android:attr/textAppearanceSmall" />
+
+            <Spinner
+                android:id="@+id/sp_loan_officers"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:layout_marginTop="8dp"
+            android:gravity="center"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/label_center_name"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/center"
+                android:textAppearance="?android:attr/textAppearanceSmall" />
+
+            <Spinner
+                android:id="@+id/sp_centers"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:layout_marginTop="8dp"
+            android:gravity="center"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/label_group"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/group"
+                android:textAppearance="?android:attr/textAppearanceSmall" />
+
+            <Spinner
+                android:id="@+id/sp_groups"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/bt_generate_collection_sheet"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginBottom="8dp"
+            android:layout_marginTop="8dp"
+            android:text="@string/generate_collection_sheet" />
     </LinearLayout>
-
-    <LinearLayout
-        android:orientation="horizontal"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:layout_marginTop="8dp"
-        android:gravity="center">
-
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceSmall"
-            android:text="@string/meeting_date"
-            android:layout_weight="1"
-            android:id="@+id/label_meeting_date" />
-
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceSmall"
-            android:text="14 July 2014"
-            android:layout_weight="1"
-            android:id="@+id/tv_meeting_date" />
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:orientation="horizontal"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:layout_marginTop="8dp"
-        android:gravity="center">
-
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceSmall"
-            android:text="@string/staff_name"
-            android:layout_weight="1"
-            android:id="@+id/label_staff" />
-
-        <Spinner
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:id="@+id/sp_loan_officers"
-            android:layout_weight="1" />
-    </LinearLayout>
-
-    <LinearLayout
-        android:orientation="horizontal"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:layout_marginTop="8dp"
-        android:gravity="center">
-
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceSmall"
-            android:text="@string/center"
-            android:layout_weight="1"
-            android:id="@+id/label_center_name" />
-
-        <Spinner
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:id="@+id/sp_centers"
-            android:layout_weight="1" />
-    </LinearLayout>
-
-    <LinearLayout
-        android:orientation="horizontal"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:layout_marginTop="8dp"
-        android:gravity="center">
-
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceSmall"
-            android:text="@string/group"
-            android:layout_weight="1"
-            android:id="@+id/label_group" />
-
-        <Spinner
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:id="@+id/sp_groups" />
-    </LinearLayout>
-
-    <Button
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/generate_collection_sheet"
-        android:id="@+id/bt_generate_collection_sheet"
-        android:layout_marginBottom="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_gravity="center_horizontal" />
-
-
-</LinearLayout>
+</ViewFlipper>

--- a/mifosng-android/src/main/res/layout/fragment_group_details.xml
+++ b/mifosng-android/src/main/res/layout/fragment_group_details.xml
@@ -2,139 +2,153 @@
   ~ This project is licensed under the open source MPL V2.
   ~ See https://github.com/openMF/android-client/blob/master/LICENSE.md
   -->
+<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/view_flipper"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:inAnimation="@android:anim/fade_in"
+    android:outAnimation="@android:anim/fade_out">
 
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    style="@style/ScrollView.Base">
+    <!-- Comment this out when editing the actual content -->
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
 
-    <LinearLayout style="@style/LinearLayout.Base">
+    <!-- Actual content -->
+    <ScrollView style="@style/ScrollView.Base">
 
-        <LinearLayout style="@style/LinearLayout.Width">
+        <LinearLayout style="@style/LinearLayout.Base">
 
-            <TextView
-                android:id="@+id/tv_groupsName"
-                style="@style/TextView.Client" />
+            <LinearLayout style="@style/LinearLayout.Width">
+
+                <TextView
+                    android:id="@+id/tv_groupsName"
+                    style="@style/TextView.Client" />
+
+            </LinearLayout>
+
+
+            <TableLayout
+                android:id="@+id/tbl_clientDetails"
+                style="@style/Table">
+
+                <TableRow
+                    android:id="@+id/row_account"
+                    style="@style/TableRow">
+
+                    <TextView
+                        android:id="@+id/tv_groupNumber"
+                        style="@style/TextView.Row.Value" />
+                </TableRow>
+
+                <TableRow
+                    android:id="@+id/row_external"
+                    style="@style/TableRow">
+
+                    <TextView
+                        style="@style/TextView.Row"
+                        android:text="@string/external_id" />
+
+                    <TextView
+                        android:id="@+id/tv_groupexternalId"
+                        style="@style/TextView.Row.Value" />
+                </TableRow>
+
+                <TableRow
+                    android:id="@+id/row_activation"
+                    style="@style/TableRow">
+
+                    <TextView
+                        style="@style/TextView.Row"
+                        android:text="@string/activation_date" />
+
+                    <TextView
+                        android:id="@+id/tv_groupactivationDate"
+                        style="@style/TextView.Row.Value" />
+                </TableRow>
+
+                <TableRow
+                    android:id="@+id/row_office"
+                    style="@style/TableRow">
+
+                    <TextView
+                        style="@style/TextView.Row"
+                        android:text="@string/office" />
+
+                    <TextView
+                        android:id="@+id/tv_groupoffice"
+                        style="@style/TextView.Row.Value" />
+                </TableRow>
+
+                <TableRow
+                    android:id="@+id/row_group"
+                    style="@style/TableRow"
+                    android:visibility="gone">
+
+                    <TextView
+                        style="@style/TextView.Row"
+                        android:text="@string/group" />
+
+                    <TextView
+                        android:id="@+id/tv_group"
+                        style="@style/TextView.Row.Value" />
+                </TableRow>
+
+                <TableRow
+                    android:id="@+id/row_staff"
+                    style="@style/TableRow"
+                    android:visibility="gone">
+
+                    <TextView
+                        style="@style/TextView.Row"
+                        android:text="@string/staff" />
+
+                    <TextView
+                        android:id="@+id/tv_loanOfficer"
+                        style="@style/TextView.Row"
+                        android:gravity="right"
+                        android:text="" />
+                </TableRow>
+
+                <TableRow
+                    android:id="@+id/row_loan"
+                    style="@style/TableRow"
+                    android:visibility="gone">
+
+                    <TextView
+                        style="@style/TextView.Row"
+                        android:text="@string/loan_cycle" />
+
+                    <TextView
+                        android:id="@+id/tv_loanCycle"
+                        style="@style/TextView.Row"
+                        android:gravity="right"
+                        android:text="" />
+                </TableRow>
+
+            </TableLayout>
+
+            <include
+                android:id="@+id/account_accordion_section_loans"
+                layout="@layout/view_account_accordion_section"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp" />
+
+            <include
+                android:id="@+id/account_accordion_section_savings"
+                layout="@layout/view_account_accordion_section"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <include
+                android:id="@+id/account_accordion_section_recurring"
+                layout="@layout/view_account_accordion_section"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
 
         </LinearLayout>
-
-
-        <TableLayout
-            android:id="@+id/tbl_clientDetails"
-            style="@style/Table">
-
-            <TableRow
-                android:id="@+id/row_account"
-                style="@style/TableRow">
-
-                <TextView
-                    android:id="@+id/tv_groupNumber"
-                    style="@style/TextView.Row.Value" />
-            </TableRow>
-
-            <TableRow
-                android:id="@+id/row_external"
-                style="@style/TableRow">
-
-                <TextView
-                    style="@style/TextView.Row"
-                    android:text="@string/external_id" />
-
-                <TextView
-                    android:id="@+id/tv_groupexternalId"
-                    style="@style/TextView.Row.Value" />
-            </TableRow>
-
-            <TableRow
-                android:id="@+id/row_activation"
-                style="@style/TableRow">
-
-                <TextView
-                    style="@style/TextView.Row"
-                    android:text="@string/activation_date" />
-
-                <TextView
-                    android:id="@+id/tv_groupactivationDate"
-                    style="@style/TextView.Row.Value" />
-            </TableRow>
-
-            <TableRow
-                android:id="@+id/row_office"
-                style="@style/TableRow">
-
-                <TextView
-                    style="@style/TextView.Row"
-                    android:text="@string/office" />
-
-                <TextView
-                    android:id="@+id/tv_groupoffice"
-                    style="@style/TextView.Row.Value" />
-            </TableRow>
-
-            <TableRow
-                android:id="@+id/row_group"
-                style="@style/TableRow"
-                android:visibility="gone">
-
-                <TextView
-                    style="@style/TextView.Row"
-                    android:text="@string/group" />
-
-                <TextView
-                    android:id="@+id/tv_group"
-                    style="@style/TextView.Row.Value" />
-            </TableRow>
-
-            <TableRow
-                android:id="@+id/row_staff"
-                style="@style/TableRow"
-                android:visibility="gone">
-
-                <TextView
-                    style="@style/TextView.Row"
-                    android:text="@string/staff" />
-
-                <TextView
-                    android:id="@+id/tv_loanOfficer"
-                    style="@style/TextView.Row"
-                    android:gravity="right"
-                    android:text="" />
-            </TableRow>
-
-            <TableRow
-                android:id="@+id/row_loan"
-                android:visibility="gone"
-                style="@style/TableRow">
-
-                <TextView
-                    style="@style/TextView.Row"
-                    android:text="@string/loan_cycle" />
-
-                <TextView
-                    android:id="@+id/tv_loanCycle"
-                    style="@style/TextView.Row"
-                    android:gravity="right"
-                    android:text="" />
-            </TableRow>
-
-        </TableLayout>
-
-        <include
-            android:layout_marginTop="10dp"
-            android:id="@+id/account_accordion_section_loans"
-            layout="@layout/view_account_accordion_section"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-
-        <include
-            android:id="@+id/account_accordion_section_savings"
-            layout="@layout/view_account_accordion_section"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-
-        <include
-            android:id="@+id/account_accordion_section_recurring"
-            layout="@layout/view_account_accordion_section"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-
-    </LinearLayout>
-</ScrollView>
+    </ScrollView>
+</ViewFlipper>

--- a/mifosng-android/src/main/res/layout/fragment_group_list.xml
+++ b/mifosng-android/src/main/res/layout/fragment_group_list.xml
@@ -9,11 +9,22 @@
     android:layout_height="match_parent"
     tools:context=".online.GroupListFragment">
 
+    <ViewFlipper
+        android:id="@+id/view_flipper"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:inAnimation="@android:anim/fade_in"
+        android:outAnimation="@android:anim/fade_out">
 
-    <ListView
-        android:id="@+id/lv_group_list"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_weight="1" />
+        <ProgressBar
+            android:id="@+id/progress_bar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center" />
 
+        <ListView
+            android:id="@+id/lv_group_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </ViewFlipper>
 </LinearLayout>

--- a/mifosng-android/src/main/res/layout/fragment_loan_account_summary.xml
+++ b/mifosng-android/src/main/res/layout/fragment_loan_account_summary.xml
@@ -2,485 +2,499 @@
   ~ This project is licensed under the open source MPL V2.
   ~ See https://github.com/openMF/android-client/blob/master/LICENSE.md
   -->
-
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/view_flipper"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="@dimen/default_vertical_padding">
+    android:inAnimation="@android:anim/fade_in"
+    android:outAnimation="@android:anim/fade_out">
 
-    <RelativeLayout
+    <!-- Comment this out when editing the actual content -->
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
+
+    <!-- Actual content -->
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:padding="@dimen/default_vertical_padding">
 
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
-        <LinearLayout
-            android:id="@+id/linear_layout_1"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentTop="true"
-            android:orientation="horizontal"
-            android:paddingBottom="8dp">
-
-            <TextView
-                android:id="@+id/tv_clientName"
-                android:layout_width="0dp"
+            <LinearLayout
+                android:id="@+id/linear_layout_1"
+                android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_weight="0.8"
-                android:tag="large"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentTop="true"
+                android:orientation="horizontal"
+                android:paddingBottom="8dp">
 
-            <QuickContactBadge
-                android:id="@+id/quickContactBadge_client"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="right|end"
-                android:layout_marginLeft="100dp" />
+                <TextView
+                    android:id="@+id/tv_clientName"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:layout_weight="0.8"
+                    android:tag="large"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
 
-        </LinearLayout>
+                <QuickContactBadge
+                    android:id="@+id/quickContactBadge_client"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="right|end"
+                    android:layout_marginLeft="100dp" />
 
-        <View
-            android:id="@+id/divider_1"
-            android:layout_width="fill_parent"
-            android:layout_height="1dp"
-            android:layout_below="@+id/linear_layout_1"
-            android:background="@color/black" />
-
-        <LinearLayout
-            android:id="@+id/linear_layout_2"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_below="@+id/linear_layout_1"
-            android:layout_marginTop="8dp"
-            android:orientation="horizontal">
+            </LinearLayout>
 
             <View
-                android:id="@+id/view_status_indicator"
-                android:layout_width="16dp"
-                android:layout_height="16dp"
-                android:layout_gravity="center"
-                android:layout_marginRight="8dp"
-                android:background="@color/light_red" />
+                android:id="@+id/divider_1"
+                android:layout_width="fill_parent"
+                android:layout_height="1dp"
+                android:layout_below="@+id/linear_layout_1"
+                android:background="@color/black" />
+
+            <LinearLayout
+                android:id="@+id/linear_layout_2"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_below="@+id/linear_layout_1"
+                android:layout_marginTop="8dp"
+                android:orientation="horizontal">
+
+                <View
+                    android:id="@+id/view_status_indicator"
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    android:layout_gravity="center"
+                    android:layout_marginRight="8dp"
+                    android:background="@color/light_red" />
+
+                <TextView
+                    android:id="@+id/tv_loan_product_short_name"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0.6"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                <TextView
+                    android:id="@+id/tv_loanAccountNumber"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0.4"
+                    android:gravity="right"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+            </LinearLayout>
+
+            <View
+                android:id="@+id/divider_2"
+                android:layout_width="fill_parent"
+                android:layout_height="1dp"
+                android:layout_below="@+id/linear_layout_2"
+                android:layout_marginTop="4dp"
+                android:background="@color/black" />
+
 
             <TextView
-                android:id="@+id/tv_loan_product_short_name"
-                android:layout_width="0dp"
+                android:id="@+id/loan_amount_disbursed"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_weight="0.6"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_below="@id/divider_2"
+                android:layout_marginTop="8dp"
+                android:text="@string/loan_amount_disbursed"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
 
             <TextView
-                android:id="@+id/tv_loanAccountNumber"
-                android:layout_width="0dp"
+                android:id="@+id/tv_amount_disbursed"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_weight="0.4"
+                android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
+                android:layout_below="@+id/divider_2"
+                android:layout_marginTop="8dp"
                 android:gravity="right"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
 
-        </LinearLayout>
+            <TextView
+                android:id="@+id/loan_disbursement_date"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_below="@+id/loan_amount_disbursed"
+                android:layout_marginTop="8dp"
+                android:text="@string/loan_disbursement_date"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
 
-        <View
-            android:id="@+id/divider_2"
-            android:layout_width="fill_parent"
-            android:layout_height="1dp"
-            android:layout_below="@+id/linear_layout_2"
-            android:layout_marginTop="4dp"
-            android:background="@color/black" />
+            <TextView
+                android:id="@+id/tv_disbursement_date"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
+                android:layout_below="@+id/loan_amount_disbursed"
+                android:layout_marginTop="8dp"
+                android:gravity="right"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
 
+            <TextView
+                android:id="@+id/in_arrears"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_below="@+id/tv_disbursement_date"
+                android:layout_marginTop="8dp"
+                android:text="@string/loan_in_arrears"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
 
-        <TextView
-            android:id="@+id/loan_amount_disbursed"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_below="@id/divider_2"
-            android:layout_marginTop="8dp"
-            android:text="@string/loan_amount_disbursed"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
+            <TextView
+                android:id="@+id/tv_in_arrears"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
+                android:layout_below="@+id/tv_disbursement_date"
+                android:layout_marginTop="8dp"
+                android:gravity="right"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
 
-        <TextView
-            android:id="@+id/tv_amount_disbursed"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:layout_below="@+id/divider_2"
-            android:layout_marginTop="8dp"
-            android:gravity="right"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
+            <TextView
+                android:id="@+id/loan_officer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_below="@+id/tv_in_arrears"
+                android:layout_marginTop="8dp"
+                android:text="@string/staff"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
 
-        <TextView
-            android:id="@+id/loan_disbursement_date"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_below="@+id/loan_amount_disbursed"
-            android:layout_marginTop="8dp"
-            android:text="@string/loan_disbursement_date"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
+            <TextView
+                android:id="@+id/tv_loan_officer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
 
-        <TextView
-            android:id="@+id/tv_disbursement_date"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:layout_below="@+id/loan_amount_disbursed"
-            android:layout_marginTop="8dp"
-            android:gravity="right"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
-
-        <TextView
-            android:id="@+id/in_arrears"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_below="@+id/tv_disbursement_date"
-            android:layout_marginTop="8dp"
-            android:text="@string/loan_in_arrears"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
-
-        <TextView
-            android:id="@+id/tv_in_arrears"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:layout_below="@+id/tv_disbursement_date"
-            android:layout_marginTop="8dp"
-            android:gravity="right"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
-
-        <TextView
-            android:id="@+id/loan_officer"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_below="@+id/tv_in_arrears"
-            android:layout_marginTop="8dp"
-            android:text="@string/staff"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
-
-        <TextView
-            android:id="@+id/tv_loan_officer"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:layout_below="@+id/tv_in_arrears"
-            android:layout_marginTop="8dp"
-            android:gravity="right"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
+                android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
+                android:layout_below="@+id/tv_in_arrears"
+                android:layout_marginTop="8dp"
+                android:gravity="right"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
 
 
-        <TableLayout
-            android:id="@+id/tbl_loanSummary"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_below="@+id/loan_officer"
-            android:layout_marginTop="8dp">
-
-
-            <TableRow
+            <TableLayout
+                android:id="@+id/tbl_loanSummary"
                 android:layout_width="fill_parent"
                 android:layout_height="fill_parent"
-                android:background="#ffd1d1d1">
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_below="@+id/loan_officer"
+                android:layout_marginTop="8dp">
 
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="4">
 
-                    <TextView
-                        android:id="@+id/name"
-                        android:layout_width="0dp"
+                <TableRow
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent"
+                    android:background="#ffd1d1d1">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="@string/summary"
-                        android:textAppearance="?android:attr/textAppearanceMedium"
-                        android:textStyle="bold" />
+                        android:layout_weight="4">
 
-                    <TextView
-                        android:id="@+id/textView2"
-                        android:layout_width="0dp"
+                        <TextView
+                            android:id="@+id/name"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/summary"
+                            android:textAppearance="?android:attr/textAppearanceMedium"
+                            android:textStyle="bold" />
+
+                        <TextView
+                            android:id="@+id/textView2"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="right"
+                            android:text="@string/loan"
+                            android:textAppearance="?android:attr/textAppearanceMedium"
+                            android:textStyle="bold" />
+
+                        <TextView
+                            android:id="@+id/textView3"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="right"
+                            android:text="@string/amount_paid"
+                            android:textAppearance="?android:attr/textAppearanceMedium"
+                            android:textStyle="bold" />
+
+                        <TextView
+                            android:id="@+id/textView4"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="right"
+                            android:text="@string/balance"
+                            android:textAppearance="?android:attr/textAppearanceMedium"
+                            android:textStyle="bold" />
+                    </LinearLayout>
+                </TableRow>
+
+                <TableRow
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent"
+                    android:padding="4dp">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:gravity="right"
-                        android:text="@string/loan"
-                        android:textAppearance="?android:attr/textAppearanceMedium"
-                        android:textStyle="bold" />
+                        android:layout_weight="4">
 
-                    <TextView
-                        android:id="@+id/textView3"
-                        android:layout_width="0dp"
+                        <TextView
+                            android:id="@+id/textView5"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/loan_principal"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                        <TextView
+                            android:id="@+id/tv_principal"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="right"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                        <TextView
+                            android:id="@+id/tv_loan_principal_paid"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="right"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                        <TextView
+                            android:id="@+id/tv_loan_principal_due"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="right"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                    </LinearLayout>
+
+
+                </TableRow>
+
+                <TableRow
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent"
+                    android:background="#DEDEDE"
+                    android:padding="4dp">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:gravity="right"
-                        android:text="@string/amount_paid"
-                        android:textAppearance="?android:attr/textAppearanceMedium"
-                        android:textStyle="bold" />
+                        android:layout_weight="4">
 
-                    <TextView
-                        android:id="@+id/textView4"
-                        android:layout_width="0dp"
+                        <TextView
+                            android:id="@+id/textView6"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/loan_interest"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                        <TextView
+                            android:id="@+id/tv_interest"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="right"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                        <TextView
+                            android:id="@+id/tv_loan_interest_paid"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="right"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                        <TextView
+                            android:id="@+id/tv_loan_interest_due"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="right"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
+                    </LinearLayout>
+                </TableRow>
+
+                <TableRow
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent"
+                    android:padding="4dp">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:gravity="right"
-                        android:text="@string/balance"
-                        android:textAppearance="?android:attr/textAppearanceMedium"
-                        android:textStyle="bold" />
-                </LinearLayout>
-            </TableRow>
+                        android:layout_weight="4">
 
-            <TableRow
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
-                android:padding="4dp">
+                        <TextView
+                            android:id="@+id/textView7"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/loan_fees"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
 
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="4">
+                        <TextView
+                            android:id="@+id/tv_fees"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="right"
 
-                    <TextView
-                        android:id="@+id/textView5"
-                        android:layout_width="0dp"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                        <TextView
+                            android:id="@+id/tv_loan_fees_paid"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="right"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                        <TextView
+                            android:id="@+id/tv_loan_fees_due"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="right"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
+                    </LinearLayout>
+                </TableRow>
+
+                <TableRow
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent"
+                    android:background="#DEDEDE"
+                    android:padding="4dp">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="@string/loan_principal"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
+                        android:layout_weight="4">
 
-                    <TextView
-                        android:id="@+id/tv_principal"
-                        android:layout_width="0dp"
+                        <TextView
+                            android:id="@+id/textView8"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/loan_penalty"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                        <TextView
+                            android:id="@+id/tv_penalty"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="right"
+
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                        <TextView
+                            android:id="@+id/tv_loan_penalty_paid"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="right"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                        <TextView
+                            android:id="@+id/tv_loan_penalty_due"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="right"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
+                    </LinearLayout>
+                </TableRow>
+
+                <TableRow
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent"
+                    android:padding="4dp">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:gravity="right"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
+                        android:layout_weight="4">
 
-                    <TextView
-                        android:id="@+id/tv_loan_principal_paid"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:gravity="right"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
+                        <TextView
+                            android:id="@+id/textView9"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/total"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
 
-                    <TextView
-                        android:id="@+id/tv_loan_principal_due"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:gravity="right"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
+                        <TextView
+                            android:id="@+id/tv_total"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="right"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
 
-                </LinearLayout>
+                        <TextView
+                            android:id="@+id/tv_total_paid"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="right"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
 
+                        <TextView
+                            android:id="@+id/tv_total_due"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="right"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
+                    </LinearLayout>
+                </TableRow>
 
-            </TableRow>
+            </TableLayout>
 
-            <TableRow
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
-                android:background="#DEDEDE"
-                android:padding="4dp">
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="4">
-
-                    <TextView
-                        android:id="@+id/textView6"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="@string/loan_interest"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-
-                    <TextView
-                        android:id="@+id/tv_interest"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:gravity="right"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-
-                    <TextView
-                        android:id="@+id/tv_loan_interest_paid"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:gravity="right"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-
-                    <TextView
-                        android:id="@+id/tv_loan_interest_due"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:gravity="right"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-                </LinearLayout>
-            </TableRow>
-
-            <TableRow
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
-                android:padding="4dp">
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="4">
-
-                    <TextView
-                        android:id="@+id/textView7"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="@string/loan_fees"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-
-                    <TextView
-                        android:id="@+id/tv_fees"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:gravity="right"
-
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-
-                    <TextView
-                        android:id="@+id/tv_loan_fees_paid"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:gravity="right"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-
-                    <TextView
-                        android:id="@+id/tv_loan_fees_due"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:gravity="right"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-                </LinearLayout>
-            </TableRow>
-
-            <TableRow
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
-                android:background="#DEDEDE"
-                android:padding="4dp">
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="4">
-
-                    <TextView
-                        android:id="@+id/textView8"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="@string/loan_penalty"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-
-                    <TextView
-                        android:id="@+id/tv_penalty"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:gravity="right"
-
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-
-                    <TextView
-                        android:id="@+id/tv_loan_penalty_paid"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:gravity="right"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-
-                    <TextView
-                        android:id="@+id/tv_loan_penalty_due"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:gravity="right"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-                </LinearLayout>
-            </TableRow>
-
-            <TableRow
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
-                android:padding="4dp">
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="4">
-
-                    <TextView
-                        android:id="@+id/textView9"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="@string/total"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-
-                    <TextView
-                        android:id="@+id/tv_total"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:gravity="right"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-
-                    <TextView
-                        android:id="@+id/tv_total_paid"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:gravity="right"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-
-                    <TextView
-                        android:id="@+id/tv_total_due"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:gravity="right"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-                </LinearLayout>
-            </TableRow>
-
-        </TableLayout>
-
-        <Button
-            android:id="@+id/bt_processLoanTransaction"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/tbl_loanSummary"
-            android:layout_marginBottom="8dp"
-            android:layout_marginTop="8dp"
-            android:text="@string/process_loan_transaction" />
+            <Button
+                android:id="@+id/bt_processLoanTransaction"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/tbl_loanSummary"
+                android:layout_marginBottom="8dp"
+                android:layout_marginTop="8dp"
+                android:text="@string/process_loan_transaction" />
 
 
-    </RelativeLayout>
-</ScrollView>
+        </RelativeLayout>
+    </ScrollView>
+</ViewFlipper>

--- a/mifosng-android/src/main/res/layout/fragment_loan_repayment.xml
+++ b/mifosng-android/src/main/res/layout/fragment_loan_repayment.xml
@@ -1,307 +1,321 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ This project is licensed under the open source MPL V2.
   ~ See https://github.com/openMF/android-client/blob/master/LICENSE.md
   -->
-
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/view_flipper"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:inAnimation="@android:anim/fade_in"
+    android:outAnimation="@android:anim/fade_out">
 
-    <RelativeLayout
+    <!-- Comment this out when editing the actual content -->
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
+
+    <!-- Actual content -->
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_margin="@dimen/activity_horizontal_margin">
+        android:layout_height="match_parent">
 
-        <LinearLayout
-            android:id="@+id/linear_layout_1"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentTop="true"
-            android:orientation="horizontal"
-            android:padding="4dp"
-            android:paddingBottom="8dp">
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_margin="@dimen/activity_horizontal_margin">
 
-            <TextView
-                android:id="@+id/tv_clientName"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_weight="0.8"
-                android:text="@string/client_name"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
-
-            <QuickContactBadge
-                android:id="@+id/quickContactBadge_client"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="right|end"
-                android:layout_marginLeft="100dp" />
-
-        </LinearLayout>
-
-        <View
-            android:id="@+id/divider_1"
-            android:layout_width="fill_parent"
-            android:layout_height="1dp"
-            android:layout_below="@+id/linear_layout_1"
-            android:background="@color/black" />
-
-        <LinearLayout
-            android:id="@+id/linear_layout_2"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_below="@+id/linear_layout_1"
-            android:layout_marginTop="8dp"
-            android:orientation="horizontal"
-            android:padding="4dp">
-
-
-            <TextView
-                android:id="@+id/tv_loan_product_short_name"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0.6"
-                android:text="@string/product_name"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
-
-            <TextView
-                android:id="@+id/tv_loanAccountNumber"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0.4"
-                android:gravity="right"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
-
-        </LinearLayout>
-
-
-        <TextView
-            android:id="@+id/in_arrears"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_below="@+id/linear_layout_2"
-            android:layout_marginTop="8dp"
-            android:padding="4dp"
-            android:text="@string/loan_in_arrears"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
-
-        <TextView
-            android:id="@+id/tv_in_arrears"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:layout_below="@+id/linear_layout_2"
-            android:layout_marginTop="8dp"
-            android:gravity="right"
-            android:padding="4dp"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
-
-        <TextView
-            android:id="@+id/amount_due"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_below="@+id/in_arrears"
-            android:layout_marginTop="8dp"
-            android:padding="4dp"
-            android:text="@string/loan_amount_due"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
-
-        <TextView
-            android:id="@+id/tv_amount_due"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:layout_below="@+id/tv_in_arrears"
-            android:layout_marginTop="8dp"
-            android:gravity="right"
-            android:padding="4dp"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
-
-
-        <View
-            android:id="@+id/divider_2"
-            android:layout_width="fill_parent"
-            android:layout_height="1dp"
-            android:layout_below="@+id/amount_due"
-            android:background="@color/black" />
-
-        <TableLayout
-            android:id="@+id/tb_repaymentForm"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:layout_below="@+id/divider_2"
-            android:layout_centerHorizontal="true"
-            android:layout_marginTop="8dp">
-
-
-            <TableRow
-                android:id="@+id/tableRow1"
+            <LinearLayout
+                android:id="@+id/linear_layout_1"
                 android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
-                android:padding="4dp">
-
-
-                <TextView
-                    android:id="@+id/name"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="@string/loan_repayment_date"
-                    android:textAppearance="?android:attr/textAppearanceMedium" />
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentTop="true"
+                android:orientation="horizontal"
+                android:padding="4dp"
+                android:paddingBottom="8dp">
 
                 <TextView
-                    android:id="@+id/tv_repayment_date"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:ems="10" />
-            </TableRow>
-
-            <TableRow
-                android:id="@+id/tableRow2"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
-                android:padding="4dp">
-
-                <TextView
-                    android:id="@+id/textView2"
+                    android:id="@+id/tv_clientName"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_vertical"
-                    android:layout_weight="1"
-                    android:text="@string/payment_type"
+                    android:layout_weight="0.8"
+                    android:text="@string/client_name"
                     android:textAppearance="?android:attr/textAppearanceMedium" />
 
-                <Spinner
-                    android:id="@+id/sp_payment_type"
-                    android:layout_width="0dp"
+                <QuickContactBadge
+                    android:id="@+id/quickContactBadge_client"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1" />
-            </TableRow>
+                    android:layout_gravity="right|end"
+                    android:layout_marginLeft="100dp" />
 
-            <TableRow
-                android:id="@+id/tableRow3"
+            </LinearLayout>
+
+            <View
+                android:id="@+id/divider_1"
                 android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
+                android:layout_height="1dp"
+                android:layout_below="@+id/linear_layout_1"
+                android:background="@color/black" />
+
+            <LinearLayout
+                android:id="@+id/linear_layout_2"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_below="@+id/linear_layout_1"
+                android:layout_marginTop="8dp"
+                android:orientation="horizontal"
                 android:padding="4dp">
 
+
                 <TextView
-                    android:id="@+id/textView3"
+                    android:id="@+id/tv_loan_product_short_name"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="@string/amount"
+                    android:layout_weight="0.6"
+                    android:text="@string/product_name"
                     android:textAppearance="?android:attr/textAppearanceMedium" />
 
-                <EditText
-                    android:id="@+id/et_amount"
+                <TextView
+                    android:id="@+id/tv_loanAccountNumber"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:ems="10"
-                    android:inputType="numberDecimal" />
-            </TableRow>
+                    android:layout_weight="0.4"
+                    android:gravity="right"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
 
-            <TableRow
-                android:id="@+id/tableRow4"
+            </LinearLayout>
+
+
+            <TextView
+                android:id="@+id/in_arrears"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_below="@+id/linear_layout_2"
+                android:layout_marginTop="8dp"
+                android:padding="4dp"
+                android:text="@string/loan_in_arrears"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
+
+            <TextView
+                android:id="@+id/tv_in_arrears"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
+                android:layout_below="@+id/linear_layout_2"
+                android:layout_marginTop="8dp"
+                android:gravity="right"
+                android:padding="4dp"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
+
+            <TextView
+                android:id="@+id/amount_due"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_below="@+id/in_arrears"
+                android:layout_marginTop="8dp"
+                android:padding="4dp"
+                android:text="@string/loan_amount_due"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
+
+            <TextView
+                android:id="@+id/tv_amount_due"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
+                android:layout_below="@+id/tv_in_arrears"
+                android:layout_marginTop="8dp"
+                android:gravity="right"
+                android:padding="4dp"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
+
+
+            <View
+                android:id="@+id/divider_2"
+                android:layout_width="fill_parent"
+                android:layout_height="1dp"
+                android:layout_below="@+id/amount_due"
+                android:background="@color/black" />
+
+            <TableLayout
+                android:id="@+id/tb_repaymentForm"
                 android:layout_width="fill_parent"
                 android:layout_height="fill_parent"
-                android:padding="4dp">
+                android:layout_below="@+id/divider_2"
+                android:layout_centerHorizontal="true"
+                android:layout_marginTop="8dp">
 
-                <TextView
-                    android:id="@+id/textView4"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="@string/additional_payment"
-                    android:textAppearance="?android:attr/textAppearanceMedium" />
 
-                <EditText
-                    android:id="@+id/et_additional_payment"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:ems="10"
-                    android:inputType="numberDecimal" />
-            </TableRow>
+                <TableRow
+                    android:id="@+id/tableRow1"
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent"
+                    android:padding="4dp">
 
-            <TableRow
-                android:id="@+id/tableRow5"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
-                android:padding="4dp">
 
-                <TextView
-                    android:id="@+id/textView5"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="@string/loan_fees"
-                    android:textAppearance="?android:attr/textAppearanceMedium" />
+                    <TextView
+                        android:id="@+id/name"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/loan_repayment_date"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
 
-                <EditText
-                    android:id="@+id/et_fees"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:ems="10"
-                    android:inputType="numberDecimal" />
+                    <TextView
+                        android:id="@+id/tv_repayment_date"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:ems="10" />
+                </TableRow>
 
-            </TableRow>
+                <TableRow
+                    android:id="@+id/tableRow2"
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent"
+                    android:padding="4dp">
 
-            <TableRow
-                android:id="@+id/tableRow6"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
-                android:padding="4dp">
+                    <TextView
+                        android:id="@+id/textView2"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:layout_weight="1"
+                        android:text="@string/payment_type"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
 
-                <TextView
-                    android:id="@+id/textView6"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="@string/total"
-                    android:textAppearance="?android:attr/textAppearanceMedium" />
+                    <Spinner
+                        android:id="@+id/sp_payment_type"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1" />
+                </TableRow>
 
-                <TextView
-                    android:id="@+id/tv_total"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:textAppearance="?android:attr/textAppearanceMedium" />
+                <TableRow
+                    android:id="@+id/tableRow3"
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent"
+                    android:padding="4dp">
 
-            </TableRow>
+                    <TextView
+                        android:id="@+id/textView3"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/amount"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
 
-        </TableLayout>
+                    <EditText
+                        android:id="@+id/et_amount"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:ems="10"
+                        android:inputType="numberDecimal" />
+                </TableRow>
 
-        <Button
-            android:id="@+id/bt_cancelPayment"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentStart="true"
-            android:layout_below="@+id/tb_repaymentForm"
-            android:layout_margin="8dp"
-            android:text="@string/cancel" />
+                <TableRow
+                    android:id="@+id/tableRow4"
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent"
+                    android:padding="4dp">
 
-        <Button
-            android:id="@+id/bt_paynow"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
-            android:layout_below="@+id/tb_repaymentForm"
-            android:layout_margin="8dp"
-            android:text="@string/review_payment" />
+                    <TextView
+                        android:id="@+id/textView4"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/additional_payment"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
 
-    </RelativeLayout>
-</ScrollView>
+                    <EditText
+                        android:id="@+id/et_additional_payment"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:ems="10"
+                        android:inputType="numberDecimal" />
+                </TableRow>
+
+                <TableRow
+                    android:id="@+id/tableRow5"
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent"
+                    android:padding="4dp">
+
+                    <TextView
+                        android:id="@+id/textView5"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/loan_fees"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                    <EditText
+                        android:id="@+id/et_fees"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:ems="10"
+                        android:inputType="numberDecimal" />
+
+                </TableRow>
+
+                <TableRow
+                    android:id="@+id/tableRow6"
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent"
+                    android:padding="4dp">
+
+                    <TextView
+                        android:id="@+id/textView6"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/total"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                    <TextView
+                        android:id="@+id/tv_total"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                </TableRow>
+
+            </TableLayout>
+
+            <Button
+                android:id="@+id/bt_cancelPayment"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentStart="true"
+                android:layout_below="@+id/tb_repaymentForm"
+                android:layout_margin="8dp"
+                android:text="@string/cancel" />
+
+            <Button
+                android:id="@+id/bt_paynow"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentEnd="true"
+                android:layout_below="@+id/tb_repaymentForm"
+                android:layout_margin="8dp"
+                android:text="@string/review_payment" />
+
+        </RelativeLayout>
+    </ScrollView>
+</ViewFlipper>

--- a/mifosng-android/src/main/res/layout/fragment_loan_repayment_schedule.xml
+++ b/mifosng-android/src/main/res/layout/fragment_loan_repayment_schedule.xml
@@ -2,83 +2,97 @@
   ~ This project is licensed under the open source MPL V2.
   ~ See https://github.com/openMF/android-client/blob/master/LICENSE.md
   -->
-
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/view_flipper"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:inAnimation="@android:anim/fade_in"
+    android:outAnimation="@android:anim/fade_out"
     tools:context=".online.LoanRepaymentScheduleFragment">
 
-    <TableLayout
-        android:id="@+id/tbl_header"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal">
-
-        <TableRow
-            android:id="@+id/tableRow3"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:background="@color/transaction_detail_table_header_bg">
-
-            <LinearLayout android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:weightSum="3.50">
-
-            </LinearLayout>
-
-            <TextView
-                android:id="@+id/tv_title_principal"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0.50"
-                android:text="@string/loan_status"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
-
-
-            <TextView
-                android:id="@+id/tv_title_interest"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="center_horizontal"
-                android:text="@string/date"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
-
-            <TextView
-                android:id="@+id/tv_title_fees"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="center_horizontal"
-                android:text="@string/loan_amount_due"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
-
-            <TextView
-                android:id="@+id/tv_title_penalties"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="right"
-                android:text="@string/amount_paid"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
-
-        </TableRow>
-    </TableLayout>
-
-    <ListView
-        android:id="@+id/lv_repayment_schedule"
+    <!-- Comment this out when editing the actual content -->
+    <ProgressBar
+        android:id="@+id/progress_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@id/tbl_header"
-        android:layout_centerHorizontal="true" />
+        android:layout_gravity="center" />
 
-    <include
-        android:id="@+id/flrs_footer"
-        layout="@layout/fragment_loan_repayment_schedule_footer"
+    <!-- Actual content -->
+    <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true" />
+        android:layout_height="match_parent">
+
+        <TableLayout
+            android:id="@+id/tbl_header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal">
+
+            <TableRow
+                android:id="@+id/tableRow3"
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent"
+                android:background="@color/transaction_detail_table_header_bg">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:weightSum="3.50">
+
+                </LinearLayout>
+
+                <TextView
+                    android:id="@+id/tv_title_principal"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0.50"
+                    android:text="@string/loan_status"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
 
 
-</RelativeLayout>
+                <TextView
+                    android:id="@+id/tv_title_interest"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center_horizontal"
+                    android:text="@string/date"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                <TextView
+                    android:id="@+id/tv_title_fees"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center_horizontal"
+                    android:text="@string/loan_amount_due"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                <TextView
+                    android:id="@+id/tv_title_penalties"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="right"
+                    android:text="@string/amount_paid"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+            </TableRow>
+        </TableLayout>
+
+        <ListView
+            android:id="@+id/lv_repayment_schedule"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/tbl_header"
+            android:layout_centerHorizontal="true" />
+
+        <include
+            android:id="@+id/flrs_footer"
+            layout="@layout/fragment_loan_repayment_schedule_footer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true" />
+    </RelativeLayout>
+</ViewFlipper>

--- a/mifosng-android/src/main/res/layout/fragment_savings_account_summary.xml
+++ b/mifosng-android/src/main/res/layout/fragment_savings_account_summary.xml
@@ -3,223 +3,234 @@
   ~ See https://github.com/openMF/android-client/blob/master/LICENSE.md
   -->
 
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/view_flipper"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:inAnimation="@android:anim/fade_in"
+    android:outAnimation="@android:anim/fade_out">
 
-    <LinearLayout
-        android:id="@+id/linear_layout_1"
-        android:layout_width="fill_parent"
+    <!-- Comment this out when editing the actual content -->
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentTop="true"
-        android:orientation="horizontal"
-        android:paddingBottom="8dp">
+        android:layout_gravity="center" />
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:id="@+id/linear_layout_1"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentTop="true"
+            android:orientation="horizontal"
+            android:paddingBottom="8dp">
+
+            <TextView
+                android:id="@+id/tv_clientName"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_weight="0.8"
+                android:text="@string/client_name"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
+
+            <QuickContactBadge
+                android:id="@+id/quickContactBadge_client"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="right|end"
+                android:layout_marginLeft="100dp" />
+
+        </LinearLayout>
+
+        <View
+            android:id="@+id/divider_1"
+            android:layout_width="fill_parent"
+            android:layout_height="1dp"
+            android:layout_below="@+id/linear_layout_1"
+            android:background="@color/primary" />
+
+        <LinearLayout
+            android:id="@+id/linear_layout_2"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:layout_below="@+id/linear_layout_1"
+            android:layout_marginTop="8dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/tv_savings_product_short_name"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.6"
+                android:text="@string/product_name"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
+
+            <TextView
+                android:id="@+id/tv_savingsAccountNumber"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.4"
+                android:gravity="right"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
+
+        </LinearLayout>
+
+
+        <View
+            android:id="@+id/divider_2"
+            android:layout_width="fill_parent"
+            android:layout_height="1dp"
+            android:layout_below="@+id/linear_layout_2"
+            android:layout_marginTop="4dp"
+            android:background="@color/primary" />
+
 
         <TextView
-            android:id="@+id/tv_clientName"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:layout_weight="0.8"
-            android:text="@string/client_name"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
-
-        <QuickContactBadge
-            android:id="@+id/quickContactBadge_client"
+            android:id="@+id/savings_account_balance"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="right|end"
-            android:layout_marginLeft="100dp" />
-
-    </LinearLayout>
-
-    <View
-        android:id="@+id/divider_1"
-        android:layout_width="fill_parent"
-        android:layout_height="1dp"
-        android:layout_below="@+id/linear_layout_1"
-        android:background="@color/primary" />
-
-    <LinearLayout
-        android:id="@+id/linear_layout_2"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_below="@+id/linear_layout_1"
-        android:layout_marginTop="8dp"
-        android:orientation="horizontal">
-
-        <TextView
-            android:id="@+id/tv_savings_product_short_name"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="0.6"
-            android:text="@string/product_name"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:layout_alignTop="@+id/tv_savings_account_balance"
+            android:layout_below="@+id/divider_2"
+            android:text="@string/savings_account_balance"
             android:textAppearance="?android:attr/textAppearanceMedium" />
 
         <TextView
-            android:id="@+id/tv_savingsAccountNumber"
-            android:layout_width="0dp"
+            android:id="@+id/tv_savings_account_balance"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_weight="0.4"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentRight="true"
+            android:layout_below="@+id/divider_2"
+            android:layout_marginTop="8dp"
             android:gravity="right"
             android:textAppearance="?android:attr/textAppearanceMedium" />
 
-    </LinearLayout>
+        <TextView
+            android:id="@+id/total_deposits"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:layout_below="@+id/tv_savings_account_balance"
+            android:layout_marginTop="8dp"
+            android:text="@string/savings_total_deposits"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
 
+        <TextView
+            android:id="@+id/tv_total_deposits"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentRight="true"
+            android:layout_below="@+id/tv_savings_account_balance"
+            android:layout_marginTop="8dp"
+            android:gravity="right"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
 
-    <View
-        android:id="@+id/divider_2"
-        android:layout_width="fill_parent"
-        android:layout_height="1dp"
-        android:layout_below="@+id/linear_layout_2"
-        android:layout_marginTop="4dp"
-        android:background="@color/primary" />
+        <TextView
+            android:id="@+id/total_withdrawals"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:layout_below="@+id/tv_total_deposits"
+            android:layout_marginTop="8dp"
+            android:text="@string/savings_total_withdrawals"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
 
+        <TextView
+            android:id="@+id/tv_total_withdrawals"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentRight="true"
+            android:layout_below="@+id/tv_total_deposits"
+            android:layout_marginTop="8dp"
+            android:gravity="right"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
 
-    <TextView
-        android:id="@+id/savings_account_balance"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_alignTop="@+id/tv_savings_account_balance"
-        android:layout_below="@+id/divider_2"
-        android:text="@string/savings_account_balance"
-        android:textAppearance="?android:attr/textAppearanceMedium" />
+        <TextView
+            android:id="@+id/interest_earned"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:layout_below="@+id/tv_total_withdrawals"
+            android:layout_marginTop="8dp"
+            android:text="@string/savings_interest_earned"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
 
-    <TextView
-        android:id="@+id/tv_savings_account_balance"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentRight="true"
-        android:layout_below="@+id/divider_2"
-        android:layout_marginTop="8dp"
-        android:gravity="right"
-        android:textAppearance="?android:attr/textAppearanceMedium" />
+        <TextView
+            android:id="@+id/tv_interest_earned"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentRight="true"
+            android:layout_below="@+id/tv_total_withdrawals"
+            android:layout_marginTop="8dp"
+            android:gravity="right"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
 
-    <TextView
-        android:id="@+id/total_deposits"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_below="@+id/tv_savings_account_balance"
-        android:layout_marginTop="8dp"
-        android:text="@string/savings_total_deposits"
-        android:textAppearance="?android:attr/textAppearanceMedium" />
+        <View
+            android:id="@+id/divider_3"
+            android:layout_width="fill_parent"
+            android:layout_height="1dp"
+            android:layout_below="@+id/tv_interest_earned"
+            android:layout_marginTop="4dp"
+            android:background="@color/primary" />
 
-    <TextView
-        android:id="@+id/tv_total_deposits"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentRight="true"
-        android:layout_below="@+id/tv_savings_account_balance"
-        android:layout_marginTop="8dp"
-        android:gravity="right"
-        android:textAppearance="?android:attr/textAppearanceMedium" />
+        <TextView
+            android:id="@+id/savings_transactions"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/divider_3"
+            android:layout_marginTop="4dp"
+            android:text="@string/transactions"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
 
-    <TextView
-        android:id="@+id/total_withdrawals"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_below="@+id/tv_total_deposits"
-        android:layout_marginTop="8dp"
-        android:text="@string/savings_total_withdrawals"
-        android:textAppearance="?android:attr/textAppearanceMedium" />
+        <ListView
+            android:id="@+id/lv_savings_transactions"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_above="@+id/buttons"
+            android:layout_below="@id/savings_transactions" />
 
-    <TextView
-        android:id="@+id/tv_total_withdrawals"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentRight="true"
-        android:layout_below="@+id/tv_total_deposits"
-        android:layout_marginTop="8dp"
-        android:gravity="right"
-        android:textAppearance="?android:attr/textAppearanceMedium" />
+        <LinearLayout
+            android:id="@+id/buttons"
+            style="@style/LinearLayout.Width"
+            android:layout_alignParentBottom="true"
+            android:layout_marginBottom="8dp"
+            android:layout_marginTop="8dp">
 
-    <TextView
-        android:id="@+id/interest_earned"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_below="@+id/tv_total_withdrawals"
-        android:layout_marginTop="8dp"
-        android:text="@string/savings_interest_earned"
-        android:textAppearance="?android:attr/textAppearanceMedium" />
+            <Button
+                android:id="@+id/bt_withdrawal"
+                style="@style/Button.Base.Weight"
+                android:layout_weight="1"
+                android:text="@string/savings_make_withdrawal" />
 
-    <TextView
-        android:id="@+id/tv_interest_earned"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentRight="true"
-        android:layout_below="@+id/tv_total_withdrawals"
-        android:layout_marginTop="8dp"
-        android:gravity="right"
-        android:textAppearance="?android:attr/textAppearanceMedium" />
+            <Button
+                android:id="@+id/bt_deposit"
+                style="@style/Button.Base.Weight"
+                android:layout_weight="0.84"
+                android:text="@string/savings_make_deposit" />
 
-    <View
-        android:id="@+id/divider_3"
-        android:layout_width="fill_parent"
-        android:layout_height="1dp"
-        android:layout_below="@+id/tv_interest_earned"
-        android:layout_marginTop="4dp"
-        android:background="@color/primary" />
+            <Button
+                android:id="@+id/bt_approve_saving"
+                style="@style/Button.Base.Weight"
+                android:layout_weight="1"
+                android:text="@string/approve_savings" />
 
-    <TextView
-        android:id="@+id/savings_transactions"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/divider_3"
-        android:layout_marginTop="4dp"
-        android:text="@string/transactions"
-        android:textAppearance="?android:attr/textAppearanceMedium" />
-
-    <ListView
-        android:id="@+id/lv_savings_transactions"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_above="@+id/buttons"
-        android:layout_below="@id/savings_transactions" />
-
-    <LinearLayout
-        android:id="@+id/buttons"
-        style="@style/LinearLayout.Width"
-        android:layout_alignParentBottom="true"
-        android:layout_marginBottom="8dp"
-        android:layout_marginTop="8dp">
-
-        <Button
-            android:id="@+id/bt_withdrawal"
-            style="@style/Button.Base.Weight"
-            android:layout_weight="1"
-            android:text="@string/savings_make_withdrawal" />
-
-        <Button
-            android:id="@+id/bt_deposit"
-            style="@style/Button.Base.Weight"
-            android:layout_weight="0.84"
-            android:text="@string/savings_make_deposit"
-            />
-
-        <Button
-            android:id="@+id/bt_approve_saving"
-            style="@style/Button.Base.Weight"
-            android:layout_weight="1"
-            android:text="@string/approve_savings"
-           />
-
-    </LinearLayout>
-
-
-</RelativeLayout>
+        </LinearLayout>
+    </RelativeLayout>
+</ViewFlipper>

--- a/mifosng-android/src/main/res/layout/fragment_savings_account_transaction.xml
+++ b/mifosng-android/src/main/res/layout/fragment_savings_account_transaction.xml
@@ -2,178 +2,193 @@
   ~ This project is licensed under the open source MPL V2.
   ~ See https://github.com/openMF/android-client/blob/master/LICENSE.md
   -->
-
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/view_flipper"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_margin="16dp"
+    android:inAnimation="@android:anim/fade_in"
+    android:outAnimation="@android:anim/fade_out"
     tools:context="com.mifos.mifosxdroid.online.SavingsAccountTransactionFragment">
 
-    <LinearLayout
-        android:id="@+id/linear_layout_1"
-        android:layout_width="fill_parent"
+    <!-- Comment this out when editing the actual content -->
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentTop="true"
-        android:orientation="horizontal"
-        android:paddingBottom="8dp">
+        android:layout_gravity="center" />
 
-        <TextView
-            android:id="@+id/tv_clientName"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:layout_weight="0.8"
-            android:text="@string/client_name"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
-
-        <QuickContactBadge
-            android:id="@+id/quickContactBadge_client"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="right|end"
-            android:layout_marginLeft="100dp" />
-
-    </LinearLayout>
-
-    <View
-        android:id="@+id/divider_1"
-        android:layout_width="fill_parent"
-        android:layout_height="1dp"
-        android:layout_below="@+id/linear_layout_1"
-        android:background="@color/black" />
-
-    <TableLayout
-        android:id="@+id/tbl_transaction_details"
+    <!-- Actual content -->
+    <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/divider_1"
-        android:layout_marginTop="4dp">
+        android:layout_height="match_parent"
+        android:layout_margin="16dp">
 
-        <TableRow
-            android:id="@+id/tbl_transaction_details_row_1"
+        <LinearLayout
+            android:id="@+id/linear_layout_1"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentTop="true"
+            android:orientation="horizontal"
+            android:paddingBottom="8dp">
+
+            <TextView
+                android:id="@+id/tv_clientName"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_weight="0.8"
+                android:text="@string/client_name"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
+
+            <QuickContactBadge
+                android:id="@+id/quickContactBadge_client"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="right|end"
+                android:layout_marginLeft="100dp" />
+
+        </LinearLayout>
+
+        <View
+            android:id="@+id/divider_1"
+            android:layout_width="fill_parent"
+            android:layout_height="1dp"
+            android:layout_below="@+id/linear_layout_1"
+            android:background="@color/black" />
+
+        <TableLayout
+            android:id="@+id/tbl_transaction_details"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/divider_1"
+            android:layout_marginTop="4dp">
+
+            <TableRow
+                android:id="@+id/tbl_transaction_details_row_1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingBottom="4dp"
+                android:paddingTop="4dp">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:layout_weight="0.6"
+                    android:text="@string/account_number"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                <TextView
+                    android:id="@+id/tv_savingsAccountNumber"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:layout_weight="0.4"
+                    android:gravity="left"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+            </TableRow>
+
+            <TableRow
+                android:id="@+id/tbl_transaction_details_row_2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingBottom="4dp"
+                android:paddingTop="4dp">
+
+                <TextView
+                    android:id="@+id/transaction_date"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:layout_weight="0.6"
+                    android:text="@string/date"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                <TextView
+                    android:id="@+id/tv_transaction_date"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="right|center_vertical"
+                    android:layout_weight="0.4"
+                    android:gravity="left" />
+
+            </TableRow>
+
+            <TableRow
+                android:id="@+id/tbl_transaction_details_row_3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingBottom="4dp"
+                android:paddingTop="4dp">
+
+                <TextView
+                    android:id="@+id/tv_transaction_amount"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:layout_weight="0.6"
+                    android:text="@string/amount"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                <EditText
+                    android:id="@+id/et_transaction_amount"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:layout_weight="0.4"
+                    android:gravity="left"
+                    android:inputType="numberDecimal" />
+
+            </TableRow>
+
+            <TableRow
+                android:id="@+id/tbl_transaction_details_row_4"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingBottom="4dp"
+                android:paddingTop="4dp">
+
+                <TextView
+                    android:id="@+id/tv_payment_type"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:layout_weight="0.6"
+                    android:text="@string/payment_type"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                <Spinner
+                    android:id="@+id/sp_payment_type"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0.4"
+                    android:gravity="left" />
+
+            </TableRow>
+
+        </TableLayout>
+
+        <Button
+            android:id="@+id/bt_cancelTransaction"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:paddingBottom="4dp"
-            android:paddingTop="4dp">
+            android:layout_alignParentStart="true"
+            android:layout_below="@+id/tbl_transaction_details"
+            android:layout_marginTop="8dp"
+            android:text="@string/cancel" />
 
-            <TextView
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_weight="0.6"
-                android:text="@string/account_number"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
-
-            <TextView
-                android:id="@+id/tv_savingsAccountNumber"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_weight="0.4"
-                android:gravity="left"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
-
-        </TableRow>
-
-        <TableRow
-            android:id="@+id/tbl_transaction_details_row_2"
+        <Button
+            android:id="@+id/bt_reviewTransaction"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:paddingBottom="4dp"
-            android:paddingTop="4dp">
+            android:layout_alignParentEnd="true"
+            android:layout_below="@+id/tbl_transaction_details"
+            android:layout_marginTop="8dp"
+            android:text="@string/review_transaction" />
 
-            <TextView
-                android:id="@+id/transaction_date"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_weight="0.6"
-                android:text="@string/date"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
-
-            <TextView
-                android:id="@+id/tv_transaction_date"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="right|center_vertical"
-                android:layout_weight="0.4"
-                android:gravity="left" />
-
-        </TableRow>
-
-        <TableRow
-            android:id="@+id/tbl_transaction_details_row_3"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingBottom="4dp"
-            android:paddingTop="4dp">
-
-            <TextView
-                android:id="@+id/tv_transaction_amount"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_weight="0.6"
-                android:text="@string/amount"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
-
-            <EditText
-                android:id="@+id/et_transaction_amount"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_weight="0.4"
-                android:gravity="left"
-                android:inputType="numberDecimal" />
-
-        </TableRow>
-
-        <TableRow
-            android:id="@+id/tbl_transaction_details_row_4"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingBottom="4dp"
-            android:paddingTop="4dp">
-
-            <TextView
-                android:id="@+id/tv_payment_type"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_weight="0.6"
-                android:text="@string/payment_type"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
-
-            <Spinner
-                android:id="@+id/sp_payment_type"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0.4"
-                android:gravity="left" />
-
-        </TableRow>
-
-    </TableLayout>
-
-    <Button
-        android:id="@+id/bt_cancelTransaction"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentStart="true"
-        android:layout_below="@+id/tbl_transaction_details"
-        android:layout_marginTop="8dp"
-        android:text="@string/cancel" />
-
-    <Button
-        android:id="@+id/bt_reviewTransaction"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
-        android:layout_below="@+id/tbl_transaction_details"
-        android:layout_marginTop="8dp"
-        android:text="@string/review_transaction" />
-
-</RelativeLayout>
+    </RelativeLayout>
+</ViewFlipper>

--- a/mifosng-android/src/main/res/layout/fragment_survey_list.xml
+++ b/mifosng-android/src/main/res/layout/fragment_survey_list.xml
@@ -4,32 +4,49 @@
   ~ This project is licensed under the open source MPL V2.
   ~ See https://github.com/openMF/android-client/blob/master/LICENSE.md
   -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent" android:layout_height="match_parent">
+<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/view_flipper"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:inAnimation="@android:anim/fade_in"
+    android:outAnimation="@android:anim/fade_out">
 
-    <TextView
+    <!-- Comment this out when editing the actual content -->
+    <ProgressBar
+        android:id="@+id/progress_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Please select one of the Survey"
-        android:textSize="18sp"
-        android:paddingLeft="20dip"
-        android:paddingRight="10dip"
-        android:paddingTop="20dip"
-        android:id="@+id/tv_survey_name"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true" />
+        android:layout_gravity="center" />
 
-    <ListView
-        android:layout_width="wrap_content"
-        android:divider="@android:color/transparent"
-        android:dividerHeight="10dp"
-        android:paddingLeft="10dip"
-        android:paddingRight="10dip"
-        android:paddingTop="1dip"
-        android:layout_height="wrap_content"
-        android:id="@+id/lv_surveys_list"
-        android:layout_centerVertical="true"
-        android:layout_centerHorizontal="true"
-        android:layout_below="@+id/tv_survey_name"/>
-</RelativeLayout>
+    <!-- Actual content -->
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/tv_survey_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentTop="true"
+            android:paddingLeft="20dip"
+            android:paddingRight="10dip"
+            android:paddingTop="20dip"
+            android:text="Please select one of the Survey"
+            android:textSize="18sp" />
+
+        <ListView
+            android:id="@+id/lv_surveys_list"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/tv_survey_name"
+            android:layout_centerHorizontal="true"
+            android:layout_centerVertical="true"
+            android:divider="@android:color/transparent"
+            android:dividerHeight="10dp"
+            android:paddingLeft="10dip"
+            android:paddingRight="10dip"
+            android:paddingTop="1dip" />
+    </RelativeLayout>
+</ViewFlipper>


### PR DESCRIPTION
At the moment, progress indication for network operations is done by displaying Progress Dialogs. This is bad for al least two reasons:
**1)** It's bad UX as it heavily restricts users. Users have no means of navigating back from a Fragment/Activity until an operation completes. And since these are network operations, their duration may greatly vary from connection to connection, and sometimes cause intolerable wait times. This could be extremely annoying if a user accidentally navigates into such a situation.
**2)** In places where multiple operations are executed in a queue, we see multiple "blinks" and dialogs popping up one after the other. This is pretty ugly.

As a solution, we could display `ProgressBar`s inside layouts themselves with the help of the `ViewFlipper` class. An example of how this looks can be found here: https://streamable.com/nnes

#### Roadmap:
✔️  **1.** Add [`ProgressableFragment`](https://github.com/xiprox/android-client/blob/progress_improvements/mifosng-android/src/main/java/com/mifos/mifosxdroid/core/ProgressableFragment.java) and  [`ProgressableDialogFragment`](https://github.com/xiprox/android-client/blob/progress_improvements/mifosng-android/src/main/java/com/mifos/mifosxdroid/core/ProgressableDialogFragment.java) base classes which extend `MifosBaseFragment` or `DialogFragment` and provides a method (`showProgress(boolean)`) for easy `ViewFlipper` flipping.

✔️  **2.** Make the following Classes/Fragments extend `ProgressableFragment` or `ProgressableDialogFragment` (if Fragments or DialogFragments), replace `ProgressDialog` calls with `ViewFlipper` calls, and make the necessary changes to their layouts (addition of `ViewFlipper` and `ProgressBar`):
- [x] CenterListFragment
- [x] ClientDetailsFragment
- [x] LoanAccountSummaryFragment
- [x] SavingsAccountSummaryFragment
- [x] GroupDetailsFragment
- [x] CreateNewClientFragment
- [x] CreateNewGroupFragment
- [x] ClientChooseFragment
- [x] CenterListFragment
- [x] SurveyListFragment
- [x] GroupListFragment
- [x] ClientIdentifiersFragment
- [x] DataTableDataFragment
- [x] DocumentListFragment
- [x] GenerateCollectionSheetFragment
- [x] LoanRepaymentFragment
- [x] LoanRepaymentScheduleFragment
- [x] SavingsAccountTransactionFragment
- [x] ~~SavingsAccountTransactionFragment#processTransaction~~  - We are making a transaction here. We could implement a Snackbar-based solution here. We'd have to implement operation cancelation too in that case though. I'm simply leaving this untouched.
- [x] GroupLoanAccountFragment
- [x] ~~AsyncFileDownloader~~ - A better solution could be a Snackbar or a Notification. That'd require too much work and the implementation of cancellability though. Leaving untouched.
- [x] ChargeDialogFragment - There are two such calls here. One is for loading Spinner entries and the second is for the save operation. I'm replacing the load ProgressDialog with ViewFlipper. The dialog for the save operation stays there though.
- [x] ~~DataTableRowDialogFragment~~ - Not able to test. Looks like an operation initiated by a button click. Better off with a Progress Dialog.
- [x] ~~DocumentDialogFragment~~ - User initiated Upload operation. Would require work on cancellability. Better off with a Progress Dialog.
- [x] LoanAccountFragment
- [x] LoanChargeDialogFragment
- [x] SavingsAccountFragment

**Note about ClientListFragment and GroupListFragment:** These two Fragments implement the SwipeRefresh pattern. Currently, the progress indicators aren't being shown on first load. They will be omitted in this PR and fixes for the SwipeRefreshLayouts' indicators will be submitted as a separate PR.

✔️  **3.** Fix crashes caused by not keeping a reference to a `Context` and directly calling `getActivity()` in async operation results. Fragments get detached from their parent `Activity` and the `getActivity()` call returns `null`. A call on this `null` is made at a further point which in turn causes an exception to be thrown. The reason this never came up until now is because Progress Dialogs prevented users from leaving a Fragment before the result of an async operation was delivered. Fix is easy; just keep a reference to the parent `Activity`/`Context` from when it isn't `null`. An example of this can be seen in #190.