### PR TITLE
MIFOSX-142 Unnecessary search button on activities related to center list resolved

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Mon Feb 22 17:53:36 EET 2016
+#Fri Apr 08 00:37:51 IST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/CentersActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/CentersActivity.java
@@ -26,7 +26,7 @@ public class CentersActivity extends MifosBaseActivity implements CenterListFrag
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        getMenuInflater().inflate(R.menu.centers, menu);
+
         return true;
     }
 


### PR DESCRIPTION
There was a unnecessary search button on center list page which closes the activity on pressing. 
Moreover successive fragment has also these button - 
1. Fragment that contain the list of groups in any particular center
2. Client list page that contain the list of client in any particular group
Now there is no search button.

<a href="url"><img src="https://cloud.githubusercontent.com/assets/11210887/14393356/42214600-fde4-11e5-9f48-e3d98a05e06a.png" align="left" height="600" ></a>

<a href="url"><img src="https://cloud.githubusercontent.com/assets/11210887/14393410/920257cc-fde4-11e5-8457-217b059976f2.png" align="left" height="600" ></a>

<a href="url"><img src="https://cloud.githubusercontent.com/assets/11210887/14393452/c2dc7990-fde4-11e5-8fc8-73a2f103ca61.png" align="left" height="600" ></a>
