### PR TITLE
correct centers list titles

### DIFF
--- a/mifosng-android/src/instrumentTest/java/com/mifos/mifosxdroid/tests/CenterListFragmentTest.java
+++ b/mifosng-android/src/instrumentTest/java/com/mifos/mifosxdroid/tests/CenterListFragmentTest.java
@@ -2,6 +2,7 @@ package com.mifos.mifosxdroid.tests;
 
 import android.test.ActivityInstrumentationTestCase2;
 import android.test.ViewAsserts;
+import android.test.suitebuilder.annotation.MediumTest;
 import android.test.suitebuilder.annotation.SmallTest;
 import android.test.suitebuilder.annotation.Suppress;
 import android.view.KeyEvent;
@@ -10,6 +11,11 @@ import android.widget.ListView;
 
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.online.CentersActivity;
+
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
 
 /**
  * Created by Gabriel Esteban on 12/12/14.
@@ -69,5 +75,50 @@ public class CenterListFragmentTest extends ActivityInstrumentationTestCase2<Cen
 
         //waiting again for the API
         Thread.sleep(6000);
+    }
+
+    /**
+     * - open center list, check title is "Centers"
+     * - open a center and check title is "Groups"
+     * - open a group and check title is "Clients"
+     * - press back and check title is "Groups"
+     * - press back and check title is "Centers"
+     */
+    @MediumTest
+    public void testCorrectTitles() throws InterruptedException {
+        assertEquals(getActivity().getTitle().toString(), "Centers");
+
+        // open a center
+        Thread.sleep(2000);
+        onData(org.hamcrest.core.IsAnything.anything())
+                .inAdapterView(withId(R.id.lv_center_list))
+                .atPosition(0)
+                .perform(click());
+
+        assertEquals(getActivity().getTitle().toString(), "Groups");
+
+        // open a group
+        Thread.sleep(2000);
+        onData(org.hamcrest.core.IsAnything.anything())
+                .inAdapterView(withId(R.id.lv_group_list))
+                .atPosition(0)
+                .perform(click());
+        Thread.sleep(2000);
+
+        assertEquals(getActivity().getTitle().toString(), "Clients");
+
+        // go back to groups
+        Thread.sleep(2000);
+        sendKeys(KeyEvent.KEYCODE_BACK);
+
+        assertEquals(getActivity().getTitle().toString(), "Groups");
+
+        // go back to cecnters
+        Thread.sleep(2000);
+        sendKeys(KeyEvent.KEYCODE_BACK);
+
+        assertEquals(getActivity().getTitle().toString(), "Centers");
+
+
     }
 }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/CenterListFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/CenterListFragment.java
@@ -49,6 +49,7 @@ public class CenterListFragment extends MifosBaseFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         rootView = inflater.inflate(R.layout.fragment_centers_list, container, false);
         lv_centers_list = (ListView) rootView.findViewById(R.id.lv_center_list);
+        setToolbarTitle(getResources().getString(R.string.title_activity_centers));
 
         showProgress();
         App.apiManager.getCenters(new Callback<List<Center>>() {

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientListFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientListFragment.java
@@ -73,6 +73,7 @@ public class ClientListFragment extends MifosBaseFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         rootView = inflater.inflate(R.layout.fragment_client, container, false);
         setHasOptionsMenu(true);
+        setToolbarTitle(getResources().getString(R.string.clients));
         ButterKnife.inject(this, rootView);
 
         swipeRefreshLayout.setColorSchemeResources(R.color.blue_light, R.color.green_light, R.color.orange_light, R.color.red_light);

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/GroupListFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/GroupListFragment.java
@@ -60,7 +60,7 @@ public class GroupListFragment extends MifosBaseFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         rootView = inflater.inflate(R.layout.fragment_group_list, container, false);
         ButterKnife.inject(this, rootView);
-        setToolbarTitle(getResources().getString(R.string.group));
+        setToolbarTitle(getResources().getString(R.string.title_center_list));
         inflateGroupList();
         return rootView;
     }

--- a/mifosng-android/src/main/res/values/strings.xml
+++ b/mifosng-android/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="total">Total</string>
     <string name="client_name">Client Name</string>
     <string name="client">Client</string>
+    <string name="clients">Clients</string>
     <string name="save">Save</string>
     <string name="due_date">Due Date</string>
     <string name="locale">Locale</string>


### PR DESCRIPTION
MIFOSAC-143
Now if you open the center list the title will be "Centers"
when you choose a center the title will change to "Groups"
when you choose a group from the center's groups the title will change to "Clients"
Before that fix, the title will change to "Groups" when choosing a center and remain like that  even after going back to the centers list

Added an activity test for the fix

