### PR TITLE
add the ability to create center savings account

### DIFF
--- a/mifosng-android/src/instrumentTest/java/com/mifos/mifosxdroid/tests/CenterListFragmentTest.java
+++ b/mifosng-android/src/instrumentTest/java/com/mifos/mifosxdroid/tests/CenterListFragmentTest.java
@@ -1,5 +1,7 @@
 package com.mifos.mifosxdroid.tests;
 
+import android.support.v4.app.Fragment;
+import android.support.v7.view.menu.ActionMenuItem;
 import android.test.ActivityInstrumentationTestCase2;
 import android.test.ViewAsserts;
 import android.test.suitebuilder.annotation.MediumTest;
@@ -11,9 +13,12 @@ import android.widget.ListView;
 
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.online.CentersActivity;
+import com.mifos.mifosxdroid.online.GroupListFragment;
+import com.mifos.mifosxdroid.online.SavingsAccountFragment;
 
 
 import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 
@@ -119,6 +124,53 @@ public class CenterListFragmentTest extends ActivityInstrumentationTestCase2<Cen
 
         assertEquals(getActivity().getTitle().toString(), "Centers");
 
+    }
 
+    /**
+     * - open center list
+     * - open the first center
+     * - choose "Add Savings account"
+     */
+    @MediumTest
+    public void testOpenAddSavingsAccount() throws InterruptedException {
+
+        // open a center
+        Thread.sleep(2000);
+        onData(org.hamcrest.core.IsAnything.anything())
+                .inAdapterView(withId(R.id.lv_center_list))
+                .atPosition(0)
+                .perform(click());
+
+        // choose option menu
+        getInstrumentation().sendKeyDownUpSync(KeyEvent.KEYCODE_MENU);
+        GroupListFragment groupListFragment =
+                (GroupListFragment) getActivity()
+                        .getSupportFragmentManager()
+                        .findFragmentById(R.id.container);
+        chooseOptionItem(groupListFragment, R.id.itemAddSavingsAccount);
+        Thread.sleep(2000);
+
+        // check the savings account fragment is there
+        SavingsAccountFragment savingsAccountFragment =
+                (SavingsAccountFragment) getActivity()
+                        .getSupportFragmentManager()
+                        .findFragmentById(R.id.container);
+        assertNotNull(savingsAccountFragment);
+
+
+    }
+
+    /**
+     * a work around to choose from an options menu made from the fragment not the activity
+     * so getInstrumentation().invokeMenuActionSync(getActivity(), R.id.charges, 0) wont work
+     */
+    public void chooseOptionItem(final Fragment fragment, final int id) {
+        centersActivity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                final ActionMenuItem item = new ActionMenuItem(centersActivity, 0, id, 0, 0, "");
+                fragment.onOptionsItemSelected(item);
+            }
+        });
     }
 }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/CentersActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/CentersActivity.java
@@ -12,6 +12,7 @@ import android.view.MenuItem;
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.core.MifosBaseActivity;
 import com.mifos.objects.client.Client;
+import com.mifos.utils.Constants;
 
 import java.util.List;
 
@@ -49,5 +50,11 @@ public class CentersActivity extends MifosBaseActivity implements CenterListFrag
     @Override
     public void loadClientsOfGroup(List<Client> clientList) {
         replaceFragment(ClientListFragment.newInstance(clientList, true), true, R.id.container);
+    }
+
+    @Override
+    public void addSavingsAccount(int centerId) {
+        replaceFragment(SavingsAccountFragment.newInstance(centerId, Constants.ClientType.CENTER), true, R.id.container);
+
     }
 }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientDetailsFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientDetailsFragment.java
@@ -549,7 +549,7 @@ public class ClientDetailsFragment extends ProgressableFragment implements Googl
     }
 
     public void addsavingsaccount() {
-        SavingsAccountFragment savingsAccountFragment = SavingsAccountFragment.newInstance(clientId);
+        SavingsAccountFragment savingsAccountFragment = SavingsAccountFragment.newInstance(clientId, Constants.ClientType.CLIENT);
         FragmentTransaction fragmentTransaction = getActivity().getSupportFragmentManager().beginTransaction();
         fragmentTransaction.addToBackStack(FragmentConstants.FRAG_CLIENT_DETAILS);
         fragmentTransaction.replace(R.id.container, savingsAccountFragment);

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/GroupListFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/GroupListFragment.java
@@ -6,8 +6,12 @@
 package com.mifos.mifosxdroid.online;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
@@ -15,6 +19,7 @@ import android.widget.ListView;
 
 import com.mifos.App;
 import com.mifos.mifosxdroid.R;
+import com.mifos.mifosxdroid.activity.PinpointClientActivity;
 import com.mifos.mifosxdroid.adapters.GroupListAdapter;
 import com.mifos.mifosxdroid.core.MifosBaseFragment;
 import com.mifos.mifosxdroid.core.ProgressableFragment;
@@ -53,6 +58,7 @@ public class GroupListFragment extends ProgressableFragment {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setHasOptionsMenu(true);
         if (getArguments() != null)
             centerId = getArguments().getInt(Constants.CENTER_ID);
     }
@@ -64,6 +70,21 @@ public class GroupListFragment extends ProgressableFragment {
         setToolbarTitle(getResources().getString(R.string.title_center_list));
         inflateGroupList();
         return rootView;
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        inflater.inflate(R.menu.menu_center, menu);
+        super.onCreateOptionsMenu(menu, inflater);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case R.id.itemAddSavingsAccount:
+                mListener.addSavingsAccount(centerId);
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     @Override
@@ -85,6 +106,8 @@ public class GroupListFragment extends ProgressableFragment {
     public interface OnFragmentInteractionListener {
 
         void loadClientsOfGroup(List<Client> clientList);
+
+        void addSavingsAccount(int centerId);
     }
 
     public void inflateGroupList() {

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SavingsAccountFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/SavingsAccountFragment.java
@@ -5,7 +5,6 @@
 
 package com.mifos.mifosxdroid.online;
 
-import android.content.Context;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 import android.util.Log;
@@ -29,6 +28,7 @@ import com.mifos.objects.client.Savings;
 import com.mifos.objects.organisation.ProductSavings;
 import com.mifos.objects.templates.savings.SavingProductsTemplate;
 import com.mifos.services.data.SavingsPayload;
+import com.mifos.services.data.SavingsPayloadFactory;
 import com.mifos.utils.Constants;
 import com.mifos.utils.DateHelper;
 import com.mifos.utils.FragmentConstants;
@@ -76,6 +76,7 @@ public class SavingsAccountFragment extends ProgressableDialogFragment implement
     private DialogFragment mfDatePicker;
     private int productId;
     private int clientId;
+    private Constants.ClientType clientType;
     private int interestCalculationTypeAdapterId;
     private int interestCompoundingPeriodTypeId;
     private int interestPostingPeriodTypeId;
@@ -84,10 +85,11 @@ public class SavingsAccountFragment extends ProgressableDialogFragment implement
     private HashMap<String, Integer> savingsNameIdHashMap = new HashMap<String, Integer>();
     private SavingProductsTemplate savingproductstemplate = new SavingProductsTemplate();
 
-    public static SavingsAccountFragment newInstance(int clientId) {
+    public static SavingsAccountFragment newInstance(int clientId, Constants.ClientType clientType) {
         SavingsAccountFragment savingsAccountFragment = new SavingsAccountFragment();
         Bundle args = new Bundle();
         args.putInt(Constants.CLIENT_ID, clientId);
+        args.putInt(Constants.CLIENT_TYPE, clientType.ordinal());
         savingsAccountFragment.setArguments(args);
         return savingsAccountFragment;
     }
@@ -95,10 +97,12 @@ public class SavingsAccountFragment extends ProgressableDialogFragment implement
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if (getArguments() != null)
+        if (getArguments() != null) {
             clientId = getArguments().getInt(Constants.CLIENT_ID);
+            int clientTypeInt = getArguments().getInt(Constants.CLIENT_TYPE);
+            clientType = Constants.ClientType.values()[clientTypeInt];
+        }
     }
-
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -115,12 +119,12 @@ public class SavingsAccountFragment extends ProgressableDialogFragment implement
             @Override
             public void onClick(View view) {
 
-                SavingsPayload savingsPayload = new SavingsPayload();
+                SavingsPayload savingsPayload =  SavingsPayloadFactory.createSavingsPayload(clientId, clientType);
+
                 savingsPayload.setExternalId(et_client_external_id.getEditableText().toString());
                 savingsPayload.setLocale("en");
                 savingsPayload.setSubmittedOnDate(submittion_date);
                 savingsPayload.setDateFormat("dd MMMM yyyy");
-                savingsPayload.setClientId(clientId);
                 savingsPayload.setProductId(productId);
                 savingsPayload.setNominalAnnualInterestRate(et_nominal_annual.getEditableText().toString());
                 savingsPayload.setInterestCompoundingPeriodType(interestCompoundingPeriodTypeId);

--- a/mifosng-android/src/main/java/com/mifos/services/data/ClientSavingsPayload.java
+++ b/mifosng-android/src/main/java/com/mifos/services/data/ClientSavingsPayload.java
@@ -1,0 +1,23 @@
+/*
+ * This project is licensed under the open source MPL V2.
+ * See https://github.com/openMF/android-client/blob/master/LICENSE.md
+ */
+
+package com.mifos.services.data;
+
+/**
+ * Created by ahmed on 4/14/2016.
+ */
+public class ClientSavingsPayload extends SavingsPayload {
+
+    private Integer clientId;
+
+    public Integer getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(Integer clientId) {
+        this.clientId = clientId;
+    }
+
+}

--- a/mifosng-android/src/main/java/com/mifos/services/data/GroupSavingsPayload.java
+++ b/mifosng-android/src/main/java/com/mifos/services/data/GroupSavingsPayload.java
@@ -1,0 +1,22 @@
+/*
+ * This project is licensed under the open source MPL V2.
+ * See https://github.com/openMF/android-client/blob/master/LICENSE.md
+ */
+
+package com.mifos.services.data;
+
+/**
+ * Created by ahmed on 4/14/2016.
+ */
+public class GroupSavingsPayload extends SavingsPayload {
+
+    private Integer groupId;
+
+    public Integer getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(Integer groupId) {
+        this.groupId = groupId;
+    }
+}

--- a/mifosng-android/src/main/java/com/mifos/services/data/SavingsPayload.java
+++ b/mifosng-android/src/main/java/com/mifos/services/data/SavingsPayload.java
@@ -6,7 +6,6 @@ package com.mifos.services.data;
 public class SavingsPayload {
 
     private Integer productId;
-    private Integer clientId;
     private Integer fieldOfficerId;
     private String locale;
     private String dateFormat;
@@ -38,13 +37,7 @@ public class SavingsPayload {
         this.productId = productId;
     }
 
-    public Integer getClientId() {
-        return clientId;
-    }
 
-    public void setClientId(Integer clientId) {
-        this.clientId = clientId;
-    }
 
     public Integer getFieldOfficerId() {
         return fieldOfficerId;

--- a/mifosng-android/src/main/java/com/mifos/services/data/SavingsPayloadFactory.java
+++ b/mifosng-android/src/main/java/com/mifos/services/data/SavingsPayloadFactory.java
@@ -1,0 +1,32 @@
+package com.mifos.services.data;
+
+import com.mifos.utils.Constants;
+
+/**
+ * Created by ahmed on 4/14/2016.
+ */
+public class SavingsPayloadFactory {
+
+    /**
+     * @param id clientId or groupId or centerId
+     * @param clientType  client or group or center
+     * @return the corresponding SavingsPayload object(ClientSavingsPayload or GroupSavingsPayload)
+     */
+    public static SavingsPayload createSavingsPayload(int id, Constants.ClientType clientType) {
+
+        switch (clientType) {
+            case CLIENT:
+                ClientSavingsPayload clientSavingsPayload = new ClientSavingsPayload();
+                clientSavingsPayload.setClientId(id);
+                return clientSavingsPayload;
+
+            case GROUP:
+            case CENTER:
+                GroupSavingsPayload groupSavingsPayload = new GroupSavingsPayload();
+                groupSavingsPayload.setGroupId(id);
+                return groupSavingsPayload;
+        };
+
+        return null;
+    }
+}

--- a/mifosng-android/src/main/java/com/mifos/utils/Constants.java
+++ b/mifosng-android/src/main/java/com/mifos/utils/Constants.java
@@ -74,7 +74,8 @@ public class Constants {
 
     public static final String LOCALE = "locale";
 
-
+    public static final String CLIENT_TYPE = "clientType";
+    public static enum ClientType{CLIENT, GROUP, CENTER};
     /**
      * Constants to identify which Data Tables have to be shown
      */

--- a/mifosng-android/src/main/res/menu/menu_center.xml
+++ b/mifosng-android/src/main/res/menu/menu_center.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ This project is licensed under the open source MPL V2.
+  ~ See https://github.com/openMF/android-client/blob/master/LICENSE.md
+  -->
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto">
+
+
+    <item
+        android:id="@+id/itemAddSavingsAccount"
+        android:title="@string/savings_account"
+        app:showAsAction="never"/>
+</menu>


### PR DESCRIPTION
MIFOSAC-129
- creates a savings account for a center
- added an activity test about accessing the SavingsAccountFragment from the
  CentersActivity

Adding a savings account is the same for clients, groups or centers
The only difference is in the SavingsPayload object being sent
So I used the factory design pattern to let us use the SavingsAccountFragment for the three types(client, group, center) as follows : 
- SavingsAccountFragment receives the clientType in the arguments
- when submitting, SavingsAccountFragment would ask SavingsPayloadFactory to create the SavingsPayload corresponding to the clientType it received in the arguments

![Screenshot]
(http://i.imgur.com/g7Q3oiz.png)
