### PR TITLE
Fix SwipeRefreshLayout indicators not being shown

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientListFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/ClientListFragment.java
@@ -94,7 +94,6 @@ public class ClientListFragment extends MifosBaseFragment implements RecyclerIte
         swipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
             @Override
             public void onRefresh() {
-                swipeRefreshLayout.setRefreshing(true);
                 fetchClientList();
             }
         });
@@ -106,7 +105,6 @@ public class ClientListFragment extends MifosBaseFragment implements RecyclerIte
         ClientNameListAdapter clientNameListAdapter = new ClientNameListAdapter(getContext(), clientList);
         rv_clients.setAdapter(clientNameListAdapter);
 
-        hideProgress();
         // initialize OnScroll Listener
         if (isInfiniteScrollEnabled)
             setInfiniteScrollListener(clientNameListAdapter);
@@ -114,7 +112,12 @@ public class ClientListFragment extends MifosBaseFragment implements RecyclerIte
 
     public void fetchClientList() {
         EspressoIdlingResource.increment(); // App is busy until further notice.
-        showProgress();
+        swipeRefreshLayout.post(new Runnable() {
+            @Override
+            public void run() {
+                swipeRefreshLayout.setRefreshing(true);
+            }
+        });
             totalFilteredRecords = 0;
             App.apiManager.listClients(new Callback<Page<Client>>() {
                 @Override
@@ -132,7 +135,8 @@ public class ClientListFragment extends MifosBaseFragment implements RecyclerIte
                     if (swipeRefreshLayout.isRefreshing())
                         swipeRefreshLayout.setRefreshing(false);
                     Toaster.show(rootView, "There was some error fetching list.");
-                    hideProgress();
+                    if (swipeRefreshLayout.isRefreshing())
+                        swipeRefreshLayout.setRefreshing(false);
                     EspressoIdlingResource.decrement(); // App is idle.
                 }
             });
@@ -148,7 +152,12 @@ public class ClientListFragment extends MifosBaseFragment implements RecyclerIte
             @Override
             public void onLoadMore(int current_page) {
                 Toaster.show(rootView, "Loading More Clients");
-                swipeRefreshLayout.setRefreshing(true);
+                swipeRefreshLayout.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        swipeRefreshLayout.setRefreshing(true);
+                    }
+                });
                 App.apiManager.listClients(clientList.size(), limit, new Callback<Page<Client>>() {
                     @Override
                     public void success(Page<Client> clientPage, Response response) {

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/GroupsListFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/GroupsListFragment.java
@@ -130,7 +130,12 @@ public class GroupsListFragment extends MifosBaseFragment {
             inflateGroupList();
         } else {
 
-            swipeRefreshLayout.setRefreshing(true);
+            swipeRefreshLayout.post(new Runnable() {
+                @Override
+                public void run() {
+                    swipeRefreshLayout.setRefreshing(true);
+                }
+            });
             App.apiManager.listAllGroup(new Callback<Page<Group>>() {
                 @Override
                 public void success(Page<Group> page, Response response) {
@@ -193,7 +198,12 @@ public class GroupsListFragment extends MifosBaseFragment {
                 if (firstVisibleItem + visibleItemCount >= totalItemCount) {
 
                     offset += limit + 1;
-                    swipeRefreshLayout.setRefreshing(true);
+                    swipeRefreshLayout.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            swipeRefreshLayout.setRefreshing(true);
+                        }
+                    });
 
                     App.apiManager.listAllGroups(offset, limit, new Callback<Page<Group>>() {
                         @Override


### PR DESCRIPTION
...in ClientListFragment and GroupsListFragment on initial fetch.

As mentioned in #255:
> **Note about ClientListFragment and GroupListFragment:** These two Fragments implement the SwipeRefresh pattern. Currently, the progress indicators aren't being shown on first load. They will be omitted in this PR and fixes for the SwipeRefreshLayouts' indicators will be submitted as a separate PR.