### PR TITLE
fix identifier delete issue and add swipe to refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ mifosng-android/mifosng-android.apk
 mifosng-android/src/main/assets/crashlytics-build.properties
 android-client.iml
 mifosng-android/mifosng-android.iml
+*.hprof

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ ext {
     playServicesVersion = '8.3.0'
     mapUtilsServices = '0.4.2'
     daggerVersion = '2.2'
-    raizLabsDBFlow = '3.0.1'
+    raizLabsDBFlow = '3.1.1'
     espressoVersion = '2.2.1'
     runnerVersion = '0.4.1'
     rulesVersion = '0.4.1'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-all.zip

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/adapters/IdentifierListAdapter.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/adapters/IdentifierListAdapter.java
@@ -6,7 +6,6 @@
 package com.mifos.mifosxdroid.adapters;
 
 import android.content.Context;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -16,7 +15,6 @@ import android.widget.TextView;
 
 import com.mifos.api.BaseApiManager;
 import com.mifos.api.DataManager;
-import com.mifos.api.GenericResponse;
 import com.mifos.mifosxdroid.R;
 import com.mifos.objects.noncore.Identifier;
 
@@ -25,11 +23,6 @@ import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
-import rx.Observable;
-import rx.Subscriber;
-import rx.Subscription;
-import rx.android.schedulers.AndroidSchedulers;
-import rx.schedulers.Schedulers;
 
 /**
  * Created by ishankhanna on 03/07/14.
@@ -49,15 +42,21 @@ public class IdentifierListAdapter extends BaseAdapter {
     DataManager dataManager;
     BaseApiManager baseApiManager;
 
+    private DeleteIdentifierListener mDeleteIdentifierListener;
 
-    public IdentifierListAdapter(Context context, List<Identifier> identifierList, int clientId) {
+    public interface DeleteIdentifierListener {
+        void onClickRemoveIdentifier(int identifierId, int position);
+    }
 
+    public IdentifierListAdapter(Context context, List<Identifier> identifierList, int clientId
+            , DeleteIdentifierListener listener) {
         this.context = context;
         layoutInflater = LayoutInflater.from(context);
         identifiers = identifierList;
         this.clientId = clientId;
         baseApiManager = new BaseApiManager();
         dataManager = new DataManager(baseApiManager);
+        mDeleteIdentifierListener = listener;
     }
 
     @Override
@@ -76,7 +75,7 @@ public class IdentifierListAdapter extends BaseAdapter {
     }
 
     @Override
-    public View getView(int i, View view, ViewGroup viewGroup) {
+    public View getView(final int i, View view, ViewGroup viewGroup) {
 
         ReusableIdentifierViewHolder reusableIdentifierViewHolder;
         if (view == null) {
@@ -100,28 +99,7 @@ public class IdentifierListAdapter extends BaseAdapter {
                 .OnClickListener() {
             @Override
             public void onClick(View view) {
-
-                Observable<GenericResponse> call = dataManager.deleteIdentifier(clientId,
-                        identifier.getId());
-                Subscription subscription = call.subscribeOn(Schedulers.io())
-                        .observeOn(AndroidSchedulers.mainThread())
-                        .subscribe(new Subscriber<GenericResponse>() {
-                            @Override
-                            public void onCompleted() {
-
-                            }
-
-                            @Override
-                            public void onError(Throwable e) {
-                                Log.d(getClass().getSimpleName(), e.getMessage());
-                            }
-
-                            @Override
-                            public void onNext(GenericResponse genericResponse) {
-                                Log.d(LOG_TAG, genericResponse.toString());
-                            }
-                        });
-
+                mDeleteIdentifierListener.onClickRemoveIdentifier(identifier.getId(), i);
             }
         });
 

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientidentifiers/ClientIdentifiersFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientidentifiers/ClientIdentifiersFragment.java
@@ -6,6 +6,7 @@
 package com.mifos.mifosxdroid.online.clientidentifiers;
 
 import android.os.Bundle;
+import android.support.v4.widget.SwipeRefreshLayout;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -26,16 +27,22 @@ import javax.inject.Inject;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 
+import static com.mifos.mifosxdroid.adapters.IdentifierListAdapter.DeleteIdentifierListener;
+
 
 public class ClientIdentifiersFragment extends ProgressableFragment
-        implements ClientIdentifiersMvpView {
+        implements ClientIdentifiersMvpView, DeleteIdentifierListener {
 
     @BindView(R.id.lv_identifiers)
     ListView lv_identifiers;
+    @BindView(R.id.swipe_refresh_layout)
+    SwipeRefreshLayout mSwipeRefreshLayout;
     @Inject
     ClientIdentifiersPresenter mClientIdentifiersPresenter;
     private View rootView;
     private int clientId;
+    List<Identifier> identifiers;
+    IdentifierListAdapter identifierListAdapter;
 
     public static ClientIdentifiersFragment newInstance(int clientId) {
         ClientIdentifiersFragment fragment = new ClientIdentifiersFragment();
@@ -64,31 +71,56 @@ public class ClientIdentifiersFragment extends ProgressableFragment
         setToolbarTitle(getString(R.string.identifiers));
         loadIdentifiers();
 
+        swipeToRefresh();
+
         return rootView;
     }
 
     public void loadIdentifiers() {
         mClientIdentifiersPresenter.loadIdentifiers(clientId);
+    }
 
+    public void swipeToRefresh() {
+        mSwipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
+            @Override
+            public void onRefresh() {
+                loadIdentifiers();
+                mSwipeRefreshLayout.setRefreshing(false);
+            }
+        });
     }
 
     @Override
     public void showClientIdentifiers(List<Identifier> identifiers) {
         /* Activity is null - Fragment has been detached; no need to do anything. */
         if (getActivity() == null) return;
+        this.identifiers = identifiers;
 
         if (identifiers != null && identifiers.size() > 0) {
-            IdentifierListAdapter identifierListAdapter =
-                    new IdentifierListAdapter(getActivity(), identifiers, clientId);
+            identifierListAdapter = new IdentifierListAdapter(getActivity(),
+                    this.identifiers, clientId, this);
             lv_identifiers.setAdapter(identifierListAdapter);
         } else {
             Toast.makeText(getActivity(), getString(R.string
-                    .message_no_identifiers_available), Toast.LENGTH_SHORT).show();
+                            .message_no_identifiers_available),
+                    Toast.LENGTH_SHORT).show();
         }
     }
 
     @Override
     public void showFetchingError(String s) {
+        Toast.makeText(getActivity(), s, Toast.LENGTH_SHORT).show();
+    }
+
+    @Override
+    public void onClickRemoveIdentifier(int identifierId, int position) {
+        mClientIdentifiersPresenter.deleteIdentifier(clientId, identifierId, position);
+    }
+
+    @Override
+    public void identifierDeletedSuccessfully(String s, int position) {
+        identifiers.remove(position);
+        identifierListAdapter.notifyDataSetChanged();
         Toast.makeText(getActivity(), s, Toast.LENGTH_SHORT).show();
     }
 

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientidentifiers/ClientIdentifiersMvpView.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientidentifiers/ClientIdentifiersMvpView.java
@@ -13,4 +13,8 @@ public interface ClientIdentifiersMvpView extends MvpView {
     void showClientIdentifiers(List<Identifier> identifiers);
 
     void showFetchingError(String s);
+
+    void onClickRemoveIdentifier(int identifierId, int position);
+
+    void identifierDeletedSuccessfully(String s, int position);
 }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientidentifiers/ClientIdentifiersPresenter.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientidentifiers/ClientIdentifiersPresenter.java
@@ -1,6 +1,7 @@
 package com.mifos.mifosxdroid.online.clientidentifiers;
 
 import com.mifos.api.DataManager;
+import com.mifos.api.GenericResponse;
 import com.mifos.mifosxdroid.base.BasePresenter;
 import com.mifos.objects.noncore.Identifier;
 
@@ -60,6 +61,34 @@ public class ClientIdentifiersPresenter extends BasePresenter<ClientIdentifiersM
                     public void onNext(List<Identifier> identifiers) {
                         getMvpView().showProgressbar(false);
                         getMvpView().showClientIdentifiers(identifiers);
+                    }
+                });
+    }
+
+    public void deleteIdentifier(final int clientId, int identifierId, final int position) {
+        checkViewAttached();
+        getMvpView().showProgressbar(true);
+        if (mSubscription != null) mSubscription.unsubscribe();
+        mSubscription = mDataManager.deleteIdentifier(clientId, identifierId)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeOn(Schedulers.io())
+                .subscribe(new Subscriber<GenericResponse>() {
+                    @Override
+                    public void onCompleted() {
+                        getMvpView().showProgressbar(false);
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+                        getMvpView().showProgressbar(false);
+                        getMvpView().showFetchingError("Failed to delete Identifier");
+                    }
+
+                    @Override
+                    public void onNext(GenericResponse genericResponse) {
+                        getMvpView().identifierDeletedSuccessfully("Successfully deleted"
+                                , position);
+                        getMvpView().showProgressbar(false);
                     }
                 });
     }

--- a/mifosng-android/src/main/res/layout-land/fragment_client_identifiers.xml
+++ b/mifosng-android/src/main/res/layout-land/fragment_client_identifiers.xml
@@ -23,11 +23,18 @@
         android:layout_height="match_parent"
         tools:context=".online.clientidentifiers.ClientIdentifiersFragment">
 
-        <ListView
-            android:id="@+id/lv_identifiers"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentTop="true"
-            android:layout_centerHorizontal="true" />
+        <android.support.v4.widget.SwipeRefreshLayout
+            android:id="@+id/swipe_refresh_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <ListView
+                android:id="@+id/lv_identifiers"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentTop="true"
+                android:layout_centerHorizontal="true" />
+
+        </android.support.v4.widget.SwipeRefreshLayout>
     </RelativeLayout>
 </ViewFlipper>

--- a/mifosng-android/src/main/res/layout/fragment_client_identifiers.xml
+++ b/mifosng-android/src/main/res/layout/fragment_client_identifiers.xml
@@ -23,11 +23,18 @@
         android:layout_height="match_parent"
         tools:context=".online.clientidentifiers.ClientIdentifiersFragment">
 
-        <ListView
-            android:id="@+id/lv_identifiers"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentTop="true"
-            android:layout_centerHorizontal="true" />
+        <android.support.v4.widget.SwipeRefreshLayout
+            android:id="@+id/swipe_refresh_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <ListView
+                android:id="@+id/lv_identifiers"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentTop="true"
+                android:layout_centerHorizontal="true" />
+
+        </android.support.v4.widget.SwipeRefreshLayout>
     </RelativeLayout>
 </ViewFlipper>


### PR DESCRIPTION
- Removes identifier from view after deleted from the API request
- Fixes issue #316
- Added swipe to refresh

Steps:
- Listener for the Remove button
- Its onClick makes an API call to delete the identifier
- On successful response identifier List updated and `notifyDataSetChanged()` called