### PR TITLE
fix: Error message and error icon overlap making the error message illegible

### DIFF
--- a/mifosng-android/src/main/res/layout/fragment_centers_list.xml
+++ b/mifosng-android/src/main/res/layout/fragment_centers_list.xml
@@ -47,16 +47,15 @@
             android:layout_width="48dp"
             android:layout_height="48dp"
             android:layout_centerHorizontal="true"
-            android:layout_centerVertical="true"
-            android:src="@drawable/ic_error_black_24dp" />
+            android:layout_gravity='center'
+            android:src="@drawable/ic_error_black_24dp"/>
 
         <TextView
             android:id="@+id/noCenterText"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:layout_below="@id/noCentersIcon"
-            android:layout_gravity="center"/>
+            android:layout_below="@id/noCentersIcon" />
 
     </RelativeLayout>
 

--- a/mifosng-android/src/main/res/layout/fragment_client.xml
+++ b/mifosng-android/src/main/res/layout/fragment_client.xml
@@ -38,7 +38,7 @@
             android:layout_width="48dp"
             android:layout_height="48dp"
             android:layout_centerHorizontal="true"
-            android:layout_centerVertical="true"
+            android:layout_gravity='center'
             android:src="@drawable/ic_error_black_24dp"/>
 
         <TextView

--- a/mifosng-android/src/main/res/layout/fragment_groups.xml
+++ b/mifosng-android/src/main/res/layout/fragment_groups.xml
@@ -47,7 +47,7 @@
             android:layout_width="48dp"
             android:layout_height="48dp"
             android:layout_centerHorizontal="true"
-            android:layout_centerVertical="true"
+            android:layout_gravity='center'
             android:src="@drawable/ic_error_black_24dp" />
 
         <TextView
@@ -55,8 +55,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:layout_below="@id/noGroupsIcon"
-            android:layout_gravity="center"/>
+            android:layout_below="@id/noGroupsIcon" />
 
     </RelativeLayout>
 


### PR DESCRIPTION

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

After fixing the issue -

![screenshot_20170311-124321](https://cloud.githubusercontent.com/assets/20839661/23821446/8eeab962-0658-11e7-9925-78e29be86afd.png)

![screenshot_20170311-124325](https://cloud.githubusercontent.com/assets/20839661/23821445/8e8a895c-0658-11e7-9be2-cbe78e6975de.png)

![screenshot_20170311-124329](https://cloud.githubusercontent.com/assets/20839661/23821447/8f949de2-0658-11e7-8282-b90cb160156e.png)
