### PR TITLE
Handling EditText hint text and items in option menu

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DashboardActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DashboardActivity.java
@@ -103,31 +103,30 @@ public class DashboardActivity extends MifosBaseActivity
                             setMenuCreateCentre(false);
                             setMenuCreateGroup(true);
                         }
-
                     }
                 });
 
     }
 
-    private void setMenuCreateGroup(boolean visibility) {
+    private void setMenuCreateGroup(boolean isEnabled) {
         if (menu != null) {
             //position of mItem_create_new_group is 2
-            menu.getItem(2).setVisible(visibility);
+            menu.getItem(2).setEnabled(isEnabled);
         }
 
     }
 
-    private void setMenuCreateCentre(boolean visibility) {
+    private void setMenuCreateCentre(boolean isEnabled) {
         if (menu != null) {
             //position of mItem_create_new_centre is 1
-            menu.getItem(1).setVisible(visibility);
+            menu.getItem(1).setEnabled(isEnabled);
         }
     }
 
-    private void setMenuCreateClient(boolean visibility) {
+    private void setMenuCreateClient(boolean isEnabled) {
         if (menu != null) {
             //position of mItem_create_new_client is 0
-            menu.getItem(0).setVisible(visibility);
+            menu.getItem(0).setEnabled(isEnabled);
         }
     }
 
@@ -273,6 +272,9 @@ public class DashboardActivity extends MifosBaseActivity
         if (mDrawerLayout != null && mDrawerLayout.isDrawerOpen(GravityCompat.START)) {
             mDrawerLayout.closeDrawer(Gravity.LEFT);
         } else {
+            setMenuCreateClient(true);
+            setMenuCreateCentre(true);
+            setMenuCreateGroup(true);
             super.onBackPressed();
         }
 

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/search/SearchFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/search/SearchFragment.java
@@ -99,7 +99,7 @@ public class SearchFragment extends MifosBaseFragment implements SearchMvpView,
         searchOptionsAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         sp_search.setAdapter(searchOptionsAdapter);
         sp_search.setOnItemSelectedListener(this);
-
+        et_search.requestFocus();
         layoutManager = new LinearLayoutManager(getActivity());
         layoutManager.setOrientation(LinearLayoutManager.VERTICAL);
         rv_search.setLayoutManager(layoutManager);

--- a/studio_android-client.iml
+++ b/studio_android-client.iml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id="studio_android-client" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="java-gradle" name="Java-Gradle">
+      <configuration>
+        <option name="BUILD_FOLDER_PATH" value="$MODULE_DIR$/build" />
+        <option name="BUILDABLE" value="false" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.gradle" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>


### PR DESCRIPTION
Fix: EditText hint text can be read fully.
EditText hint text cannot be read fully.

Fix: Items in option menu are shown in all fragments, only disabled in certain case.
Items in option menu are not stable as they become invisible in certain fragments and after coming back to DashboardActivity, the items in option menu does not get refreshed to the original status.