### PR TITLE
Fix: Progress Bar in offline mode won't stop loading #579

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientdetails/ClientDetailsFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientdetails/ClientDetailsFragment.java
@@ -461,6 +461,13 @@ public class ClientDetailsFragment extends MifosBaseFragment implements ClientDe
                 }
             });
             //inflateClientsAccounts();
+        } else {
+            Toaster.show(getView(), R.string.failed_to_load_client_details);
+            iv_clientImage.setImageDrawable(
+                    ResourcesCompat.getDrawable(getResources(), R.drawable
+                            .ic_launcher, null));
+
+            pb_imageProgressBar.setVisibility(GONE);
         }
     }
 

--- a/mifosng-android/src/main/res/values/strings.xml
+++ b/mifosng-android/src/main/res/values/strings.xml
@@ -550,6 +550,7 @@
     <string name="failed_to_sync_loan">Failed to Sync Loan</string>
     <string name="failed_to_sync_loanrepayment">Failed to Sync LoanRepayment</string>
     <string name="failed_to_load_client">Failed To Load Clients</string>
+    <string name="failed_to_load_client_details">Failed To Load Client Details</string>
     <string name="failed_to_fetch_savingsaccount">Failed To Fetch SavingsAccount</string>
     <string name="failed_to_fetch_datatable">Failed To Fetch DataTable</string>
     <string name="failed_to_fetch_savings_template">Failed to load Saving Template</string>


### PR DESCRIPTION

In the offline mode when the user clicks on a client the client information is not loaded and the progress bar over the client's image keeps on loading. I have handled the event when the client is returned as null and displayed a snackbar to alert the user. Also i have loaded the default image for the client and stopped the progress bar.

The issue #579 is fixed now and is working properly.
Please merge this PR.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.