### PR TITLE
Fix: Toast Message not correct #596

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/exceptions/InvalidTextInputException.java
+++ b/mifosng-android/src/main/java/com/mifos/exceptions/InvalidTextInputException.java
@@ -9,7 +9,7 @@ import android.content.Context;
 import android.widget.Toast;
 
 public class InvalidTextInputException extends Exception {
-    public static final String TYPE_ALPHABETS = "ALPHABETS";
+    public static final String TYPE_ALPHABETS = "Alphabets";
     private String fieldInput;
     private String localisedErrorMessage;
     private String inputType;
@@ -23,7 +23,7 @@ public class InvalidTextInputException extends Exception {
 
     @Override
     public String toString() {
-        return fieldInput + "" + localisedErrorMessage + inputType;
+        return fieldInput + " " + localisedErrorMessage + " " + inputType;
     }
 
 


### PR DESCRIPTION
Toast message fixed.

After fix 
<img width="191" alt="screen shot 2017-03-18 at 9 12 17 pm" src="https://cloud.githubusercontent.com/assets/7893859/24073596/a9bc65e8-0c1f-11e7-96a3-fb0b0a3d99be.png">


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.