### PR TITLE
fix: EditText in the Identifier Dialog Fragment has no defined limit which results in overflow

### DIFF
--- a/mifosng-android/src/main/res/layout/dialog_fragment_identifier.xml
+++ b/mifosng-android/src/main/res/layout/dialog_fragment_identifier.xml
@@ -98,7 +98,9 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:background="@color/light_grey"/>
+                    android:background="@color/light_grey"
+                    android:maxLines="3"
+                    android:scrollbars="vertical"/>
 
             </TableRow>
 
@@ -121,7 +123,9 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:background="@color/light_grey"/>
+                    android:background="@color/light_grey"
+                    android:maxLines="3"
+                    android:scrollbars="vertical"/>
 
             </TableRow>
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

**Issue Reference:**
#606

**After fixing the issue -**

![screenshot_20170319-123016](https://cloud.githubusercontent.com/assets/20839661/24078900/48dd0f94-0ca0-11e7-85e0-269ff9f0de92.png)
