### PR TITLE
style: EditText in the Charge Dialog Fragment has no defined limit which results in overflow

### DIFF
--- a/mifosng-android/src/main/res/layout/dialog_fragment_charge.xml
+++ b/mifosng-android/src/main/res/layout/dialog_fragment_charge.xml
@@ -70,12 +70,10 @@
 
                 <EditText
                     android:id="@+id/amount_due_charge"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:background="@color/light_grey"
-                    android:inputType="numberDecimal"/>
-            </TableRow>
+                    android:inputType="numberDecimal"
+                    style="@style/DialogFragmentChargeEditText"/>
+
+</TableRow>
 
             <TableRow
                 android:id="@+id/tableRow3"
@@ -93,11 +91,8 @@
 
                 <EditText
                     android:id="@+id/et_date"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:background="@color/light_grey"
-                    android:focusable="false"/>
+                    android:focusable="false"
+                    style="@style/DialogFragmentChargeEditText"/>
 
             </TableRow>
 

--- a/mifosng-android/src/main/res/values/styles.xml
+++ b/mifosng-android/src/main/res/values/styles.xml
@@ -56,5 +56,12 @@
         <item name="android:textColorPrimary">@color/black</item>
         <item name="android:background">@color/white</item>
     </style>
-
+    <!--Style for Charge Dialog Fragment EditText-->
+    <style name="DialogFragmentChargeEditText">
+        <item name="android:background">@color/light_grey</item>
+        <item name="android:maxLines">1</item>
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_weight">1</item>
+    </style>
 </resources>


### PR DESCRIPTION

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

**After fixing the issue-**

There is no more overflow of EditText field on pressing enter multiple times.

![videotogif_2017 03 20_21 11 25](https://cloud.githubusercontent.com/assets/20839661/24107970/41ea5cf6-0db2-11e7-9951-021e96eff930.gif)
