### PR TITLE
style: The Due Date field in the Charge Dialog Fragment displays both keyboard and calender to enter the date

### DIFF
--- a/mifosng-android/src/main/res/layout/dialog_fragment_charge.xml
+++ b/mifosng-android/src/main/res/layout/dialog_fragment_charge.xml
@@ -95,7 +95,8 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:background="@color/light_grey" />
+                    android:background="@color/light_grey"
+                    android:focusable="false"/>
 
             </TableRow>
 


### PR DESCRIPTION

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

**After fixing the issue-**

Now, only the calender is displayed to enter the due date.

![videotogif_2017 03 20_21 37 18](https://cloud.githubusercontent.com/assets/20839661/24113811/f9d49410-0dc3-11e7-94f8-4558e5ac0709.gif)
