### PR TITLE
style: Incorrect input type in Amount field of the Charge Dialog Fragment

### DIFF
--- a/mifosng-android/src/main/res/layout/dialog_fragment_charge.xml
+++ b/mifosng-android/src/main/res/layout/dialog_fragment_charge.xml
@@ -73,7 +73,8 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:background="@color/light_grey" />
+                    android:background="@color/light_grey"
+                    android:inputType="numberDecimal"/>
             </TableRow>
 
             <TableRow


### PR DESCRIPTION

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

**After fixing the issue-**

![videotogif_2017 03 21_00 31 36](https://cloud.githubusercontent.com/assets/20839661/24116870/14704cb0-0dce-11e7-93cf-8d2aee48a2ee.gif)
