### PR TITLE
fix: The progress bar in Datatables of both Clients and Groups loads endlessly.

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/datatable/DataTableFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/datatable/DataTableFragment.java
@@ -99,7 +99,6 @@ public class DataTableFragment extends MifosBaseFragment implements DataTableMvp
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        ((MifosBaseActivity) getActivity()).getActivityComponent().inject(this);
         if (getArguments() != null) {
             tableName = getArguments().getString(Constants.DATA_TABLE_NAME);
             entityId = getArguments().getInt(Constants.ENTITY_ID);
@@ -110,6 +109,7 @@ public class DataTableFragment extends MifosBaseFragment implements DataTableMvp
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable
             Bundle savedInstanceState) {
+        ((MifosBaseActivity) getActivity()).getActivityComponent().inject(this);
         rootView = inflater.inflate(R.layout.fragment_datatables, container, false);
         ButterKnife.bind(this, rootView);
         dataTablePresenter.attachView(this);

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/datatable/DataTablePresenter.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/datatable/DataTablePresenter.java
@@ -26,6 +26,7 @@ public class DataTablePresenter extends BasePresenter<DataTableMvpView> {
     public DataTablePresenter(DataManagerDataTable dataManagerDataTable) {
         this.dataManagerDataTable = dataManagerDataTable;
         subscriptions = new CompositeSubscription();
+
     }
 
     @Override
@@ -36,7 +37,7 @@ public class DataTablePresenter extends BasePresenter<DataTableMvpView> {
     @Override
     public void detachView() {
         super.detachView();
-        subscriptions.unsubscribe();
+        subscriptions.clear();
     }
 
     /**


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

**Issue Reference :**
#597

**After fixing the issue-**
The progress bar now doesn't load endlessly on going back from a Datatable to the list of Datatables.

![videotogif_2017 03 21_18 24 19](https://cloud.githubusercontent.com/assets/20839661/24148248/fc0b88b0-0e63-11e7-98d0-0edf946a5248.gif)
