### PR TITLE
Fix: Overlapping of failed message icon with path tracking details in recyclerview ,while refreshing (when not connected to internet) issue #641

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/activity/pathtracking/PathTrackingActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/activity/pathtracking/PathTrackingActivity.java
@@ -150,6 +150,8 @@ public class PathTrackingActivity extends MifosBaseActivity implements PathTrack
 
     @Override
     public void showError() {
+        this.userLocations.clear();
+        pathTrackingAdapter.notifyDataSetChanged();
         llError.setVisibility(View.VISIBLE);
         tvNoPathTracker.setText(getString(R.string.failed_to_fetch_path_tracking_details));
         ivNoPathTracker.setImageResource(R.drawable.ic_error_black_24dp);


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

GIF After Fix:

![device-2017-03-31-041535](https://cloud.githubusercontent.com/assets/24658811/24529729/f3ff7122-15ca-11e7-8e35-b7ef4aed1c7d.gif)
