### PR TITLE
Fix: Incorrect content in client screen, if data are not available #475

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientdetails/ClientDetailsFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientdetails/ClientDetailsFragment.java
@@ -166,6 +166,9 @@ public class ClientDetailsFragment extends MifosBaseFragment implements ClientDe
     @BindView(R.id.rl_client)
     RelativeLayout rlClient;
 
+    @BindView(R.id.rl_error)
+    RelativeLayout rlError;
+
     @Inject
     ClientDetailsPresenter mClientDetailsPresenter;
 
@@ -678,6 +681,24 @@ public class ClientDetailsFragment extends MifosBaseFragment implements ClientDe
     @Override
     public void showFetchingError(String s) {
         Toast.makeText(getActivity(), s, Toast.LENGTH_SHORT).show();
+
+        //Show the error box
+        showErrorBox(true);
+    }
+
+    public void showErrorBox(boolean show) {
+        if (show) {
+            rlError.setVisibility(VISIBLE);
+        } else {
+            rlError.setVisibility(GONE);
+        }
+    }
+
+    @OnClick(R.id.rl_error)
+    public void onErrorBoxClick() {
+        //Refresh the fragment
+        showErrorBox(false);
+        mClientDetailsPresenter.loadClientDetailsAndClientAccounts(clientId);
     }
 
     public interface OnFragmentInteractionListener {

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientdetails/ClientDetailsPresenter.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientdetails/ClientDetailsPresenter.java
@@ -138,6 +138,10 @@ public class ClientDetailsPresenter extends BasePresenter<ClientDetailsMvpView> 
                     public void onError(Throwable e) {
                         getMvpView().showProgressbar(false);
                         getMvpView().showFetchingError("Client not found.");
+
+                        //IN CASE THERE IS AN ERROR OR NO INTERNET CONNECTION
+                        //show the default client accounts info
+                        getMvpView().showClientAccount(new ClientAccounts());
                     }
 
                     @Override

--- a/mifosng-android/src/main/res/layout/fragment_client_details.xml
+++ b/mifosng-android/src/main/res/layout/fragment_client_details.xml
@@ -172,6 +172,33 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"/>
 
+            <RelativeLayout
+                android:layout_marginTop="50px"
+                android:id="@+id/rl_error"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:visibility="gone"
+                android:clickable="true">
+
+                <ImageView
+                    android:id="@+id/noClientIcon"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:layout_centerHorizontal="true"
+                    android:layout_gravity='center'
+                    android:src="@drawable/ic_error_black_24dp"/>
+
+                <TextView
+                    android:id="@+id/noClientText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:text="Click to reload"
+                    android:layout_below="@id/noClientIcon"/>
+
+            </RelativeLayout>
+
         </LinearLayout>
     </ScrollView>
 


### PR DESCRIPTION
UI issue with multiple savings accounts labels when showing client details while offline

This fixes two issues:
- #475 
- #657