### PR TITLE
fix:  Amount field in Savings Account Transaction Fragment accepts zero (0) as amount 

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/savingaccounttransaction/SavingsAccountTransactionFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/savingaccounttransaction/SavingsAccountTransactionFragment.java
@@ -18,6 +18,7 @@ import android.widget.ArrayAdapter;
 import android.widget.EditText;
 import android.widget.Spinner;
 import android.widget.TextView;
+import android.widget.Toast;
 import android.widget.ViewFlipper;
 
 import com.google.gson.Gson;
@@ -205,6 +206,20 @@ public class SavingsAccountTransactionFragment extends ProgressableFragment impl
                     .message_field_required)).notifyUserWithToast(getActivity());
             return;
         }
+        // Notify the user if zero is entered in the Amount
+        // field or only "." (Decimal point) is entered.
+        try {
+            if (Float.parseFloat(et_transactionAmount.getEditableText().toString()) == 0) {
+                new RequiredFieldException(getString(R.string.amount), getString(string
+                        .message_cannot_be_zero)).notifyUserWithToast(getActivity());
+                return;
+            }
+        } catch (NumberFormatException e) {
+
+            Toast.makeText(getActivity(), string.error_invalid_amount, Toast.LENGTH_SHORT).show();
+            return;
+        }
+
         String[] headers = {getResources().getString(string.field),
                 getResources().getString(string.value)};
         String[][] data = {

--- a/mifosng-android/src/main/res/values/strings.xml
+++ b/mifosng-android/src/main/res/values/strings.xml
@@ -384,6 +384,7 @@
     <string name="message_no_identifiers_available">No Identifiers available for this client</string>
     <string name="message_no_charges_available">No Charges available for this client</string>
     <string name="message_field_required"> is mandatory and cannot be left blank</string>
+    <string name="message_cannot_be_zero">cannot be zero</string>
     <string name="upload_document">Upload Document</string>
     <string name="uploaded_successfully">%1$s Uploaded Successfully</string>
     <string name="upload_failed">Upload Failed</string>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

**After the fix-**

I have also included a fix to an app-crash that occurred due to the user entering only the decimal point (".") in the Amount field.

![videotogif_2017 04 07_09 21 05](https://cloud.githubusercontent.com/assets/20839661/24785035/3186c924-1b74-11e7-84b9-f68c6e7a3ac1.gif)
