### PR TITLE
fix: App crashes on leaving the "Amount Disbursed" field in the Disburse Loan Dialog fragment empty

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/loanaccountdisbursement/LoanAccountDisbursementFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/loanaccountdisbursement/LoanAccountDisbursementFragment.java
@@ -20,6 +20,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.mifos.api.GenericResponse;
+import com.mifos.exceptions.RequiredFieldException;
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.core.MifosBaseActivity;
 import com.mifos.mifosxdroid.core.MifosBaseFragment;
@@ -118,6 +119,12 @@ public class LoanAccountDisbursementFragment extends MifosBaseFragment implement
 
     @OnClick(R.id.btn_disburse_loan)
     void onSubmitDisburse() {
+        // Notify the user if Amount field is blank
+        if (etDisbursedAmount.getEditableText().toString().isEmpty()) {
+            new RequiredFieldException(getString(R.string.amount), getString(R.string
+                    .message_field_required)).notifyUserWithToast(getActivity());
+            return;
+        }
         LoanDisbursement loanDisbursement = new LoanDisbursement();
         loanDisbursement.setNote(etDisbursementNote.getEditableText().toString());
         loanDisbursement.setActualDisbursementDate(disbursementDates);


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

**After fixing the issue-**

![videotogif_2017 04 08_18 10 33](https://cloud.githubusercontent.com/assets/20839661/24829050/56565656-1c88-11e7-8fbd-a60633ac362d.gif)
