### PR TITLE
Fix issue #857:Dialog closes after successfully creating charges and gap between…

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/dialogfragments/chargedialog/ChargeDialogFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/dialogfragments/chargedialog/ChargeDialogFragment.java
@@ -194,6 +194,7 @@ public class ChargeDialogFragment extends ProgressableDialogFragment implements
     public void showChargesCreatedSuccessfully(Charges changes) {
         Toast.makeText(getActivity(), "Charge created successfully", Toast.LENGTH_LONG)
                 .show();
+        getDialog().dismiss();
     }
 
     @Override

--- a/mifosng-android/src/main/res/layout/row_charge_name.xml
+++ b/mifosng-android/src/main/res/layout/row_charge_name.xml
@@ -7,7 +7,7 @@
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:padding="8dp">
 
     <TableLayout


### PR DESCRIPTION
Fix: #857 Dialog closes after successfully creating charges and gap between charges removed .

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.