### PR TITLE
Fix issue: #841 ID,Type,Description values done vertically aligned in Create identifiers section

### DIFF
--- a/mifosng-android/src/main/res/layout/row_identifier_list.xml
+++ b/mifosng-android/src/main/res/layout/row_identifier_list.xml
@@ -49,7 +49,7 @@
                     android:id="@+id/tv_identifier_id"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
+                    android:layout_weight="0.86"
                     android:gravity="left"
                     android:text="" />
 


### PR DESCRIPTION
Fix issue: #841 ID,Type,Description values done vertically aligned in Create identifiers section.

![screenshot_20180209-225421 1](https://user-images.githubusercontent.com/30701209/36054544-1db666ec-0e1d-11e8-86d3-b59b1432ea27.png)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.