### PR TITLE
Fix:Issue #849-Empty toast while creating datatable while offline

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/utils/MFErrorParser.java
+++ b/mifosng-android/src/main/java/com/mifos/utils/MFErrorParser.java
@@ -9,6 +9,8 @@ package com.mifos.utils;
 import com.google.gson.Gson;
 import com.mifos.objects.mifoserror.MifosError;
 
+import java.net.UnknownHostException;
+
 import retrofit2.adapter.rxjava.HttpException;
 import rx.plugins.RxJavaPlugins;
 
@@ -29,6 +31,8 @@ public class MFErrorParser {
                 errorMessage = ((HttpException) throwableError).response().errorBody().string();
                 errorMessage =  MFErrorParser.parseError(errorMessage).getErrors()
                         .get(0).getDefaultUserMessage();
+            } else if (throwableError instanceof UnknownHostException) {
+                errorMessage = "No Internet Connection";
             }
         } catch (Throwable throwable) {
             RxJavaPlugins.getInstance().getErrorHandler().handleError(throwable);


### PR DESCRIPTION
Fix #849 
@therajanmaurya @tarun0  Please review.
The gifs have been attached in #817  since that would solve this as well.
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.