### PR TITLE
Fix #964 Charge options list visible in no data and offline mode

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/dialogfragments/chargedialog/ChargeDialogFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/dialogfragments/chargedialog/ChargeDialogFragment.java
@@ -25,7 +25,7 @@ import com.mifos.mifosxdroid.core.util.Toaster;
 import com.mifos.mifosxdroid.uihelpers.MFDatePicker;
 import com.mifos.objects.client.ChargeCreationResponse;
 import com.mifos.objects.client.Charges;
-import com.mifos.objects.templates.clients.ChargeTemplate;
+import com.mifos.objects.client.Page;
 import com.mifos.services.data.ChargesPayload;
 import com.mifos.utils.Constants;
 import com.mifos.utils.DateHelper;
@@ -74,7 +74,7 @@ public class ChargeDialogFragment extends ProgressableDialogFragment implements
 
     private List<String> chargeNameList = new ArrayList<>();
     private ArrayAdapter<String> chargeNameAdapter;
-    private ChargeTemplate mChargeTemplate;
+    private Page<Charges> mChargesPage;
     private String dueDateString;
     private List<Integer> dueDateAsIntegerList;
     private View rootView;
@@ -160,7 +160,7 @@ public class ChargeDialogFragment extends ProgressableDialogFragment implements
 
     //Charges Fetching API
     private void inflateChargesSpinner() {
-        mChargeDialogPresenter.loadAllChargesV2(clientId);
+        mChargeDialogPresenter.loadAllChargesV2(clientId, 0);
     }
 
     //Charges Creation APi
@@ -194,10 +194,10 @@ public class ChargeDialogFragment extends ProgressableDialogFragment implements
     }
 
     @Override
-    public void showAllChargesV2(ChargeTemplate chargeTemplate) {
-        mChargeTemplate = chargeTemplate;
+    public void showAllChargesV2(Page<Charges> chargesPage) {
+        mChargesPage = chargesPage;
         chargeNameList.addAll(mChargeDialogPresenter.filterChargeName
-                (chargeTemplate.getChargeOptions()));
+                (chargesPage.getPageItems()));
         chargeNameAdapter.notifyDataSetChanged();
     }
 
@@ -205,8 +205,8 @@ public class ChargeDialogFragment extends ProgressableDialogFragment implements
     public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
         switch (parent.getId()) {
             case R.id.sp_charge_name:
-                chargeId = mChargeTemplate.getChargeOptions().get(position).getId();
-                chargeName = mChargeTemplate.getChargeOptions().get(position).getName();
+                chargeId = mChargesPage.getPageItems().get(position).getChargeId();
+                chargeName = mChargesPage.getPageItems().get(position).getName();
                 break;
         }
     }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/dialogfragments/chargedialog/ChargeDialogMvpView.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/dialogfragments/chargedialog/ChargeDialogMvpView.java
@@ -2,14 +2,15 @@ package com.mifos.mifosxdroid.dialogfragments.chargedialog;
 
 import com.mifos.mifosxdroid.base.MvpView;
 import com.mifos.objects.client.ChargeCreationResponse;
-import com.mifos.objects.templates.clients.ChargeTemplate;
+import com.mifos.objects.client.Charges;
+import com.mifos.objects.client.Page;
 
 /**
  * Created by Rajan Maurya on 08/06/16.
  */
 public interface ChargeDialogMvpView extends MvpView {
 
-    void showAllChargesV2(ChargeTemplate chargeTemplate);
+    void showAllChargesV2(Page<Charges> chargesPage);
 
     void showChargesCreatedSuccessfully(ChargeCreationResponse chargeCreationResponse);
 


### PR DESCRIPTION
Fix #964 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

@therajanmaurya @tarun0 The charge options lists are visible in offline mode when data turned off.

![charges_list](https://user-images.githubusercontent.com/25134501/38437028-dc60d0f8-39f3-11e8-924a-03eaac8dccf5.jpg)
