### PR TITLE
Resolving Appcompat Custom Widgets In 2 Files

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/views/CircularImageView.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/views/CircularImageView.java
@@ -23,7 +23,7 @@ import com.mifos.mifosxdroid.R;
 /**
  * @author fomenkoo
  */
-public class CircularImageView extends ImageView {
+public class CircularImageView extends android.support.v7.widget.AppCompatImageView {
     private int borderWidth;
     private int canvasSize;
     private Bitmap image;

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/views/FontTextView.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/views/FontTextView.java
@@ -15,7 +15,7 @@ import com.mifos.mifosxdroid.R;
 /**
  * @author fomenkoo
  */
-public class FontTextView extends TextView {
+public class FontTextView extends android.support.v7.widget.AppCompatTextView {
 
     public FontTextView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);


### PR DESCRIPTION
### Fixes:  Appcompat Custom Widgets In 2 Files

### Changes:

* In 
CircularImageView.java 
FontTextView.java

* This custom view should extend 'android.support.v7.widget.AppCompatImageView' instead

* Previously, it was like this
```
public class FontTextView extends TextView
```
Now, after the change:
```
public class FontTextView extends android.support.v7.widget.AppCompatTextView 
```
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x ] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x ] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [ x] If you have multiple commits please combine them into one commit by squashing them.