### PR TITLE
Fix app crash when submitting create client form in online mode with no internet

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/createnewclient/CreateNewClientFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/createnewclient/CreateNewClientFragment.java
@@ -147,6 +147,7 @@ public class CreateNewClientFragment extends ProgressableFragment
         clientTypeList = new ArrayList<>();
         officeList = new ArrayList<>();
         staffList = new ArrayList<>();
+        clientStaff = new ArrayList<>();
     }
 
     @Override


### PR DESCRIPTION
Fixes #625. the app crashes when a create client form is submitted in online mode and no internet is present.

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
