### PR TITLE
Add autocomplete textview for selecting offices in collection sheet

### DIFF
--- a/mifosng-android/src/main/res/layout/fragment_generate_collection_sheet.xml
+++ b/mifosng-android/src/main/res/layout/fragment_generate_collection_sheet.xml
@@ -33,7 +33,7 @@
                     android:text="@string/office"
                     android:textAppearance="?android:attr/textAppearanceSmall" />
 
-                <Spinner
+                <AutoCompleteTextView
                     android:id="@+id/sp_branch_offices"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"


### PR DESCRIPTION
Fixes #1090 

This pull request adds `AutoCompleteTextView` for selecting offices in `Collection Sheet` fragment. It adds the convenience of selecting an office from the suggestions based on the initial letters, as the number of offices are very large. 

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.