### PR TITLE
Prevent app crash when clicking on an item in path tracking activity with no lat-lngs

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/activity/pathtracking/PathTrackingActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/activity/pathtracking/PathTrackingActivity.java
@@ -79,6 +79,10 @@ public class PathTrackingActivity extends MifosBaseActivity implements PathTrack
     public void onItemClick(View childView, int position) {
         List<UserLatLng> userLatLngs =
                 pathTrackingAdapter.getLatLngList(userLocations.get(position).getLatlng());
+        if (userLatLngs.size() == 0) {
+            Toast.makeText(this, "The locations do not exist", Toast.LENGTH_SHORT).show();
+            return;
+        }
         String uri = "http://maps.google.com/maps?f=d&hl=en&saddr="
                 + userLatLngs.get(0).getLat() + "," + userLatLngs.get(0).getLng() + "&daddr="
                 + userLatLngs.get(userLatLngs.size() - 1).getLat() + "," + ""

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/adapters/PathTrackingAdapter.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/adapters/PathTrackingAdapter.java
@@ -152,7 +152,7 @@ public class PathTrackingAdapter extends RecyclerView.Adapter<PathTrackingAdapte
             MapsInitializer.initialize(context);
             map = googleMap;
             UserLatLng data = (UserLatLng) mvUserLocation.getTag();
-            if (data != null) {
+            if (data != null && userLatLngs.size() != 0) {
                 setMapLocation(map, data);
             }
         }


### PR DESCRIPTION
Fixes: #1100

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.