### PR TITLE
Made Back button toast more informative in Dashboard.

### DIFF
--- a/mifosng-android/build.gradle
+++ b/mifosng-android/build.gradle
@@ -109,6 +109,7 @@ android {
     packagingOptions {
         exclude 'LICENSE.txt'
         exclude 'META-INF/LICENSE.txt'
+        exclude 'META-INF/dbflow-kotlinextensions-compileReleaseKotlin.kotlin_module'
     }
     useLibrary 'org.apache.http.legacy'
 
@@ -142,8 +143,7 @@ dependencies {
     implementation fileTree(dir: 'src/main/libs', include: ['*.jar'])
 
     //DBFlow dependencies
-    annotationProcessor "com.github.Raizlabs.DBFlow:dbflow-processor:$rootProject.raizLabsDBFlow"
-    implementation "com.github.Raizlabs.DBFlow:dbflow-core:$rootProject.raizLabsDBFlow"
+    annotationProcessor "com.github.Raizlabs.DBFlow.dbflow:dbflow-processor:3.1.1"
     implementation "com.github.Raizlabs.DBFlow:dbflow:$rootProject.raizLabsDBFlow"
 
     // App's Support dependencies, including test

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DashboardActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DashboardActivity.java
@@ -64,6 +64,7 @@ public class DashboardActivity extends MifosBaseActivity
     private Menu menu;
     private boolean doubleBackToExitPressedOnce = false;
     private boolean itemClient = true, itemCenter = true, itemGroup = true;
+    private final int DELAY_FOR_SECOND_BACK_PRESS = 2000;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -307,13 +308,14 @@ public class DashboardActivity extends MifosBaseActivity
                 return;
             }
             this.doubleBackToExitPressedOnce = true;
-            Toast.makeText(this, R.string.back_again, Toast.LENGTH_SHORT).show();
-            new Handler().postDelayed(new Runnable() {
-                @Override
-                public void run() {
-                    doubleBackToExitPressedOnce = false;
-                }
-            }, 2000);
+            Fragment fragment = getSupportFragmentManager().findFragmentById(R.id.container);
+            if (fragment instanceof CreateNewClientFragment
+                    || fragment instanceof CreateNewCenterFragment
+                    || fragment instanceof CreateNewGroupFragment) {
+                showToastOnBackPressed(R.string.back_to_dashboard);
+            } else {
+                showToastOnBackPressed(R.string.back_again);
+            }
         }
     }
 
@@ -373,6 +375,16 @@ public class DashboardActivity extends MifosBaseActivity
     @VisibleForTesting
     public IdlingResource getCountingIdlingResource() {
         return EspressoIdlingResource.getIdlingResource();
+    }
+
+    private void showToastOnBackPressed(int msg) {
+        Toast.makeText(this, msg, Toast.LENGTH_SHORT).show();
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                doubleBackToExitPressedOnce = false;
+            }
+        }, DELAY_FOR_SECOND_BACK_PRESS);
     }
 }
 

--- a/mifosng-android/src/main/res/values/strings.xml
+++ b/mifosng-android/src/main/res/values/strings.xml
@@ -186,6 +186,7 @@
     <string name="disburse_loan">Disburse Loan</string>
     <string name="logging_in">Logging In</string>
     <string name="back_again">Please press back again to exit</string>
+    <string name="back_to_dashboard">Press again to go to Dashboard</string>
     <string name="dialog_logout">Are you sure you want to logout?</string>
     <string name="browse">Browse</string>
     <string name="selected_file">Selected File</string>


### PR DESCRIPTION
Fixes #1087 
I've added code that checks what fragment is loaded in the Dashboard activity and then displays the back pressed Toast message accordingly. 
I have used FragmentManger and called the findFragmentById() method to check which fragment is currently loaded onto the Dashboard Activity. If any Create 'Entity' fragment is loaded there, then on back press a toast message is shown which says "Press again to go to Dashboard" and otherwise it shows "Please press back again to exit". For this, I've created a separate method showToastOnBackPressed(int msg), which displays a toast message which is passed to it as an argument and the delay for the second back press is set to 2 seconds.
![20190307_194131](https://user-images.githubusercontent.com/36201975/53975590-2b750800-412b-11e9-8b94-029b704107e2.gif)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.