### PR TITLE
Solve deprecated builder.sslSocketFactory method

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/api/MifosOkHttpClient.java
+++ b/mifosng-android/src/main/java/com/mifos/api/MifosOkHttpClient.java
@@ -62,7 +62,7 @@ public class MifosOkHttpClient {
 
             //Set SSL certificate to OkHttpClient Builder
 
-            builder.sslSocketFactory(sslSocketFactory);
+            builder.sslSocketFactory(sslSocketFactory, (X509TrustManager) trustAllCerts[0]);
 
             builder.hostnameVerifier(new HostnameVerifier() {
                 @Override


### PR DESCRIPTION
Fixes: #1108

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.