### PR TITLE
Unregister receiver in ReportCategoryFragment to prevent memory leaks

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/runreports/reportcategory/ReportCategoryFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/runreports/reportcategory/ReportCategoryFragment.java
@@ -59,6 +59,18 @@ public class ReportCategoryFragment extends MifosBaseFragment
         }
     };
 
+    @Override
+    public void onResume() {
+        super.onResume();
+        getActivity().registerReceiver(this.broadCastNewMessage,
+                new IntentFilter(Constants.ACTION_REPORT));
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        getActivity().unregisterReceiver(this.broadCastNewMessage);
+    }
 
     public ReportCategoryFragment() {
     }
@@ -74,8 +86,6 @@ public class ReportCategoryFragment extends MifosBaseFragment
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((MifosBaseActivity) getActivity()).getActivityComponent().inject(this);
-        getActivity().registerReceiver(this.broadCastNewMessage,
-                new IntentFilter(Constants.ACTION_REPORT));
     }
 
     @Nullable


### PR DESCRIPTION
Fixes: #1117

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.