### PR TITLE
Improved the UI of Office Spinner in Create Center fragment. 

### DIFF
--- a/mifosng-android/src/main/res/layout/fragment_create_new_center.xml
+++ b/mifosng-android/src/main/res/layout/fragment_create_new_center.xml
@@ -30,13 +30,14 @@
 
             />
 
-        <Spinner
+        <androidx.appcompat.widget.AppCompatSpinner
             android:id="@+id/sp_center_offices"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
+            style="@style/Widget.AppCompat.Spinner.Underlined"
             android:layout_height="wrap_content"
             android:paddingTop="10dp"
             android:spinnerMode="dropdown"
-            android:background="@color/light_grey"/>
+            android:backgroundTint="@color/gray_dark"/>
         <com.google.android.material.textfield.TextInputLayout style="@style/TextInput.Base">
         </com.google.android.material.textfield.TextInputLayout>
         <CheckBox


### PR DESCRIPTION
It was using grey background due to which, the drop down arrow was not showing. I've also included the underline style for the spinner for showing a nice grey underline like other spinners.

Fixes #1126 
Before change: 
![photo6068660387361957963](https://user-images.githubusercontent.com/36201975/54121172-c158ad80-441f-11e9-9ad8-9586922df1f5.jpg)

After change: 
![photo6068660387361957965](https://user-images.githubusercontent.com/36201975/54121421-63789580-4420-11e9-8510-1867e0efaf99.jpg)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.