### PR TITLE
fix: Unable to view Snackbar if keyboard open

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientdetails/ClientDetailsFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientdetails/ClientDetailsFragment.java
@@ -682,7 +682,7 @@ public class ClientDetailsFragment extends MifosBaseFragment implements ClientDe
                 getListView(context).setVisibility(GONE);
             }
 
-            private void configureSection(Activity context, final AccountAccordion accordion) {
+            private void configureSection(final Activity context, final AccountAccordion accordion) {
                 final ListView listView = getListView(context);
                 final TextView textView = getTextView(context);
                 final IconTextView iconView = getIconView(context);
@@ -694,6 +694,8 @@ public class ClientDetailsFragment extends MifosBaseFragment implements ClientDe
                             accordion.setCurrentSection(null);
                         } else if (listView != null && listView.getCount() > 0) {
                             accordion.setCurrentSection(Section.this);
+                        } else if (listView.getCount() == 0){
+                            Toast.makeText(context, "No "+textView.getText().toString()+" found.", Toast.LENGTH_SHORT).show();
                         }
                     }
                 };

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/savingaccounttransaction/SavingsAccountTransactionFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/savingaccounttransaction/SavingsAccountTransactionFragment.java
@@ -13,6 +13,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.EditText;
@@ -49,6 +50,8 @@ import javax.inject.Inject;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
+
+import static android.content.Context.INPUT_METHOD_SERVICE;
 
 
 public class SavingsAccountTransactionFragment extends ProgressableFragment implements
@@ -199,6 +202,18 @@ public class SavingsAccountTransactionFragment extends ProgressableFragment impl
 
     @OnClick(R.id.bt_reviewTransaction)
     public void onReviewTransactionButtonClicked() {
+
+        //If the keyboard is open when the Review Transcation
+        // button is pressed, the error Snackbar is hidden. So
+        // dismiss the keyboard on pressing it
+        InputMethodManager key = (InputMethodManager) getActivity()
+                                                        .getSystemService(INPUT_METHOD_SERVICE);
+        if (key.isAcceptingText()) { // verify if the soft keyboard is open
+            key.hideSoftInputFromWindow(getActivity()
+                                            .getCurrentFocus()
+                                            .getWindowToken(), 0);
+        }
+
         // Notify user if Amount field is blank and Review
         // Transaction button is pressed.
         if (et_transactionAmount.getEditableText().toString().isEmpty()) {


### PR DESCRIPTION
If there is an error message, then a Snackbar pops up, however if the keyboard is open at the time, it isnt visible. So dismiss the keyboard when the Review Transaction Button is pressed.

Fixes #1132

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.