### PR TITLE
Fix : Upload Dialog Fragment now corrected, allows user to input Name and Description

### DIFF
--- a/mifosng-android/src/main/res/layout/dialog_fragment_document.xml
+++ b/mifosng-android/src/main/res/layout/dialog_fragment_document.xml
@@ -23,7 +23,7 @@
         <TextView
             style="@style/Base.TextAppearance.AppCompat.Large"
             android:id="@+id/tv_document_action"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_width="match_parent"
             android:paddingBottom="@dimen/layout_padding_30dp"
             android:paddingLeft="24dp"
@@ -36,7 +36,7 @@
             android:textStyle="bold"/>
 
         <android.support.design.widget.TextInputLayout
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_width="match_parent"
             android:paddingLeft="24dp"
             android:paddingRight="24dp">
@@ -45,13 +45,13 @@
                 android:hint="@string/name"
                 android:id="@+id/et_document_name"
                 android:inputType="text"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_width="match_parent"/>
         </android.support.design.widget.TextInputLayout>
 
         <android.support.design.widget.TextInputLayout
             android:id="@+id/til_description"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_width="match_parent"
             android:paddingLeft="24dp"
             android:paddingRight="24dp"
@@ -61,7 +61,7 @@
                 android:hint="@string/description"
                 android:id="@+id/et_document_description"
                 android:inputType="textMultiLine"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_width="match_parent"
                 android:scrollHorizontally="false"
                 android:scrollbars="vertical"/>
@@ -71,7 +71,7 @@
             <android.support.design.widget.TextInputLayout
                 android:id="@+id/til_selected_file"
                 android:gravity="center"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_weight=".7"
                 android:layout_width="match_parent"
                 android:paddingEnd="8dp"
@@ -83,7 +83,7 @@
                     android:id="@+id/tv_choose_file"
                     android:inputType="text"
                     android:lines="1"
-                    android:layout_height="match_parent"
+                    android:layout_height="wrap_content"
                     android:layout_width="match_parent"
                     android:scrollHorizontally="false"
                     android:enabled="false"


### PR DESCRIPTION
Fixes Issue #1119
Cause: The element widths in the dialog fragment layout were set as a match_parent which resulted in none of them being correctly visible for the user to edit
Fix: The the layout_height of the concerned elements was changed from match_parent to wrap_content

**Files still cannot be uploaded because of a 403 response from the server (It is a server side issue, not app-related)**

**New Upload Document Fragment**
![aa](https://user-images.githubusercontent.com/31567169/54361820-ddfa1d00-468d-11e9-943c-667477a1717a.jpg)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x]  Apply the MifosStyle.xml style template to your code in Android Studio.

- [x] Run the unit tests with ./gradlew check to make sure you didn't break anything

- [x]  If you have multiple commits please combine them into one commit by squashing them.