### PR TITLE
fix: No feedback when ListView, in ClientDetailsFragment with no accounts is clicked

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientdetails/ClientDetailsFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientdetails/ClientDetailsFragment.java
@@ -682,7 +682,8 @@ public class ClientDetailsFragment extends MifosBaseFragment implements ClientDe
                 getListView(context).setVisibility(GONE);
             }
 
-            private void configureSection(Activity context, final AccountAccordion accordion) {
+            private void configureSection(final Activity context,
+                                          final AccountAccordion accordion) {
                 final ListView listView = getListView(context);
                 final TextView textView = getTextView(context);
                 final IconTextView iconView = getIconView(context);
@@ -694,6 +695,9 @@ public class ClientDetailsFragment extends MifosBaseFragment implements ClientDe
                             accordion.setCurrentSection(null);
                         } else if (listView != null && listView.getCount() > 0) {
                             accordion.setCurrentSection(Section.this);
+                        } else if (listView.getCount() == 0) {
+                            Toast.makeText(context, "No " + textView.getText().toString() +
+                                                            " found.", Toast.LENGTH_SHORT).show();
                         }
                     }
                 };


### PR DESCRIPTION
In the ClientDetailsFragment, if there is an Accounts tab with no accounts, i.e. having no Savings Account, then when you press it there is no message informing the user that there are no accounts.

Now a Toast shall pop up telling that there are no Accounts found.

Fixes #1140 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.