### PR TITLE
Fix #1144 - Groups Activity keeps on loading when Create client is selected in offline

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/groupslist/GroupsListFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/groupslist/GroupsListFragment.java
@@ -33,6 +33,7 @@ import com.mifos.mifosxdroid.online.createnewgroup.CreateNewGroupFragment;
 import com.mifos.objects.group.Group;
 import com.mifos.utils.Constants;
 import com.mifos.utils.FragmentConstants;
+import com.mifos.utils.Utils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -314,6 +315,11 @@ public class GroupsListFragment extends MifosBaseFragment implements GroupsListM
         String errorMessage = getStringMessage(R.string.failed_to_fetch_groups);
         sweetUIErrorHandler.showSweetErrorUI(errorMessage,
                 R.drawable.ic_error_black_24dp, rv_groups, errorView);
+    }
+
+    @Override
+    public boolean isInternetConnected() {
+        return Utils.isInternetAvailable(getContext());
     }
 
 

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/groupslist/GroupsListFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/groupslist/GroupsListFragment.java
@@ -4,7 +4,9 @@
  */
 package com.mifos.mifosxdroid.online.groupslist;
 
+import android.content.Context;
 import android.content.Intent;
+import android.net.ConnectivityManager;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.v4.app.FragmentTransaction;
@@ -319,7 +321,9 @@ public class GroupsListFragment extends MifosBaseFragment implements GroupsListM
 
     @Override
     public boolean isInternetConnected() {
-        return Utils.isInternetAvailable(getContext());
+        ConnectivityManager cm =
+                (ConnectivityManager) getContext().getSystemService(Context.CONNECTIVITY_SERVICE);
+        return cm.getActiveNetworkInfo() != null;
     }
 
 

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/groupslist/GroupsListMvpView.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/groupslist/GroupsListMvpView.java
@@ -23,4 +23,6 @@ public interface GroupsListMvpView extends MvpView {
     void showMessage(int message);
 
     void showFetchingError();
+
+    boolean isInternetConnected();
 }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/groupslist/GroupsListPresenter.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/groupslist/GroupsListPresenter.java
@@ -1,10 +1,13 @@
 package com.mifos.mifosxdroid.online.groupslist;
 
+import android.content.Context;
+
 import com.mifos.api.datamanager.DataManagerGroups;
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.base.BasePresenter;
 import com.mifos.objects.client.Page;
 import com.mifos.objects.group.Group;
+import com.mifos.utils.Utils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -136,6 +139,11 @@ public class GroupsListPresenter extends BasePresenter<GroupsListMvpView> {
                         getMvpView().showProgressbar(false);
                     }
                 }));
+         //Check internet connection
+        if (!getMvpView().isInternetConnected()) {
+            getMvpView().showProgressbar(false);
+            getMvpView().showFetchingError();
+        }
     }
 
     public void loadDatabaseGroups() {

--- a/mifosng-android/src/main/java/com/mifos/utils/Utils.java
+++ b/mifosng-android/src/main/java/com/mifos/utils/Utils.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
+import android.net.ConnectivityManager;
 import android.support.v4.content.ContextCompat;
 
 import com.mifos.mifosxdroid.R;
@@ -12,6 +13,7 @@ import com.mifos.objects.accounts.loan.LoanAccount;
 import com.mifos.objects.accounts.savings.SavingsAccount;
 import com.mifos.objects.client.Client;
 
+import java.net.InetAddress;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -185,5 +187,11 @@ public class Utils {
         Drawable image = ContextCompat.getDrawable(context, R.drawable.circular_background);
         LayerDrawable ld = new LayerDrawable(new Drawable[]{image, color});
         return ld;
+    }
+
+    public static boolean isInternetAvailable(Context context) {
+        ConnectivityManager cm =
+                (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        return cm.getActiveNetworkInfo() != null;
     }
 }

--- a/mifosng-android/src/main/java/com/mifos/utils/Utils.java
+++ b/mifosng-android/src/main/java/com/mifos/utils/Utils.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
-import android.net.ConnectivityManager;
 import android.support.v4.content.ContextCompat;
 
 import com.mifos.mifosxdroid.R;
@@ -13,7 +12,6 @@ import com.mifos.objects.accounts.loan.LoanAccount;
 import com.mifos.objects.accounts.savings.SavingsAccount;
 import com.mifos.objects.client.Client;
 
-import java.net.InetAddress;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -187,11 +185,5 @@ public class Utils {
         Drawable image = ContextCompat.getDrawable(context, R.drawable.circular_background);
         LayerDrawable ld = new LayerDrawable(new Drawable[]{image, color});
         return ld;
-    }
-
-    public static boolean isInternetAvailable(Context context) {
-        ConnectivityManager cm =
-                (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-        return cm.getActiveNetworkInfo() != null;
     }
 }


### PR DESCRIPTION
Fixes #1144 Groups Activity keeps on loading when Create client is selected in offline
Now shows the correct error message at this time.