### PR TITLE
Fix #1148-Unusual text alignment in checkbox of new center fragment

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Aug 15 20:28:24 IST 2016
+#Thu Mar 21 12:02:54 IST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/mifosng-android/build.gradle
+++ b/mifosng-android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         classpath 'io.fabric.tools:gradle:1.+'
         classpath 'com.github.triplet.gradle:play-publisher:1.1.5'
     }
@@ -34,7 +34,7 @@ apply plugin: 'com.github.triplet.play'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
+    buildToolsVersion '28.0.2'
 
     defaultConfig {
         multiDexEnabled true

--- a/mifosng-android/src/main/res/layout/fragment_create_new_center.xml
+++ b/mifosng-android/src/main/res/layout/fragment_create_new_center.xml
@@ -45,8 +45,10 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
             android:checked="false"
-            android:paddingTop="10dp"
+            android:paddingTop="5dp"
             android:text="@string/center_active"
+            android:gravity="left"
+            android:textSize="15dp"
             />
 
         <LinearLayout

--- a/mifosng-android/src/main/res/layout/fragment_create_new_center.xml
+++ b/mifosng-android/src/main/res/layout/fragment_create_new_center.xml
@@ -48,7 +48,7 @@
             android:paddingTop="5dp"
             android:text="@string/center_active"
             android:gravity="left"
-            android:textSize="15dp"
+            android:textSize="16dp"
             />
 
         <LinearLayout


### PR DESCRIPTION
Fixes #1148 
![Screenshot_20190323-224910](https://user-images.githubusercontent.com/43517972/54869428-2a480a00-4dbe-11e9-919d-c6e2949cb34f.png)


Please Add Screenshots If there are any UI changes.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

