### PR TITLE
Fix issue #1128 UI improvement: white space above tool bar bug.

### DIFF
--- a/mifosng-android/src/main/res/layout/activity_dashboard.xml
+++ b/mifosng-android/src/main/res/layout/activity_dashboard.xml
@@ -5,6 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     tools:context=".online.DashboardActivity">
 
     <LinearLayout

--- a/mifosng-android/src/main/res/layout/fragment_client.xml
+++ b/mifosng-android/src/main/res/layout/fragment_client.xml
@@ -8,7 +8,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="false">
+    android:fitsSystemWindows="true">
 
     <android.support.v4.widget.SwipeRefreshLayout
         android:id="@+id/swipe_container"


### PR DESCRIPTION
Changed fragment_client.xml and activity_dashboard.xml to set fitsSystemWindows="true".

(Tested in online and offline mode)...
- Tested that there was no whitespace above tool bar when navigating: Centers -> Dashboard, and Groups-> Dashboard.
- Tested that there was no whitespace above tool bar when navigating: Centers -> Clients, and Groups -> Clients.

Fixes #1128

Please Add Screenshots If there are any UI changes.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x]  If you have multiple commits please combine them into one commit by squashing them.