### PR TITLE
Added a fragment backStackChangeListener in RunReportsActivity…

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/RunReportsActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/RunReportsActivity.java
@@ -3,6 +3,8 @@ package com.mifos.mifosxdroid.online;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
@@ -10,7 +12,9 @@ import android.widget.Spinner;
 
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.core.MifosBaseActivity;
+import com.mifos.mifosxdroid.online.runreports.report.ReportFragment;
 import com.mifos.mifosxdroid.online.runreports.reportcategory.ReportCategoryFragment;
+import com.mifos.mifosxdroid.online.runreports.reportdetail.ReportDetailFragment;
 import com.mifos.utils.Constants;
 
 /**
@@ -20,7 +24,9 @@ import com.mifos.utils.Constants;
 public class RunReportsActivity extends MifosBaseActivity
         implements Spinner.OnItemSelectedListener {
 
-    Intent intent;
+    private Intent intent;
+    private Spinner spinner;
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -29,7 +35,7 @@ public class RunReportsActivity extends MifosBaseActivity
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayShowTitleEnabled(false);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-        Spinner spinner = new Spinner(getSupportActionBar().getThemedContext());
+        spinner = new Spinner(getSupportActionBar().getThemedContext());
 
         ArrayAdapter<CharSequence> adapter = ArrayAdapter.createFromResource(this,
                 R.array.array_runreport, R.layout.simple_spinner_item);
@@ -40,7 +46,9 @@ public class RunReportsActivity extends MifosBaseActivity
         intent = new Intent(Constants.ACTION_REPORT);
         ReportCategoryFragment fragment = new ReportCategoryFragment();
         replaceFragment(fragment, false, R.id.container);
+        addOnBackStackChangedListener();
     }
+
 
     @Override
     public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
@@ -79,4 +87,125 @@ public class RunReportsActivity extends MifosBaseActivity
     public void onNothingSelected(AdapterView<?> adapterView) {
 
     }
+
+    private void addOnBackStackChangedListener() {
+        if (getSupportFragmentManager() == null) {
+            return;
+        }
+        getSupportFragmentManager().addOnBackStackChangedListener(
+                new FragmentManager.OnBackStackChangedListener() {
+                    @Override
+                    public void onBackStackChanged() {
+                        final FragmentManager fragmentManager = getSupportFragmentManager();
+                        Fragment fragment = fragmentManager.findFragmentById(R.id.container);
+
+                        if (fragment instanceof ReportDetailFragment) {
+                            spinner.setOnItemSelectedListener(
+                                    new AdapterView.OnItemSelectedListener() {
+                                        @Override
+                                        public void onItemSelected(
+                                                AdapterView<?> adapterView,
+                                                View view, int i, long l) {
+                                            switch (i) {
+                                                case 0: //Clients
+                                                    sendBroadcastFromReportDetailsFragment(
+                                                            fragmentManager, Constants.CLIENT);
+                                                    break;
+                                                case 1: //Loan
+                                                    sendBroadcastFromReportDetailsFragment(
+                                                            fragmentManager, Constants.LOAN);
+                                                    break;
+                                                case 2:
+                                                    sendBroadcastFromReportDetailsFragment(
+                                                            fragmentManager, Constants.SAVINGS);
+                                                    break;
+
+                                                case 3:
+                                                    sendBroadcastFromReportDetailsFragment(
+                                                            fragmentManager, Constants.FUND);
+                                                    break;
+
+                                                case 4:
+                                                    sendBroadcastFromReportDetailsFragment(
+                                                            fragmentManager, Constants.ACCOUNTING);
+                                                    break;
+
+                                                case 5:
+                                                    break;
+                                            }
+                                        }
+
+                                        @Override
+                                        public void onNothingSelected(AdapterView<?> adapterView) {
+
+                                        }
+                                    }
+                            );
+                        } else if (fragment instanceof ReportFragment) {
+                            spinner.setOnItemSelectedListener(
+                                    new AdapterView.OnItemSelectedListener() {
+                                        @Override
+                                        public void onItemSelected(
+                                                AdapterView<?> adapterView,
+                                                View view, int i, long l) {
+                                            switch (i) {
+                                                case 0: //Clients
+                                                    sendBroadcastFromReportFragment(
+                                                            fragmentManager, Constants.CLIENT);
+                                                    break;
+
+                                                case 1: //Loan
+                                                    sendBroadcastFromReportFragment(
+                                                            fragmentManager, Constants.LOAN);
+                                                    break;
+
+                                                case 2:
+                                                    sendBroadcastFromReportFragment(
+                                                            fragmentManager, Constants.SAVINGS);
+                                                    break;
+
+                                                case 3:
+                                                    sendBroadcastFromReportFragment(
+                                                            fragmentManager, Constants.FUND);
+                                                    break;
+
+                                                case 4:
+                                                    sendBroadcastFromReportFragment(
+                                                            fragmentManager, Constants.ACCOUNTING);
+                                                    break;
+
+                                                case 5:
+                                                    break;
+                                            }
+                                        }
+
+                                        @Override
+                                        public void onNothingSelected(AdapterView<?> adapterView) {
+
+                                        }
+                                    }
+                            );
+                        }
+                    }
+                }
+        );
+    }
+
+    private void sendBroadcastFromReportFragment(FragmentManager fragmentManager,
+                                                 String reportCategory) {
+        fragmentManager.popBackStack();
+        fragmentManager.popBackStack();
+        fragmentManager.executePendingTransactions();
+        intent.putExtra(Constants.REPORT_CATEGORY, reportCategory);
+        sendBroadcast(intent);
+    }
+
+    private void sendBroadcastFromReportDetailsFragment(FragmentManager fragmentManager,
+                                                        String reportCategory) {
+        fragmentManager.popBackStack();
+        fragmentManager.executePendingTransactions();
+        intent.putExtra(Constants.REPORT_CATEGORY, reportCategory);
+        sendBroadcast(intent);
+    }
 }
+


### PR DESCRIPTION
… which will check which fragment is loaded in the RunReportsActivity and accordingly sets the onItemSelectedListener for the spinner.In case the ReportsDetail fragment is loaded then it will popbackstack() and sendBroadcast according to the item selected in the spinner and in case of ReportFragment, it will popBackStack() two times and then send the broadcast

Fixes #1158 

Before Change: 
![prev](https://user-images.githubusercontent.com/36201975/58450033-c5e15800-812a-11e9-9a20-42515000e6ae.gif)

After Change:
![20190528_091233](https://user-images.githubusercontent.com/36201975/58450041-cda0fc80-812a-11e9-98b8-e97f7ed02443.gif)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.