### PR TITLE
Fixed app crash on clicking path tracker

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/adapters/PathTrackingAdapter.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/adapters/PathTrackingAdapter.java
@@ -19,6 +19,7 @@ import com.google.android.gms.maps.model.PolylineOptions;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.mifos.mifosxdroid.R;
+import com.mifos.mifosxdroid.activity.pathtracking.PathTrackingActivity;
 import com.mifos.objects.user.UserLatLng;
 import com.mifos.objects.user.UserLocation;
 
@@ -112,6 +113,10 @@ public class PathTrackingAdapter extends RecyclerView.Adapter<PathTrackingAdapte
     }
 
     private void setMapLocation(GoogleMap map, UserLatLng location) {
+        if (userLatLngs == null) {
+            ((PathTrackingActivity) context).showError();
+            return;
+        }
         // Add a marker for this item and set the camera
         PolylineOptions polylineOptions = new PolylineOptions();
         for (UserLatLng userLatLng : userLatLngs) {


### PR DESCRIPTION
Fixes #1165 

**Summary:**

Fixed the app crash by adding a null check on the list in the `PathTrackingAdapter.java`.

Please Add Screenshots If there are any UI changes.

If the list has no tracked paths:
![WhatsApp Image 2019-06-27 at 4 36 58 PM (1)](https://user-images.githubusercontent.com/30550059/60277023-5f627c00-991a-11e9-8bda-11cbd06bf4f1.jpeg)

If the list contains tracked paths:
![WhatsApp Image 2019-06-27 at 4 36 58 PM](https://user-images.githubusercontent.com/30550059/60277064-76a16980-991a-11e9-95ca-397bff5f2a0c.jpeg)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.