### PR TITLE
Corrected order of the list in Path Tracking Activity

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/activity/pathtracking/PathTrackingActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/activity/pathtracking/PathTrackingActivity.java
@@ -38,6 +38,7 @@ import com.mifos.utils.Constants;
 import com.mifos.utils.PrefManager;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -132,6 +133,7 @@ public class PathTrackingActivity extends MifosBaseActivity implements PathTrack
     @Override       
     public void showPathTracking(List<UserLocation> userLocations) {
         this.userLocations = userLocations;
+        Collections.reverse(userLocations);
         pathTrackingAdapter.setPathTracker(userLocations);
     }
 


### PR DESCRIPTION
Fixes #1167 

**Summary:**
Sorted the order of the list of tracked paths in Path Tracking Activity. Now Latest tracked path will be shown on the top.

Please Add Screenshots If there are any UI changes.

![WhatsApp Image 2019-06-28 at 12 19 41 PM](https://user-images.githubusercontent.com/30550059/60323906-fc67f800-99a0-11e9-8958-ea8ba107097c.jpeg)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.