### PR TITLE
Fix #1148 - Unusual text alignment in checkbox of new center fragment

### DIFF
--- a/mifosng-android/src/main/res/layout/fragment_create_new_center.xml
+++ b/mifosng-android/src/main/res/layout/fragment_create_new_center.xml
@@ -40,14 +40,13 @@
         <com.google.android.material.textfield.TextInputLayout style="@style/TextInput.Base">
         </com.google.android.material.textfield.TextInputLayout>
         <CheckBox
-            android:id="@+id/cb_center_active_status"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
-            android:checked="false"
-            android:paddingTop="10dp"
             android:text="@string/center_active"
-            />
+            android:id="@+id/cb_center_active_status"
+            android:checked="false"
+            android:padding="2dp"
+            android:layout_marginTop="10dp"/>
 
         <LinearLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #1148-Unusual text alignment in the checkbox of new centre fragment

![Alignment](https://user-images.githubusercontent.com/44283521/69146279-7ab26b80-0af5-11ea-94a5-aa86bc80ea6a.png)

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.