### PR TITLE
Added functionality to upload existing photo in Edit client page

### DIFF
--- a/mifosng-android/src/main/res/menu/client_image_popup.xml
+++ b/mifosng-android/src/main/res/menu/client_image_popup.xml
@@ -10,6 +10,9 @@
         android:id="@+id/client_image_capture"
         android:title="@string/menu_take_photo" />
     <item
+        android:id="@+id/client_image_upload"
+        android:title="@string/menu_upload_photo" />
+    <item
         android:id="@+id/client_image_remove"
         android:title="@string/menu_remove_photo" />
 </menu>

--- a/mifosng-android/src/main/res/values/strings.xml
+++ b/mifosng-android/src/main/res/values/strings.xml
@@ -524,6 +524,7 @@
     <string name="dashboard">Dashboard</string>
     <string name="menu_take_photo">Take new photo</string>
     <string name="menu_remove_photo">Remove photo</string>
+    <string name="menu_upload_photo">Upload existing photo</string>
     <string name="toast_welcome">Welcome</string>
     <string name="client_image_updated">Client image updated</string>
     <string name="failed_to_capture_image">Failed to capture image</string>


### PR DESCRIPTION
Fixes #1182: No options to upload existing photo in Edit client page

[Task link](https://codein.withgoogle.com/dashboard/task-instances/4725971010191360/)

![screen-recorder](https://user-images.githubusercontent.com/39671162/70450855-7234cb80-1aca-11ea-8234-eb755945b454.gif)

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.
- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything
- [x]  If you have multiple commits please combine them into one commit by squashing them.
