### PR TITLE
Fix: Remove already empty client profile picture

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientdetails/ClientDetailsFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientdetails/ClientDetailsFragment.java
@@ -426,7 +426,7 @@ public class ClientDetailsFragment extends MifosBaseFragment implements ClientDe
     }
 
     @Override
-    public void showClientInformation(Client client) {
+    public void showClientInformation(final Client client) {
         if (client != null) {
             setToolbarTitle(getString(R.string.client) + " - " + client.getLastname());
             isClientActive = client.isActive();
@@ -481,6 +481,9 @@ public class ClientDetailsFragment extends MifosBaseFragment implements ClientDe
                     PopupMenu menu = new PopupMenu(getActivity(), view);
                     menu.getMenuInflater().inflate(R.menu.client_image_popup, menu
                             .getMenu());
+                    if (!client.isImagePresent()) {
+                        menu.getMenu().findItem(R.id.client_image_remove).setVisible(false);
+                    }
                     menu.setOnMenuItemClickListener(
                             new PopupMenu.OnMenuItemClickListener() {
                                 @Override


### PR DESCRIPTION
Fixes #805 

Screenshot:
![WhatsApp Image 2019-12-09 at 18 31 09](https://user-images.githubusercontent.com/44428198/70437927-b7e59a00-1ab2-11ea-9d8b-20f342e6538f.jpeg)

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.