### PR TITLE
fix: Space between toolbar and status bar

### DIFF
--- a/mifosng-android/src/main/res/layout/activity_dashboard.xml
+++ b/mifosng-android/src/main/res/layout/activity_dashboard.xml
@@ -5,11 +5,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     tools:context=".online.DashboardActivity">
 
     <LinearLayout
         style="@style/LinearLayout.Base"
-        android:fitsSystemWindows="true">
+        >
 
         <include layout="@layout/toolbar"/>
 


### PR DESCRIPTION
Fixes #1256
Solved  Space between toolbar and status bar

**Screenshots**
![GIF-200110_153339](https://user-images.githubusercontent.com/38184186/72144815-2d4ccf00-33bf-11ea-8b5f-1d1c9c887a61.gif)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.