### PR TITLE
Fix: Enter to the next editText section directly

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/formwidgets/FormNumericEditText.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/formwidgets/FormNumericEditText.java
@@ -28,7 +28,7 @@ public class FormNumericEditText extends FormWidget {
 
         input = new EditText(context);
         input.setInputType(InputType.TYPE_CLASS_PHONE);
-        input.setImeOptions(EditorInfo.IME_ACTION_DONE);
+        input.setImeOptions(EditorInfo.IME_ACTION_NEXT);
         input.setLayoutParams(FormWidget.defaultLayoutParams);
 
         layout.addView(label);


### PR DESCRIPTION
Fixes #1293

Please Add Screenshots If there are any UI changes.

![resolveded26](https://user-images.githubusercontent.com/52889867/73852471-38c3d680-4855-11ea-947a-eb514b389817.png)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.