### PR TITLE
Fix #1325: Current default API Endpoint for login is not functional

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/api/BaseUrl.java
+++ b/mifosng-android/src/main/java/com/mifos/api/BaseUrl.java
@@ -11,7 +11,7 @@ package com.mifos.api;
 public class BaseUrl {
 
     public static final String PROTOCOL_HTTPS = "https://";
-    public static final String API_ENDPOINT = "demo.openmf.org";
+    public static final String API_ENDPOINT = "demo.mifos.io";
     public static final String API_PATH = "/fineract-provider/api/v1/";
     public static final String PORT = "80";
     // "/" in the last of the base url always


### PR DESCRIPTION
Fixes #1325 Changed the default API endpoint base url.

Please Add Screenshots If there are any UI changes.

![fix - api endpoint incorrect](https://user-images.githubusercontent.com/30969403/75075263-6ed6ab00-5523-11ea-8dcc-2965bd2f7038.jpg)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.