### PR TITLE
Fix #1285: Run Reports toolbar font inconsistent

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/RunReportsActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/RunReportsActivity.java
@@ -2,6 +2,7 @@ package com.mifos.mifosxdroid.online;
 
 import android.content.Intent;
 import android.os.Bundle;
+
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
@@ -40,7 +41,7 @@ public class RunReportsActivity extends MifosBaseActivity
 
         ArrayAdapter<CharSequence> adapter = ArrayAdapter.createFromResource(this,
                 R.array.array_runreport, R.layout.simple_spinner_item);
-        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        adapter.setDropDownViewResource(R.layout.spinner_dropdown_item);
         spinner.setAdapter(adapter);
         spinner.setOnItemSelectedListener(this);
         toolbar.addView(spinner);

--- a/mifosng-android/src/main/res/layout/simple_spinner_item.xml
+++ b/mifosng-android/src/main/res/layout/simple_spinner_item.xml
@@ -3,5 +3,4 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:textColor="@color/white"
-    android:textStyle="bold"
-    android:textSize="25sp"/>
+    android:textStyle="bold" />

--- a/mifosng-android/src/main/res/layout/spinner_dropdown_item.xml
+++ b/mifosng-android/src/main/res/layout/spinner_dropdown_item.xml
@@ -1,0 +1,8 @@
+<CheckedTextView xmlns:android="http://schemas.android.com/apk/res/android"
+    style="?android:attr/spinnerDropDownItemStyle"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:ellipsize="marquee"
+    android:padding="@dimen/default_spinner_dropdown_padding"
+    android:singleLine="true"
+    android:textColor="@color/white" />

--- a/mifosng-android/src/main/res/values/dimens.xml
+++ b/mifosng-android/src/main/res/values/dimens.xml
@@ -10,6 +10,7 @@
     <dimen name="login_margin_top">24dp</dimen>
     <dimen name="default_margin">8dp</dimen>
     <dimen name="default_padding">16dp</dimen>
+    <dimen name="default_spinner_dropdown_padding">10dp</dimen>
     <dimen name="default_horizontal_padding">8dp</dimen>
     <dimen name="default_vertical_padding">8dp</dimen>
     <dimen name="login_padding_top">56dp</dimen>


### PR DESCRIPTION
Fixes #1285 Font of **Client** is fixed and drop down items are now inline with app theme

Please Add Screenshots If there are any UI changes.

![fix - font size on toolbar of Run Reports inconsistent](https://user-images.githubusercontent.com/30969403/75078896-e826cb80-552c-11ea-959c-a4cb93b818e9.gif)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.