### PR TITLE
Startup time improvement and Dynamic Shortcuts

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/api/BaseUrl.java
+++ b/mifosng-android/src/main/java/com/mifos/api/BaseUrl.java
@@ -11,7 +11,7 @@ package com.mifos.api;
 public class BaseUrl {
 
     public static final String PROTOCOL_HTTPS = "https://";
-    public static final String API_ENDPOINT = "demo.openmf.org";
+    public static final String API_ENDPOINT = "demo.mifos.io";
     public static final String API_PATH = "/fineract-provider/api/v1/";
     public static final String PORT = "80";
     // "/" in the last of the base url always

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/SplashScreenActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/SplashScreenActivity.java
@@ -24,7 +24,6 @@ public class SplashScreenActivity extends MifosBaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_splash);
         if (!PrefManager.isAuthenticated()) {
             PrefManager.setInstanceUrl(BaseUrl.PROTOCOL_HTTPS
                     + BaseUrl.API_ENDPOINT + BaseUrl.API_PATH);
@@ -34,7 +33,7 @@ public class SplashScreenActivity extends MifosBaseActivity {
                     PassCodeActivity.class);
             intent.putExtra(PassCodeConstants.PASSCODE_INITIAL_LOGIN, true);
             intent.setAction(getIntent().getAction());
-            PassCodeActivity.action=getIntent().getAction();
+            PassCodeActivity.action = getIntent().getAction();
             startActivity(intent);
         }
         finish();

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/SplashScreenActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/SplashScreenActivity.java
@@ -33,6 +33,8 @@ public class SplashScreenActivity extends MifosBaseActivity {
             Intent intent = new Intent(SplashScreenActivity.this,
                     PassCodeActivity.class);
             intent.putExtra(PassCodeConstants.PASSCODE_INITIAL_LOGIN, true);
+            intent.setAction(getIntent().getAction());
+            PassCodeActivity.action=getIntent().getAction();
             startActivity(intent);
         }
         finish();

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DashboardActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DashboardActivity.java
@@ -21,8 +21,6 @@ import androidx.core.view.GravityCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.widget.SwitchCompat;
-
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -48,10 +46,8 @@ import com.mifos.utils.Constants;
 import com.mifos.utils.EspressoIdlingResource;
 import com.mifos.utils.PrefManager;
 
-
 import java.util.ArrayList;
 import java.util.List;
-
 import butterknife.BindView;
 import butterknife.ButterKnife;
 
@@ -84,7 +80,7 @@ public class DashboardActivity extends MifosBaseActivity
         ButterKnife.bind(this);
         initialiseShortcuts();
         replaceFragment(new SearchFragment(), false, R.id.container);
-        if(getIntent().getAction()!=null)
+        if (getIntent().getAction() != null)
             listenForActions(getIntent().getAction());
         // setup navigation drawer and Navigation Toggle click and Offline Mode SwitchButton
         setupNavigationBar();
@@ -151,44 +147,22 @@ public class DashboardActivity extends MifosBaseActivity
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N_MR1) {
             shortcutManager = getSystemService(ShortcutManager.class);
             Intent intent = new Intent(this, SplashScreenActivity.class);
+            String[] shortcutLabelArray = {getString(R.string.clients), getString(R.string.groups),
+                getString(R.string.centers), getString(R.string.settings)};
+            int[] drawableArray = {R.drawable.ic_person_black_24dp, R.drawable.ic_group_black_24dp,
+                    R.drawable.ic_centers_24dp, R.drawable.ic_settings};
             List<ShortcutInfo> shortcutList = new ArrayList<>();
-            shortcutList.add(
-                    new ShortcutInfo.Builder(this, getString(R.string.clients))
-                            .setShortLabel(getString(R.string.clients))
-                            .setLongLabel(getString(R.string.clients))
-                            .setIcon(Icon.createWithResource(this, R.drawable.ic_person_black_24dp))
-                            .setIntent(intent.setAction(
-                                    getString(R.string.clients)))
-                            .build()
-            );
-            shortcutList.add(
-                    new ShortcutInfo.Builder(this, getString(R.string.groups))
-                            .setShortLabel(
-                                    getString(R.string.groups))
-                            .setLongLabel(getString(R.string.groups))
-                            .setIcon(Icon.createWithResource(this,
-                                    R.drawable.ic_group_black_24dp))
-                            .setIntent(intent.setAction(
-                                    getString(R.string.groups)))
-                            .build()
-            );
-            shortcutList.add(
-                    new ShortcutInfo.Builder(this, getString(R.string.centers))
-                            .setShortLabel(getString(R.string.centers))
-                            .setLongLabel(getString(R.string.centers))
-                            .setIcon(Icon.createWithResource(this, R.drawable.ic_centers_24dp))
-                            .setIntent(intent.setAction(getString(R.string.centers)))
-                            .build()
-            );
-            shortcutList.add(
-                    new ShortcutInfo.Builder(this, getString(R.string.settings))
-                            .setShortLabel(getString(R.string.settings))
-                            .setLongLabel(getString(R.string.settings))
-                            .setIcon(Icon.createWithResource(this,
-                                    R.drawable.ic_settings))
-                            .setIntent(intent.setAction(getString(R.string.settings)))
-                            .build()
-            );
+            for (int i = 0; i < 4; ++i) {
+                shortcutList.add(
+                        new ShortcutInfo.Builder(this, shortcutLabelArray[i])
+                                .setShortLabel(shortcutLabelArray[i])
+                                .setLongLabel(shortcutLabelArray[i])
+                                .setIcon(Icon.createWithResource(this, drawableArray[i]))
+                                .setIntent(intent.setAction(
+                                        shortcutLabelArray[i]))
+                                .build()
+                );
+            }
             shortcutManager.setDynamicShortcuts(shortcutList);
         }
     }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DashboardActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DashboardActivity.java
@@ -6,6 +6,9 @@
 package com.mifos.mifosxdroid.online;
 
 import android.content.Intent;
+import android.content.pm.ShortcutInfo;
+import android.content.pm.ShortcutManager;
+import android.graphics.drawable.Icon;
 import android.os.Bundle;
 import android.os.Handler;
 
@@ -18,6 +21,8 @@ import androidx.core.view.GravityCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.widget.SwitchCompat;
+
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -27,6 +32,7 @@ import android.widget.Toast;
 
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.SettingsActivity;
+import com.mifos.mifosxdroid.SplashScreenActivity;
 import com.mifos.mifosxdroid.activity.pathtracking.PathTrackingActivity;
 import com.mifos.mifosxdroid.core.MifosBaseActivity;
 import com.mifos.mifosxdroid.offline.offlinedashbarod.OfflineDashboardFragment;
@@ -42,6 +48,9 @@ import com.mifos.utils.Constants;
 import com.mifos.utils.EspressoIdlingResource;
 import com.mifos.utils.PrefManager;
 
+
+import java.util.ArrayList;
+import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -73,9 +82,10 @@ public class DashboardActivity extends MifosBaseActivity
         setContentView(R.layout.activity_dashboard);
 
         ButterKnife.bind(this);
-
+        initialiseShortcuts();
         replaceFragment(new SearchFragment(), false, R.id.container);
-
+        if(getIntent().getAction()!=null)
+            listenForActions(getIntent().getAction());
         // setup navigation drawer and Navigation Toggle click and Offline Mode SwitchButton
         setupNavigationBar();
 
@@ -122,6 +132,66 @@ public class DashboardActivity extends MifosBaseActivity
 
     }
 
+    private void listenForActions(String actions) {
+
+        if (actions.trim().equals(getString(R.string.clients))) {
+            replaceFragment(ClientListFragment.newInstance(), false, R.id.container);
+        } else if (actions.trim().equals(getString(R.string.groups))) {
+            replaceFragment(GroupsListFragment.newInstance(), false, R.id.container);
+        } else if (actions.trim().equals(getString(R.string.centers))) {
+            replaceFragment(CenterListFragment.newInstance(), false, R.id.container);
+        } else if (actions.trim().equals(getString(R.string.settings))) {
+            startActivity(new Intent(this, SettingsActivity.class));
+        }
+
+    }
+
+    private void initialiseShortcuts() {
+        ShortcutManager shortcutManager;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N_MR1) {
+            shortcutManager = getSystemService(ShortcutManager.class);
+            Intent intent = new Intent(this, SplashScreenActivity.class);
+            List<ShortcutInfo> shortcutList = new ArrayList<>();
+            shortcutList.add(
+                    new ShortcutInfo.Builder(this, getString(R.string.clients))
+                            .setShortLabel(getString(R.string.clients))
+                            .setLongLabel(getString(R.string.clients))
+                            .setIcon(Icon.createWithResource(this, R.drawable.ic_person_black_24dp))
+                            .setIntent(intent.setAction(
+                                    getString(R.string.clients)))
+                            .build()
+            );
+            shortcutList.add(
+                    new ShortcutInfo.Builder(this, getString(R.string.groups))
+                            .setShortLabel(
+                                    getString(R.string.groups))
+                            .setLongLabel(getString(R.string.groups))
+                            .setIcon(Icon.createWithResource(this,
+                                    R.drawable.ic_group_black_24dp))
+                            .setIntent(intent.setAction(
+                                    getString(R.string.groups)))
+                            .build()
+            );
+            shortcutList.add(
+                    new ShortcutInfo.Builder(this, getString(R.string.centers))
+                            .setShortLabel(getString(R.string.centers))
+                            .setLongLabel(getString(R.string.centers))
+                            .setIcon(Icon.createWithResource(this, R.drawable.ic_centers_24dp))
+                            .setIntent(intent.setAction(getString(R.string.centers)))
+                            .build()
+            );
+            shortcutList.add(
+                    new ShortcutInfo.Builder(this, getString(R.string.settings))
+                            .setShortLabel(getString(R.string.settings))
+                            .setLongLabel(getString(R.string.settings))
+                            .setIcon(Icon.createWithResource(this,
+                                    R.drawable.ic_settings))
+                            .setIntent(intent.setAction(getString(R.string.settings)))
+                            .build()
+            );
+            shortcutManager.setDynamicShortcuts(shortcutList);
+        }
+    }
     private void setMenuCreateGroup(boolean isEnabled) {
         if (menu != null) {
             //position of mItem_create_new_group is 2

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientcharge/ClientChargeFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientcharge/ClientChargeFragment.java
@@ -249,9 +249,11 @@ public class ClientChargeFragment extends MifosBaseFragment implements ClientCha
 
     @Override
     public void showEmptyCharges() {
-        ll_error.setVisibility(View.VISIBLE);
-        mNoChargesText.setText(getResources().getString(R.string.message_no_charges_available));
-        mNoChargesIcon.setImageResource(R.drawable.ic_assignment_turned_in_black_24dp);
+        if (mChargesNameListAdapter == null || mChargesNameListAdapter.getItemCount() == 0) {
+            ll_error.setVisibility(View.VISIBLE);
+            mNoChargesText.setText(getResources().getString(R.string.message_no_charges_available));
+            mNoChargesIcon.setImageResource(R.drawable.ic_assignment_turned_in_black_24dp);
+        }
     }
 
     @Override

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/passcode/PassCodeActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/passcode/PassCodeActivity.java
@@ -19,8 +19,8 @@ public class PassCodeActivity extends MifosPassCodeActivity {
 
     @Override
     public void startNextActivity() {
-        Intent intent=new Intent(this, DashboardActivity.class);
-        if(action!=null)
+        Intent intent = new Intent(this, DashboardActivity.class);
+        if (action != null)
             intent.setAction(action);
         startActivity(intent);
     }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/passcode/PassCodeActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/passcode/PassCodeActivity.java
@@ -11,7 +11,7 @@ import com.mifos.mobile.passcode.MifosPassCodeActivity;
 import com.mifos.mobile.passcode.utils.EncryptionUtil;
 
 public class PassCodeActivity extends MifosPassCodeActivity {
-
+    public static String action;
     @Override
     public int getLogo() {
         return R.drawable.mifos_logo;
@@ -19,7 +19,10 @@ public class PassCodeActivity extends MifosPassCodeActivity {
 
     @Override
     public void startNextActivity() {
-        startActivity(new Intent(this, DashboardActivity.class));
+        Intent intent=new Intent(this, DashboardActivity.class);
+        if(action!=null)
+            intent.setAction(action);
+        startActivity(intent);
     }
 
     @Override

--- a/mifosng-android/src/main/res/layout/fragment_savings_account_summary.xml
+++ b/mifosng-android/src/main/res/layout/fragment_savings_account_summary.xml
@@ -19,14 +19,15 @@
 
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:padding="@dimen/default_vertical_padding">
 
         <LinearLayout
             android:id="@+id/linear_layout_1"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
             android:layout_alignParentStart="true"
+            android:layout_alignParentLeft="true"
             android:layout_alignParentTop="true"
             android:orientation="horizontal"
             android:paddingBottom="8dp">
@@ -60,9 +61,9 @@
             android:id="@+id/linear_layout_2"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
             android:layout_below="@+id/linear_layout_1"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentLeft="true"
             android:layout_marginTop="8dp"
             android:orientation="horizontal">
 
@@ -98,10 +99,10 @@
             android:id="@+id/savings_account_balance"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_alignTop="@+id/tv_savings_account_balance"
             android:layout_below="@+id/divider_2"
+            android:layout_alignTop="@+id/tv_savings_account_balance"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentLeft="true"
             android:text="@string/savings_account_balance"
             android:textAppearance="?android:attr/textAppearanceMedium" />
 
@@ -109,9 +110,9 @@
             android:id="@+id/tv_savings_account_balance"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_below="@+id/divider_2"
             android:layout_alignParentEnd="true"
             android:layout_alignParentRight="true"
-            android:layout_below="@+id/divider_2"
             android:layout_marginTop="8dp"
             android:gravity="right"
             android:textAppearance="?android:attr/textAppearanceMedium" />
@@ -120,9 +121,9 @@
             android:id="@+id/total_deposits"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
             android:layout_below="@+id/tv_savings_account_balance"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentLeft="true"
             android:layout_marginTop="8dp"
             android:text="@string/savings_total_deposits"
             android:textAppearance="?android:attr/textAppearanceMedium" />
@@ -131,9 +132,9 @@
             android:id="@+id/tv_total_deposits"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_below="@+id/tv_savings_account_balance"
             android:layout_alignParentEnd="true"
             android:layout_alignParentRight="true"
-            android:layout_below="@+id/tv_savings_account_balance"
             android:layout_marginTop="8dp"
             android:gravity="right"
             android:textAppearance="?android:attr/textAppearanceMedium" />
@@ -142,9 +143,9 @@
             android:id="@+id/total_withdrawals"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
             android:layout_below="@+id/tv_total_deposits"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentLeft="true"
             android:layout_marginTop="8dp"
             android:text="@string/savings_total_withdrawals"
             android:textAppearance="?android:attr/textAppearanceMedium" />
@@ -153,9 +154,9 @@
             android:id="@+id/tv_total_withdrawals"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_below="@+id/tv_total_deposits"
             android:layout_alignParentEnd="true"
             android:layout_alignParentRight="true"
-            android:layout_below="@+id/tv_total_deposits"
             android:layout_marginTop="8dp"
             android:gravity="right"
             android:textAppearance="?android:attr/textAppearanceMedium" />
@@ -164,9 +165,9 @@
             android:id="@+id/interest_earned"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
             android:layout_below="@+id/tv_total_withdrawals"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentLeft="true"
             android:layout_marginTop="8dp"
             android:text="@string/savings_interest_earned"
             android:textAppearance="?android:attr/textAppearanceMedium" />
@@ -175,9 +176,9 @@
             android:id="@+id/tv_interest_earned"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_below="@+id/tv_total_withdrawals"
             android:layout_alignParentEnd="true"
             android:layout_alignParentRight="true"
-            android:layout_below="@+id/tv_total_withdrawals"
             android:layout_marginTop="8dp"
             android:gravity="right"
             android:textAppearance="?android:attr/textAppearanceMedium" />
@@ -210,8 +211,8 @@
             android:id="@+id/buttons"
             style="@style/LinearLayout.Width"
             android:layout_alignParentBottom="true"
-            android:layout_marginBottom="8dp"
-            android:layout_marginTop="8dp">
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp">
 
             <Button
                 android:id="@+id/bt_withdrawal"


### PR DESCRIPTION
- Fixes #1314 
- I've also removed the SetContentView() in SplashScreen, which is unnecessary as the SplashScreen already loads the logo from the style.xml, thus improving startup time.



Please Add Screenshots If there are any UI changes.

![untitled](https://user-images.githubusercontent.com/25480443/76178251-be340100-61dc-11ea-9688-79b6ab800faf.gif)



Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.