### PR TITLE
fix 1432: Fixed redundant namespace declaration in all xml files

### DIFF
--- a/mifosng-android/src/main/res/layout/activity_center_details.xml
+++ b/mifosng-android/src/main/res/layout/activity_center_details.xml
@@ -10,7 +10,7 @@
 
     <include layout="@layout/toolbar" />
 
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <LinearLayout
         style="@style/LinearLayout.Base"
         android:padding="10dp">
 

--- a/mifosng-android/src/main/res/layout/activity_path_tracker.xml
+++ b/mifosng-android/src/main/res/layout/activity_path_tracker.xml
@@ -15,7 +15,6 @@
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipe_container"
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
         android:layout_below="@+id/toolbar"
         android:layout_height="match_parent">

--- a/mifosng-android/src/main/res/layout/activity_pinpoint_location.xml
+++ b/mifosng-android/src/main/res/layout/activity_pinpoint_location.xml
@@ -16,7 +16,6 @@
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipe_container"
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_below="@+id/toolbar">

--- a/mifosng-android/src/main/res/layout/activity_toolbar_container.xml
+++ b/mifosng-android/src/main/res/layout/activity_toolbar_container.xml
@@ -10,8 +10,7 @@
     android:layout_height="match_parent"
     android:fitsSystemWindows="true">
 
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                  style="@style/LinearLayout.Base">
+    <LinearLayout style="@style/LinearLayout.Base">
 
         <include layout="@layout/toolbar"/>
 

--- a/mifosng-android/src/main/res/layout/add_payment_detail.xml
+++ b/mifosng-android/src/main/res/layout/add_payment_detail.xml
@@ -8,9 +8,7 @@
     android:layout_margin="@dimen/layout_padding_24dp">
 <LinearLayout android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+    android:layout_height="match_parent">
     <androidx.cardview.widget.CardView
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/mifosng-android/src/main/res/layout/dialog_fragment_charge.xml
+++ b/mifosng-android/src/main/res/layout/dialog_fragment_charge.xml
@@ -19,7 +19,7 @@
         android:layout_gravity="center" />
 
     <!-- Actual content -->
-    <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/mifosng-android/src/main/res/layout/dialog_fragment_identifier.xml
+++ b/mifosng-android/src/main/res/layout/dialog_fragment_identifier.xml
@@ -24,8 +24,7 @@
     android:layout_centerHorizontal="true"
     android:minWidth="300dp"
     android:minHeight="300dp"
-    android:scrollbars="vertical"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+    android:scrollbars="vertical">
     <TextView
         style="@style/Base.TextAppearance.AppCompat.Large"
         android:layout_height="match_parent"

--- a/mifosng-android/src/main/res/layout/fragment_add_loan.xml
+++ b/mifosng-android/src/main/res/layout/fragment_add_loan.xml
@@ -17,8 +17,7 @@
         android:layout_width="fill_parent"
         android:layout_height="fill_parent">
 
-        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-            style="@style/LinearLayout.Base">
+        <LinearLayout style="@style/LinearLayout.Base">
 
             <TextView
                 style="@style/TextView.CreateLoanAccount"

--- a/mifosng-android/src/main/res/layout/fragment_add_savings_account.xml
+++ b/mifosng-android/src/main/res/layout/fragment_add_savings_account.xml
@@ -13,12 +13,11 @@
         android:layout_gravity="center" />
 
     <!-- Actual content -->
-    <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    <ScrollView
         android:layout_width="fill_parent"
         android:layout_height="fill_parent">
 
-        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-            style="@style/LinearLayout.Base">
+        <LinearLayout style="@style/LinearLayout.Base">
 
             <TextView
                 style="@style/TextView.CreateSavingsAccount"

--- a/mifosng-android/src/main/res/layout/fragment_centers_list.xml
+++ b/mifosng-android/src/main/res/layout/fragment_centers_list.xml
@@ -12,7 +12,6 @@
     android:fitsSystemWindows="true">
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/swipe_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent">

--- a/mifosng-android/src/main/res/layout/fragment_charge_list.xml
+++ b/mifosng-android/src/main/res/layout/fragment_charge_list.xml
@@ -12,7 +12,6 @@
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipe_container"
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/mifosng-android/src/main/res/layout/fragment_client_identifiers.xml
+++ b/mifosng-android/src/main/res/layout/fragment_client_identifiers.xml
@@ -12,7 +12,6 @@
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipe_container"
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/mifosng-android/src/main/res/layout/fragment_client_report.xml
+++ b/mifosng-android/src/main/res/layout/fragment_client_report.xml
@@ -3,7 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical" >
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/mifosng-android/src/main/res/layout/fragment_create_new_center.xml
+++ b/mifosng-android/src/main/res/layout/fragment_create_new_center.xml
@@ -4,8 +4,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:padding="10dp">
 
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                  android:id="@+id/ll_center"
+    <LinearLayout
+        android:id="@+id/ll_center"
                   style="@style/LinearLayout.Base">
         <TextView style="@style/TextView.CreateCenter" />
         <com.google.android.material.textfield.TextInputLayout style="@style/TextInput.Base">

--- a/mifosng-android/src/main/res/layout/fragment_create_new_client.xml
+++ b/mifosng-android/src/main/res/layout/fragment_create_new_client.xml
@@ -19,8 +19,7 @@
         android:layout_width="fill_parent"
         android:layout_height="fill_parent">
 
-        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-            style="@style/LinearLayout.Base">
+        <LinearLayout style="@style/LinearLayout.Base">
 
             <TextView style="@style/TextView.CreateClient" />
 

--- a/mifosng-android/src/main/res/layout/fragment_create_new_group.xml
+++ b/mifosng-android/src/main/res/layout/fragment_create_new_group.xml
@@ -19,8 +19,7 @@
         android:layout_width="fill_parent"
         android:layout_height="fill_parent">
 
-        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-            style="@style/LinearLayout.Base">
+        <LinearLayout style="@style/LinearLayout.Base">
 
             <TextView style="@style/TextView.CreateGroup" />
 

--- a/mifosng-android/src/main/res/layout/fragment_datatable.xml
+++ b/mifosng-android/src/main/res/layout/fragment_datatable.xml
@@ -13,7 +13,6 @@
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipe_container"
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
         android:layout_height="match_parent" >
 

--- a/mifosng-android/src/main/res/layout/fragment_datatables.xml
+++ b/mifosng-android/src/main/res/layout/fragment_datatables.xml
@@ -13,7 +13,6 @@
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipe_container"
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
         android:layout_height="match_parent" >
 

--- a/mifosng-android/src/main/res/layout/fragment_document_list.xml
+++ b/mifosng-android/src/main/res/layout/fragment_document_list.xml
@@ -51,7 +51,6 @@
     </TableLayout>
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipe_container"
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
         android:layout_below="@id/tbl_header"
         android:layout_height="match_parent">

--- a/mifosng-android/src/main/res/layout/fragment_new_collection_sheet.xml
+++ b/mifosng-android/src/main/res/layout/fragment_new_collection_sheet.xml
@@ -2,7 +2,7 @@
 <ScrollView android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     xmlns:android="http://schemas.android.com/apk/res/android">
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <LinearLayout
         style="@style/LinearLayout.Base"
         android:padding="10dp">
        <TextView

--- a/mifosng-android/src/main/res/layout/fragment_notes.xml
+++ b/mifosng-android/src/main/res/layout/fragment_notes.xml
@@ -10,7 +10,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipe_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent">

--- a/mifosng-android/src/main/res/layout/fragment_survey_question.xml
+++ b/mifosng-android/src/main/res/layout/fragment_survey_question.xml
@@ -10,7 +10,7 @@
     android:layout_height="match_parent"
     android:layout_gravity="center_horizontal">
 
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">

--- a/mifosng-android/src/main/res/layout/fragment_syncpayload.xml
+++ b/mifosng-android/src/main/res/layout/fragment_syncpayload.xml
@@ -12,7 +12,6 @@
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipe_container"
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/mifosng-android/src/main/res/layout/item_individual_collection_sheet.xml
+++ b/mifosng-android/src/main/res/layout/item_individual_collection_sheet.xml
@@ -9,9 +9,7 @@
     android:foreground="?android:attr/selectableItemBackground"
     android:clickable="true"
     app:cardUseCompatPadding="true" >
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:tools="http://schemas.android.com/tools"
     android:orientation="horizontal"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"

--- a/mifosng-android/src/main/res/layout/item_offline_dashboard.xml
+++ b/mifosng-android/src/main/res/layout/item_offline_dashboard.xml
@@ -6,7 +6,6 @@
     android:layout_height="wrap_content">
 
     <ImageView
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/iv_payload_image"
         android:scaleType="centerCrop"
         android:layout_width="match_parent"

--- a/mifosng-android/src/main/res/layout/item_pinpoint_location.xml
+++ b/mifosng-android/src/main/res/layout/item_pinpoint_location.xml
@@ -15,7 +15,6 @@
     xmlns:map="http://schemas.android.com/tools">
 
     <LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/ll_address"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/mifosng-android/src/main/res/layout/item_sync_center.xml
+++ b/mifosng-android/src/main/res/layout/item_sync_center.xml
@@ -7,8 +7,6 @@
 
     <androidx.cardview.widget.CardView
         android:id="@+id/card_view"
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginBottom="2dp"

--- a/mifosng-android/src/main/res/layout/item_sync_client.xml
+++ b/mifosng-android/src/main/res/layout/item_sync_client.xml
@@ -7,8 +7,6 @@
 
     <androidx.cardview.widget.CardView
         android:id="@+id/card_view"
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginBottom="2dp"

--- a/mifosng-android/src/main/res/layout/item_sync_group.xml
+++ b/mifosng-android/src/main/res/layout/item_sync_group.xml
@@ -7,8 +7,6 @@
 
     <androidx.cardview.widget.CardView
         android:id="@+id/card_view"
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginBottom="2dp"

--- a/mifosng-android/src/main/res/layout/item_sync_loan_repayment.xml
+++ b/mifosng-android/src/main/res/layout/item_sync_loan_repayment.xml
@@ -7,8 +7,6 @@
 
     <androidx.cardview.widget.CardView
         android:id="@+id/card_view"
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginBottom="2dp"

--- a/mifosng-android/src/main/res/layout/item_sync_savings_account_transaction.xml
+++ b/mifosng-android/src/main/res/layout/item_sync_savings_account_transaction.xml
@@ -7,8 +7,6 @@
 
     <androidx.cardview.widget.CardView
         android:id="@+id/card_view"
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginBottom="2dp"

--- a/mifosng-android/src/main/res/layout/row_center_list_item.xml
+++ b/mifosng-android/src/main/res/layout/row_center_list_item.xml
@@ -20,7 +20,6 @@
     app:cardUseCompatPadding="true">
 
     <LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:minHeight="?attr/listPreferredItemHeight"

--- a/mifosng-android/src/main/res/layout/row_client_name.xml
+++ b/mifosng-android/src/main/res/layout/row_client_name.xml
@@ -16,8 +16,6 @@
     app:cardUseCompatPadding="true" >
 
     <LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="?attr/listPreferredItemHeight"

--- a/mifosng-android/src/main/res/layout/row_sync_payload.xml
+++ b/mifosng-android/src/main/res/layout/row_sync_payload.xml
@@ -7,8 +7,6 @@
 
     <androidx.cardview.widget.CardView
         android:id="@+id/card_view"
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginBottom="2dp"
@@ -21,7 +19,6 @@
         app:contentPadding="0dp">
 
             <LinearLayout
-                xmlns:android="http://schemas.android.com/apk/res/android"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:orientation="vertical">


### PR DESCRIPTION
Fixes #1432 

Fixed all the redundant namespace declarations in all the xml files of the app

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.