### PR TITLE
fix 1449: Used app:srcCompat instead of android:src

### DIFF
--- a/mifosng-android/src/main/res/layout/view_nav_drawer_header.xml
+++ b/mifosng-android/src/main/res/layout/view_nav_drawer_header.xml
@@ -21,7 +21,7 @@
             android:layout_width="72dp"
             android:layout_height="72dp"
             android:elevation="2dp"
-            android:src="@drawable/ic_account_circle_black_24dp"
+            app:srcCompat="@drawable/ic_account_circle_black_24dp"
             app:border="false"
             />
 


### PR DESCRIPTION
Fixes #1449 

Replaced `android:src` with `app:srcCompat`

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.