### PR TITLE
fix: Travis Build Failure due to missing androidx annotation dependency

### DIFF
--- a/mifosng-android/build.gradle
+++ b/mifosng-android/build.gradle
@@ -246,13 +246,9 @@ dependencies {
 
     //Android-Jobs
     implementation 'com.evernote:android-job:1.2.6'
-}
-/*
-Resolves dependency versions across test and production APKs, specifically, transitive
-dependencies. This is required since Espresso internally has a dependency on support-annotations.
-*/
-configurations.all {
-    resolutionStrategy.force "com.android.support:support-annotations:23.1.1"
+
+    // androidx annotations
+    implementation 'androidx.annotation:annotation:1.1.0'
 }
 
 /*

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/offlinejobs/OfflineJobCreator.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/offlinejobs/OfflineJobCreator.java
@@ -1,7 +1,7 @@
 package com.mifos.mifosxdroid.offlinejobs;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.evernote.android.job.Job;
 import com.evernote.android.job.JobCreator;

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/offlinejobs/OfflineSyncCenter.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/offlinejobs/OfflineSyncCenter.java
@@ -1,6 +1,6 @@
 package com.mifos.mifosxdroid.offlinejobs;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.evernote.android.job.Job;
 import com.evernote.android.job.JobRequest;

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/offlinejobs/OfflineSyncClient.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/offlinejobs/OfflineSyncClient.java
@@ -1,6 +1,6 @@
 package com.mifos.mifosxdroid.offlinejobs;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.evernote.android.job.Job;
 import com.evernote.android.job.JobRequest;

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/offlinejobs/OfflineSyncGroup.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/offlinejobs/OfflineSyncGroup.java
@@ -1,6 +1,6 @@
 package com.mifos.mifosxdroid.offlinejobs;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.evernote.android.job.Job;
 import com.evernote.android.job.JobRequest;

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/offlinejobs/OfflineSyncLoanRepayment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/offlinejobs/OfflineSyncLoanRepayment.java
@@ -1,6 +1,6 @@
 package com.mifos.mifosxdroid.offlinejobs;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.evernote.android.job.Job;
 import com.evernote.android.job.JobRequest;

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/offlinejobs/OfflineSyncSavingsAccount.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/offlinejobs/OfflineSyncSavingsAccount.java
@@ -1,6 +1,6 @@
 package com.mifos.mifosxdroid.offlinejobs;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.evernote.android.job.Job;
 import com.evernote.android.job.JobRequest;


### PR DESCRIPTION
This pull request fixes the Travis Build failure due to missing androidx annotation dependency. The pull-request that caused the build failure can be found [here](https://github.com/openMF/android-client/pull/998).

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.