### PR TITLE
Fixes #1562 UI improvements in client details page 

### DIFF
--- a/mifosng-android/src/main/res/drawable/table_row_round_bg.xml
+++ b/mifosng-android/src/main/res/drawable/table_row_round_bg.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape= "rectangle">
+    <stroke android:width="1dp" android:color="@color/primary_dark"/>
+    <corners android:radius="2dp"/>
+</shape>

--- a/mifosng-android/src/main/res/layout/fragment_client_details.xml
+++ b/mifosng-android/src/main/res/layout/fragment_client_details.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_marginStart="@dimen/default_padding"
     android:layout_marginEnd="@dimen/default_padding"
     android:id="@+id/rl_client">
@@ -20,10 +20,12 @@
                     android:layout_marginTop="@dimen/marginItemsInSectionSmall"
                     android:layout_gravity="center">
 
+
                     <com.mifos.mifosxdroid.views.CircularImageView
                         android:id="@+id/iv_clientImage"
                         style="@style/ClientImage"
-                        android:layout_gravity="center"/>
+                        android:layout_gravity="center"
+                        tools:src="@drawable/ic_launcher"/>
 
                     <ProgressBar
                         android:id="@+id/pb_imageProgressBar"
@@ -31,16 +33,12 @@
                         android:layout_gravity="center"/>
 
                 </FrameLayout>
-
-                <TextView
-                    android:id="@+id/tv_fullName"
-                    style="@style/TextView.Client"
-                    android:layout_marginBottom="@dimen/marginItemsInSectionSmall"
-                    android:layout_marginTop="@dimen/marginItemsInSectionSmall"
-                    android:layout_gravity="center"/>
-
             </LinearLayout>
 
+            <TextView
+                android:id="@+id/tv_fullName"
+                style="@style/TextView.Client"
+                tools:text="Client Name" />
 
             <TableLayout
                 android:id="@+id/tbl_clientDetails"
@@ -56,7 +54,8 @@
 
                     <TextView
                         android:id="@+id/tv_accountNumber"
-                        style="@style/TextView.Row.Value"/>
+                        style="@style/TextView.Row.Value"
+                        tools:text="000000325"/>
                 </TableRow>
 
                 <TableRow
@@ -69,7 +68,8 @@
 
                     <TextView
                         android:id="@+id/tv_externalId"
-                        style="@style/TextView.Row.Value"/>
+                        style="@style/TextView.Row.Value"
+                        tools:text="ID-123"/>
                 </TableRow>
 
                 <TableRow
@@ -82,7 +82,8 @@
 
                     <TextView
                         android:id="@+id/tv_activationDate"
-                        style="@style/TextView.Row.Value"/>
+                        style="@style/TextView.Row.Value"
+                        tools:text="Nov 16, 2016"/>
                 </TableRow>
 
                 <TableRow
@@ -95,7 +96,8 @@
 
                     <TextView
                         android:id="@+id/tv_office"
-                        style="@style/TextView.Row.Value"/>
+                        style="@style/TextView.Row.Value"
+                        tools:text="GROUP AD"/>
                 </TableRow>
 
                 <TableRow
@@ -108,7 +110,8 @@
 
                     <TextView
                         android:id="@+id/tv_mobile_no"
-                        style="@style/TextView.Row.Value"/>
+                        style="@style/TextView.Row.Value"
+                        tools:text="1234567890"/>
                 </TableRow>
 
                 <TableRow
@@ -121,7 +124,8 @@
 
                     <TextView
                         android:id="@+id/tv_group"
-                        style="@style/TextView.Row.Value"/>
+                        style="@style/TextView.Row.Value"
+                        tools:text="foodies"/>
                 </TableRow>
 
                 <TableRow
@@ -158,24 +162,44 @@
 
             </TableLayout>
 
+            <LinearLayout style="@style/LinearLayout.Width"
+                android:layout_marginTop="22dp"
+                android:layout_marginBottom="12dp">
+                <TextView
+                    android:id="@+id/tv_accountHeader"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/accounts"
+                    android:textStyle="bold"
+                    />
+                <View
+                    android:id="@+id/line2"
+                    android:layout_width="wrap_content"
+                    android:layout_height="2dp"
+                    android:background="@color/primary"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginLeft="6dp"
+                    android:layout_marginStart="6dp"
+                    android:layout_marginTop="2dp"/>
+            </LinearLayout>
+
             <include
                 android:id="@+id/account_accordion_section_loans"
                 layout="@layout/view_account_accordion_section"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"/>
+                android:layout_height="wrap_content" />
 
             <include
                 android:id="@+id/account_accordion_section_savings"
                 layout="@layout/view_account_accordion_section"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
+                android:layout_height="wrap_content" />
 
             <include
                 android:id="@+id/account_accordion_section_recurring"
                 layout="@layout/view_account_accordion_section"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
+                android:layout_height="wrap_content" />
 
         </LinearLayout>
     </ScrollView>
@@ -188,12 +212,12 @@
         android:visibility="gone"
         android:orientation="horizontal">
 
-       <Button
-           android:id="@+id/btn_activate_client"
-           android:layout_width="match_parent"
-           android:layout_height="50dp"
-           android:text="@string/activate_client"
-           android:background="@color/accent" />
+        <Button
+            android:id="@+id/btn_activate_client"
+            android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:text="@string/activate_client"
+            android:background="@color/accent" />
     </LinearLayout>
 
 </RelativeLayout>

--- a/mifosng-android/src/main/res/layout/view_account_accordion_section.xml
+++ b/mifosng-android/src/main/res/layout/view_account_accordion_section.xml
@@ -2,7 +2,8 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginTop="10dp">
+    android:layout_marginTop="10dp"
+    android:paddingBottom="12dp">
 
     <com.joanzapata.iconify.widget.IconTextView
         android:id="@+id/tv_toggle_accounts_icon"
@@ -13,7 +14,8 @@
         android:layout_margin="4dp"
         android:text="{md-add-circle-outline}"
         android:textColor="@color/secondary_text"
-        android:textSize="20sp" />
+        android:textSize="20sp"
+        android:layout_alignParentStart="true" />
 
 
     <TextView
@@ -21,7 +23,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_toRightOf="@id/tv_toggle_accounts_icon"
-        android:text="@string/savingAccounts" />
+        android:text="@string/savingAccounts"
+        android:layout_toEndOf="@id/tv_toggle_accounts_icon"
+        android:layout_marginLeft="12dp"
+        android:layout_marginStart="12dp" />
 
     <TextView
         android:id="@+id/tv_count_accounts"
@@ -37,7 +42,7 @@
         android:layout_width="wrap_content"
         android:layout_height="1dp"
         android:layout_below="@id/tv_toggle_accounts"
-        android:layout_marginTop="5dp"
+        android:layout_marginTop="8dp"
         android:background="@color/primary" />
 
     <ListView

--- a/mifosng-android/src/main/res/values-ca/strings.xml
+++ b/mifosng-android/src/main/res/values-ca/strings.xml
@@ -163,4 +163,7 @@
     <string name="lang_changed">S\'ha canviat l\'idioma</string>
     <string name="lang_change_description">Seleccioneu l\'idioma en què voleu veure l\'aplicació</string>
     <string name="dark_mode">mode fosc</string>
+
+    <string name="accounts">Comptes</string>
+
 </resources>

--- a/mifosng-android/src/main/res/values-en/strings.xml
+++ b/mifosng-android/src/main/res/values-en/strings.xml
@@ -187,6 +187,7 @@
     <string name="product_name">Product Name</string>
     <string name="valid">Valid</string>
     <string name="surveyEmpty">This Survey is Empty</string>
+    <string name="accounts">Accounts</string>
 
 
 </resources>

--- a/mifosng-android/src/main/res/values-es/strings.xml
+++ b/mifosng-android/src/main/res/values-es/strings.xml
@@ -163,4 +163,7 @@
     <string name="lang_changed">Idioma cambiado</string>
     <string name="lang_change_description">Seleccione el idioma en el que desea ver la aplicación</string>
     <string name="dark_mode">modo oscuro</string>
+
+    <string name="accounts">cuenta</string>
+
 </resources>

--- a/mifosng-android/src/main/res/values-fr/strings.xml
+++ b/mifosng-android/src/main/res/values-fr/strings.xml
@@ -610,4 +610,6 @@
     <string name="lang_change_description">Sélectionnez la langue dans laquelle vous souhaitez afficher l\'application</string>
     <string name="dark_mode">mode sombre</string>
 
+    <string name="accounts">Compte</string>
+
 </resources>

--- a/mifosng-android/src/main/res/values-hi/strings.xml
+++ b/mifosng-android/src/main/res/values-hi/strings.xml
@@ -614,6 +614,7 @@
     <string name="collectionsheet_submit_success">कलेक्शन शीट सफलतापूर्वक जमा कर दी गई</string>
     <string name="individual_collection_sheet">व्यक्तिगत कलेक्शन शीट</string>
     <string name="due_collection">कलेक्शन का देय</string>
+    <string name="accounts">खाता</string>
 
     !-- About App -->
     <string name="about_app">फील्ड ऑफिसर एप्लीकेशन एक एप्लीकेशन है बैंक स्टाफ फील्ड ऑफिसर के लिए विकसित किया गया

--- a/mifosng-android/src/main/res/values-kn/strings.xml
+++ b/mifosng-android/src/main/res/values-kn/strings.xml
@@ -593,4 +593,7 @@
     <string name="lang_changed">ಭಾಷೆ ಬದಲಾಗಿದೆ</string>
     <string name="lang_change_description">ನೀವು ಅಪ್ಲಿಕೇಶನ್ ವೀಕ್ಷಿಸಲು ಬಯಸುವ ಭಾಷೆಯನ್ನು ಆಯ್ಕೆಮಾಡಿ</string>
     <string name="dark_mode">ಡಾರ್ಕ್ ಮೋಡ್</string>
+
+    <string name="accounts">ಖಾತೆ</string>
+
 </resources>

--- a/mifosng-android/src/main/res/values-sw/strings.xml
+++ b/mifosng-android/src/main/res/values-sw/strings.xml
@@ -722,6 +722,7 @@
     <string name="failed_to_load_db_clients">Upakio wa wateja wa hifadhidata umefeli</string>
     <string name="failed_to_load_db_groups">Upakio wa makundi ya hifadhidata umefeli</string>
     <string name="browse">Vinjari</string>
+    <string name="accounts">akaunti</string>
 
     <!-- Language -->
     <string name="language">Lugha</string>

--- a/mifosng-android/src/main/res/values-zh/strings.xml
+++ b/mifosng-android/src/main/res/values-zh/strings.xml
@@ -711,6 +711,7 @@
     <string name="incorrect_passcode">密码错误</string>
     <string name="incorrect_passcode_more_than_three">您已经输错三次密码了，请再次尝试</string>
     <string name="error_passcode">密码应该是4位数</string>
+    <string name="accounts">帳戶</string>
 
     <!-- Language -->
     <string name="language">语</string>

--- a/mifosng-android/src/main/res/values/strings.xml
+++ b/mifosng-android/src/main/res/values/strings.xml
@@ -834,6 +834,7 @@
     <string name="something_went_wrong">Something went wrong</string>
     <string name="entry">ENTRY</string>
     <string name="network_issue">Network Issue</string>
+    <string name="accounts">Accounts</string>
     <string name="dark_mode">Dark Mode</string>
     <string name="ui">UI</string>
     <string name="dark_mode_def_value">MODE_NIGHT_FOLLOW_SYSTEM</string>
@@ -843,13 +844,6 @@
         <item>Dark</item>
         <item>System Default</item>
     </string-array>
-
-    <string-array name="dark_mode_values"  translatable="false">
-        <item>light</item>
-        <item>dark</item>
-        <item>default</item>
-    </string-array>
-
 
     <!-- About App -->
     <string name="about_app">Field Officer Application is an application
@@ -868,13 +862,18 @@
     <string name="about_license">License</string>
     <string name="about_license_sub">Check Mozilla Public License 2.0</string>
 
+    <string-array name="dark_mode_values"  translatable="false">
+        <item>light</item>
+        <item>dark</item>
+        <item>default</item>
+    </string-array>
+
     <!-- Language -->
     <string name="language">Language</string>
     <string name="language_type" translatable="false">language_type</string>
     <string name="lang_changed">Language Changed</string>
     <string name="lang_change_description">Select the language in which you want to view the app</string>
     <string name="mode_key">dark_mode</string>
-
     <string-array name="language_option" translatable="false">
         <item>Catalan</item>
         <item>English</item>
@@ -885,7 +884,6 @@
         <item>Chinese</item>
         <item>Kannada</item>
     </string-array>
-
     <string-array name="languages_value" translatable="false">
         <item>ca</item>
         <item>en</item>
@@ -896,8 +894,6 @@
         <item>zh</item>
         <item>kn</item>
     </string-array>
-
-
     <string name="passcode">Passcode</string>
     <string name="change_passcode">Change Passcode</string>
     <string name="change_app_passcode">Change App Passcode</string>

--- a/mifosng-android/src/main/res/values/styles_linear.xml
+++ b/mifosng-android/src/main/res/values/styles_linear.xml
@@ -23,6 +23,7 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:orientation">horizontal</item>
+        <item name="android:gravity">center_horizontal</item>
     </style>
 
 </resources>

--- a/mifosng-android/src/main/res/values/styles_table.xml
+++ b/mifosng-android/src/main/res/values/styles_table.xml
@@ -9,13 +9,15 @@
     <style name="Table">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
+        <item name="background">@drawable/table_row_round_bg</item>
     </style>
 
 
     <style name="TableRow">
-        <item name="android:layout_margin">3dp</item>
+        <item name="android:layout_marginTop">8dp</item>
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
+        <item name="android:background">@drawable/table_row_round_bg</item>
     </style>
 
 </resources>

--- a/mifosng-android/src/main/res/values/styles_text.xml
+++ b/mifosng-android/src/main/res/values/styles_text.xml
@@ -30,18 +30,26 @@
     <style name="TextView.Row" parent="TextView.Base">
         <item name="android:layout_width">0dp</item>
         <item name="android:layout_weight">0.5</item>
+        <item name="android:layout_marginLeft">6dp</item>
+        <item name="android:layout_marginTop">6dp</item>
+        <item name="android:layout_marginBottom">6dp</item>
         <item name="android:textColor">@color/secondary_text</item>
     </style>
 
     <style name="TextView.Row.Value" parent="TextView.Row">
         <item name="android:gravity">right</item>
+        <item name="android:layout_marginRight">6dp</item>
+        <item name="android:layout_marginTop">6dp</item>
+        <item name="android:layout_marginBottom">6dp</item>
         <item name="android:textColor">@color/primary_text</item>
     </style>
 
     <style name="TextView.Client" parent="TextView.Base">
-        <item name="android:textColor">@color/secondary_text</item>
+        <item name="android:textColor">@color/primary_text</item>
         <item name="android:textSize">20sp</item>
         <item name="android:layout_gravity">center_vertical</item>
+        <item name="android:layout_marginTop">12dp</item>
+        <item name="android:layout_marginBottom">12dp</item>
     </style>
 
     <style name="TextView.Search" parent="TextView.Base">


### PR DESCRIPTION
Fixes #1562 

## Changes
* Added drawable `round_table_row_bg.xml` for rounded corners in a table row.
* Center aligned the image.
* Client name is now below the image instead of to the right.
* Added `Accounts` header to separate the client info table and accounts elements.
* Modified the padding and margin of account_accordion section

## Screenshot

<img width="335" alt="Screenshot 2020-11-19 at 5 10 13 PM" src="https://user-images.githubusercontent.com/31315800/99661678-33551700-2a8a-11eb-9f81-a3c077ed9f5c.png">


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.