### PR TITLE
fixes #1572 fixed back action on Clients/Centers/Groups section

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DashboardActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DashboardActivity.java
@@ -264,19 +264,19 @@ public class DashboardActivity extends MifosBaseActivity
         String currentFragment = getSupportFragmentManager().findFragmentById(R.id.container)
                 .getClass().getSimpleName();
         switch (currentFragment) {
-            case "SearchFragment":
+            case Constants.SEARCH_FRAGMENT:
                 mNavigationView.setCheckedItem(R.id.item_dashboard);
                 break;
-            case "ClientListFragment":
+            case Constants.CLIENT_LIST_FRAGMENT:
                 mNavigationView.setCheckedItem(R.id.item_clients);
                 break;
-            case "GroupsListFragment":
+            case Constants.GROUP_LIST_FRAGMENT:
                 mNavigationView.setCheckedItem(R.id.item_groups);
                 break;
-            case "CenterListFragment":
+            case Constants.CENTER_LIST_FRAGMENT:
                 mNavigationView.setCheckedItem(R.id.item_centers);
                 break;
-            case "OfflineDashboardFragment":
+            case Constants.OFFLINE_DASHBOARD_FRAGMENT:
                 mNavigationView.setCheckedItem(R.id.item_offline);
         }
     }
@@ -342,6 +342,13 @@ public class DashboardActivity extends MifosBaseActivity
         if (mDrawerLayout != null && mDrawerLayout.isDrawerOpen(GravityCompat.START)) {
             mDrawerLayout.closeDrawer(GravityCompat.START);
         } else {
+            String currentFragment = getSupportFragmentManager()
+                    .findFragmentById(R.id.container)
+                    .getClass().getSimpleName();
+            if (!currentFragment.equalsIgnoreCase(Constants.SEARCH_FRAGMENT)) {
+                replaceFragment(new SearchFragment(), false, R.id.container);
+                return;
+            }
             if (doubleBackToExitPressedOnce) {
                 setMenuCreateClient(true);
                 setMenuCreateCentre(true);

--- a/mifosng-android/src/main/java/com/mifos/utils/Constants.java
+++ b/mifosng-android/src/main/java/com/mifos/utils/Constants.java
@@ -24,6 +24,14 @@ public class Constants {
 
     public static final String API_PATH = "/mifosng-provider/api/v1";
 
+    /**
+     * Fragments
+     */
+    public static final String SEARCH_FRAGMENT = "SearchFragment";
+    public static final String CLIENT_LIST_FRAGMENT = "ClientListFragment";
+    public static final String GROUP_LIST_FRAGMENT = "GroupsListFragment";
+    public static final String CENTER_LIST_FRAGMENT = "CenterListFragment";
+    public static final String OFFLINE_DASHBOARD_FRAGMENT = "OfflineDashboardFragment";
 
     /**
      * Entity Type, Like Clients, Groups, Staff, Loans, Savings and Client Identifiers


### PR DESCRIPTION
Fixes #1572

**Changes**
Pressing back on the `Clients/Groups/Centers` section redirect back to `Dashboard` instead of showing the toast and exiting the app

<img width="335" alt="Screenshot 2020-11-19 at 5 10 13 PM" src="https://user-images.githubusercontent.com/31315800/100210152-ad751800-2f30-11eb-8b3a-0654f378d061.gif">

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.