### PR TITLE
Fixes #1573 replaced static declaration of android:text to tools namespace

### DIFF
--- a/mifosng-android/src/main/res/layout/view_account_accordion_section.xml
+++ b/mifosng-android/src/main/res/layout/view_account_accordion_section.xml
@@ -2,8 +2,10 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginTop="10dp"
-    android:paddingBottom="12dp">
+    android:paddingBottom="12dp"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_marginTop="10dp">
+
 
     <com.joanzapata.iconify.widget.IconTextView
         android:id="@+id/tv_toggle_accounts_icon"
@@ -23,10 +25,11 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_toRightOf="@id/tv_toggle_accounts_icon"
-        android:text="@string/savingAccounts"
         android:layout_toEndOf="@id/tv_toggle_accounts_icon"
         android:layout_marginLeft="12dp"
-        android:layout_marginStart="12dp" />
+        android:layout_marginStart="12dp"
+        tools:text="@string/savingAccounts" />
+
 
     <TextView
         android:id="@+id/tv_count_accounts"


### PR DESCRIPTION
Fixes #1573 

<img width="335" alt="Screenshot 2020-11-19 at 5 10 13 PM" src="https://user-images.githubusercontent.com/31315800/100260814-e54f8000-2f6f-11eb-97e0-c8666b56a7ee.gif">

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.