### PR TITLE
Fixes #1584 Implemented auto toggle when network state changes.

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DashboardActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DashboardActivity.java
@@ -5,8 +5,11 @@
 
 package com.mifos.mifosxdroid.online;
 
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.net.ConnectivityManager;
 import android.os.Bundle;
-
+import android.widget.Toast;
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.core.MifosBaseActivity;
 import com.mifos.mifosxdroid.offlinejobs.OfflineSyncCenter;
@@ -15,6 +18,10 @@ import com.mifos.mifosxdroid.offlinejobs.OfflineSyncGroup;
 import com.mifos.mifosxdroid.offlinejobs.OfflineSyncLoanRepayment;
 import com.mifos.mifosxdroid.offlinejobs.OfflineSyncSavingsAccount;
 import com.mifos.mifosxdroid.online.search.SearchFragment;
+import com.mifos.mifosxdroid.receivers.NetworkChangeReceiver;
+import com.mifos.utils.Constants;
+import com.mifos.utils.PrefManager;
+
 
 import butterknife.ButterKnife;
 
@@ -22,6 +29,8 @@ import butterknife.ButterKnife;
  * Created by shashankpriyadarshi on 19/06/20.
  */
 public class DashboardActivity extends MifosBaseActivity {
+
+    NetworkChangeReceiver receiver;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -31,6 +40,23 @@ public class DashboardActivity extends MifosBaseActivity {
         ButterKnife.bind(this);
         //runJobs();
         replaceFragment(new SearchFragment(), false, R.id.container);
+
+        receiver = new NetworkChangeReceiver();
+        IntentFilter intentFilter = new IntentFilter();
+        intentFilter.addAction(ConnectivityManager.CONNECTIVITY_ACTION);
+        registerReceiver(receiver, intentFilter);
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        int state = intent.getExtras().getInt(getString(R.string.network_state));
+        if (state != PrefManager.getUserStatus()) {
+            String info = "Auto switch to " +
+                    (state == Constants.USER_ONLINE ? "Online" : "offline") +
+                    " mode.";
+            Toast.makeText(this, info, Toast.LENGTH_LONG).show();
+        }
     }
 
     private void runJobs() {

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/receivers/NetworkChangeReceiver.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/receivers/NetworkChangeReceiver.java
@@ -1,0 +1,24 @@
+package com.mifos.mifosxdroid.receivers;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+import com.mifos.mifosxdroid.R;
+import com.mifos.mifosxdroid.online.DashboardActivity;
+import com.mifos.utils.Constants;
+import com.mifos.utils.Network;
+
+public class NetworkChangeReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        int state = Constants.USER_OFFLINE;
+        if (Network.isOnline(context)) {
+            state = Constants.USER_ONLINE;
+        }
+        Intent i = new Intent(context, DashboardActivity.class);
+        i.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        i.putExtra(context.getString(R.string.network_state), state);
+        context.startActivity(i);
+    }
+}

--- a/mifosng-android/src/main/res/values/strings.xml
+++ b/mifosng-android/src/main/res/values/strings.xml
@@ -833,7 +833,6 @@
 
     <string name="accounts">Accounts</string>
 
->>>>>>> 9e9df49d (Intro added in SearchFragment)
     <string name="dark_mode">Dark Mode</string>
     <string name="ui">UI</string>
     <string name="dark_mode_def_value">MODE_NIGHT_FOLLOW_SYSTEM</string>
@@ -911,5 +910,7 @@
     <string name="cb_exactMatch_intro">To get the result matching exactly the keyword entered.\n Simply check this box</string>
     <string name="bt_search_intro">Click this button to make a search.\nClick on three dot icon in top right to create new Client/ Center/ Group or logout.\nExplore the menu by clicking on 3 line icon on top left.</string>
     <string name="et_search_intro">Enter keyword to search among</string>
+
+    <string name="network_state">NETWORK_STATE</string>
 
 </resources>


### PR DESCRIPTION
Fixes #1584 

**Changes**
1. Implemented `NetworkChangeReceiver` broadcast receiver.
2. Registered the receiver in `DashboardActivity`.
3. Override `onNewIntent` method to toggle the app state from offline to online and vice versa.
4. Displays toast whenever auto switch takes place.

**Screenshot**
<img width="335" alt="Screenshot 2020-11-19 at 5 10 13 PM" src="https://user-images.githubusercontent.com/31315800/100720831-93ca4980-33e4-11eb-8aea-c3c4bacb4d4c.gif">

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.