### PR TITLE
Fixes #1588 Auto search added when user add filter in searchFragment

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/search/SearchFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/search/SearchFragment.java
@@ -94,6 +94,9 @@ public class SearchFragment extends MifosBaseFragment implements SearchMvpView,
     @Inject
     SearchPresenter searchPresenter;
 
+    // determines weather search is triggered by user or system
+    boolean autoTriggerSearch = false;
+
     private List<SearchedEntity> searchedEntities;
     private ArrayAdapter<CharSequence> searchOptionsAdapter;
     private String resources;
@@ -206,7 +209,9 @@ public class SearchFragment extends MifosBaseFragment implements SearchMvpView,
             EspressoIdlingResource.increment(); // App is busy until further notice.
             searchPresenter.searchResources(query, resources, cb_exactMatch.isChecked());
         } else {
-            Toaster.show(et_search, getString(R.string.no_search_query_entered));
+            if (!autoTriggerSearch) {
+                Toaster.show(et_search, getString(R.string.no_search_query_entered));
+            }
         }
     }
 
@@ -231,6 +236,7 @@ public class SearchFragment extends MifosBaseFragment implements SearchMvpView,
             fabGroup.setClickable(true);
             isFabOpen = true;
         }
+        autoTriggerSearch = false;
     }
 
     @Override
@@ -322,6 +328,8 @@ public class SearchFragment extends MifosBaseFragment implements SearchMvpView,
             } else {
                 resources = searchOptionsValues[position - 1];
             }
+            autoTriggerSearch = true;
+            onClickSearch();
         }
     }
 


### PR DESCRIPTION
Fixes #1588 

**Changes**
* All changes are made in `SearchFragment.java` file.
1. Added new boolean variable `autoTriggerSearch` to determine whether a click is called by user or user this is used for determining whether a toast is needed to be displayed or not in case of the empty search string.
2. Called the `onClickSearch` inside `onItemSelected`

**Screenshot**
<img width="335" alt="Screenshot 2020-11-19 at 5 10 13 PM" src="https://user-images.githubusercontent.com/31315800/100981917-71176c80-356d-11eb-9b12-4ed4f08fa822.gif">

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.