### PR TITLE
Fixed #1490: Changed sync switch to image button

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/SettingsFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/SettingsFragment.java
@@ -2,12 +2,19 @@ package com.mifos.mifosxdroid;
 
 import android.app.FragmentTransaction;
 import android.os.Bundle;
-import android.preference.Preference;
 import android.preference.PreferenceFragment;
-import android.preference.SwitchPreference;;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageButton;
+import android.widget.Toast;
 
 import com.mifos.mifosxdroid.dialogfragments.syncsurveysdialog.SyncSurveysDialogFragment;
 import com.mifos.utils.FragmentConstants;
+import com.mifos.utils.Network;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
 
 /**
  * Created by mayankjindal on 22/07/17.
@@ -15,7 +22,10 @@ import com.mifos.utils.FragmentConstants;
 
 public class SettingsFragment extends PreferenceFragment {
 
-    SwitchPreference mEnableSyncSurvey;
+    @BindView(R.id.settings_fragment_sync_button)
+    ImageButton syncButton;
+
+    private View rootView;
 
     public static SettingsFragment newInstance() {
         SettingsFragment fragment = new SettingsFragment();
@@ -27,25 +37,31 @@ public class SettingsFragment extends PreferenceFragment {
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        addPreferencesFromResource(R.xml.preferences);
-        mEnableSyncSurvey = (SwitchPreference)
-                findPreference(getResources().getString(R.string.sync_survey));
-        mEnableSyncSurvey.setOnPreferenceChangeListener(
-                new Preference.OnPreferenceChangeListener() {
-                @Override
-                public boolean onPreferenceChange(Preference preference, Object newValue) {
-                    if (((Boolean) newValue)) {
-                        SyncSurveysDialogFragment syncSurveysDialogFragment =
-                                SyncSurveysDialogFragment.newInstance();
-                        FragmentTransaction fragmentTransaction =
-                                getFragmentManager().beginTransaction();
-                            fragmentTransaction.addToBackStack(FragmentConstants.FRAG_SURVEYS_SYNC);
-                        syncSurveysDialogFragment.setCancelable(false);
-                        syncSurveysDialogFragment.show(fragmentTransaction,
-                                getResources().getString(R.string.sync_clients));
-                    }
-                    return true;
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, final ViewGroup container,
+            Bundle savedInstanceState) {
+        rootView = inflater.inflate(R.layout.fragment_settings, container, false);
+        ButterKnife.bind(this, rootView);
+        syncButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (Network.isOnline(container.getContext())) {
+                    SyncSurveysDialogFragment syncSurveysDialogFragment =
+                            SyncSurveysDialogFragment.newInstance();
+                    FragmentTransaction fragmentTransaction =
+                            getFragmentManager().beginTransaction();
+                    fragmentTransaction.addToBackStack(FragmentConstants.FRAG_SURVEYS_SYNC);
+                    syncSurveysDialogFragment.setCancelable(false);
+                    syncSurveysDialogFragment.show(fragmentTransaction,
+                            getResources().getString(R.string.sync_clients));
+                } else {
+                    Toast.makeText(container.getContext(),
+                          "Please Check Your Internet Connection", Toast.LENGTH_SHORT).show();
                 }
-            });
+            }
+        });
+        return rootView;
     }
 }

--- a/mifosng-android/src/main/res/drawable/ic_sync_black_30dp.xml
+++ b/mifosng-android/src/main/res/drawable/ic_sync_black_30dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="30dp" android:tint="?attr/colorControlNormal"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="30dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/black" android:pathData="M12,4L12,1L8,5l4,4L12,6c3.31,0 6,2.69 6,6 0,1.01 -0.25,1.97 -0.7,2.8l1.46,1.46C19.54,15.03 20,13.57 20,12c0,-4.42 -3.58,-8 -8,-8zM12,18c-3.31,0 -6,-2.69 -6,-6 0,-1.01 0.25,-1.97 0.7,-2.8L5.24,7.74C4.46,8.97 4,10.43 4,12c0,4.42 3.58,8 8,8v3l4,-4 -4,-4v3z"/>
+</vector>

--- a/mifosng-android/src/main/res/layout/fragment_settings.xml
+++ b/mifosng-android/src/main/res/layout/fragment_settings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="@dimen/layout_padding_16dp">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true">
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Sync Surveys"
+        android:layout_alignParentLeft="true"
+        android:layout_centerVertical="true"
+        android:layout_alignParentStart="true" />
+
+    <ImageButton
+        android:id="@+id/settings_fragment_sync_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:srcCompat="@drawable/ic_sync_black_30dp"
+        android:background="@android:color/transparent"
+        android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true" />
+
+    </RelativeLayout>
+</RelativeLayout>

--- a/mifosng-android/src/main/res/xml/preferences.xml
+++ b/mifosng-android/src/main/res/xml/preferences.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <SwitchPreference
-        android:key="@string/sync_survey"
-        android:title="@string/sync_survey"/>
-</PreferenceScreen>


### PR DESCRIPTION
Fixes #1490 
Switch has been changed to Image Button and also added **network check** so it won't crash when offline.

![GIF-201206_114320](https://user-images.githubusercontent.com/70195106/101273677-9c909600-37bd-11eb-83ef-e40e4fc82e68.gif)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.