### PR TITLE
Feat #1343: Added new feature of generating PDF from Saving Account Summary

### DIFF
--- a/mifosng-android/src/main/AndroidManifest.xml
+++ b/mifosng-android/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <uses-feature

--- a/mifosng-android/src/main/java/com/mifos/utils/Constants.java
+++ b/mifosng-android/src/main/java/com/mifos/utils/Constants.java
@@ -278,4 +278,5 @@ public class Constants {
     public static final String R_OVERDUE_X = "R_overdueX";
     public static final String R_OVERDUE_Y = "R_overdueY";
     public static final String ACTION_REPORT = "report";
+    public static final String SAVE_AS_PDF = "Save Account Summary as PDF";
 }

--- a/mifosng-android/src/main/res/layout/fragment_savings_account_summary.xml
+++ b/mifosng-android/src/main/res/layout/fragment_savings_account_summary.xml
@@ -20,9 +20,17 @@
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:padding="@dimen/default_vertical_padding">
+        android:paddingBottom="@dimen/default_vertical_padding">
 
-        <LinearLayout
+        <RelativeLayout
+            android:id="@+id/savings_account_summary_pdf_rl"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentTop="true"
+            android:layout_above="@+id/buttons"
+            android:padding="@dimen/default_vertical_padding">
+
+          <LinearLayout
             android:id="@+id/linear_layout_1"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
@@ -48,7 +56,7 @@
                 android:layout_gravity="right|end"
                 android:layout_marginLeft="100dp" />
 
-        </LinearLayout>
+           </LinearLayout>
 
         <View
             android:id="@+id/divider_1"
@@ -204,8 +212,8 @@
             android:id="@+id/lv_savings_transactions"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_above="@+id/buttons"
             android:layout_below="@id/savings_transactions" />
+        </RelativeLayout>
 
         <LinearLayout
             android:id="@+id/buttons"


### PR DESCRIPTION
Feat #1343 
Added new feature of generating PDF from Saving Account Summary. It askes for
**read and write permissions** and also checks for permission before making pdf then it  generates PDF in **Mifos Docs** directory in internal storage with file name as client name.

**Generating PDF**
![GIF-201206_173254](https://user-images.githubusercontent.com/70195106/101279924-e85a3400-37eb-11eb-8b76-381b29a1154b.gif)

**Looking for PDF in storage**
![GIF-201206_173718](https://user-images.githubusercontent.com/70195106/101279994-5e5e9b00-37ec-11eb-8c36-230c99713ad2.gif) 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.