### PR TITLE
Fixes #1601 UI enhancement in CenterDetailsFragment

### DIFF
--- a/mifosng-android/src/main/res/layout/fragment_center_details.xml
+++ b/mifosng-android/src/main/res/layout/fragment_center_details.xml
@@ -10,7 +10,7 @@
     android:id="@+id/rl_center">
 
     <ScrollView style="@style/ScrollView.Base"
-                android:id="@+id/container">
+        android:id="@+id/container">
 
         <TableLayout
             android:id="@+id/tbl_centerDetails"
@@ -22,7 +22,9 @@
                 android:gravity="center_horizontal"
                 style="@style/TextView.Client"
                 android:textColor="@color/black"
-                android:text="@string/center_details"/>
+                android:text="@string/center_details"
+                android:paddingTop="@dimen/dimension_32_dp"
+                android:paddingBottom="@dimen/layout_padding_16dp"/>
 
             <TableRow
                 android:id="@+id/row_activation_date"
@@ -80,15 +82,17 @@
             <TextView
                 android:paddingTop="5dp"
                 android:paddingBottom="5dp"
-                android:layout_height="1dp"
+                android:layout_height="2dp"
                 android:layout_width="match_parent"
-                android:background="@color/black"/>
+                android:background="@color/black"
+                android:layout_marginTop="8dp"/>
 
             <TextView
                 android:layout_height="wrap_content"
                 android:layout_width="wrap_content"
                 android:gravity="center_horizontal"
-                android:paddingTop="16dp"
+                android:paddingTop="@dimen/dimension_32_dp"
+                android:paddingBottom="@dimen/layout_padding_16dp"
                 style="@style/TextView.Client"
                 android:textColor="@color/black"
                 android:text="@string/summary_info"/>

--- a/mifosng-android/src/main/res/values/styles_table.xml
+++ b/mifosng-android/src/main/res/values/styles_table.xml
@@ -18,6 +18,9 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:background">@drawable/table_row_round_bg</item>
+        <item name="android:padding">8dp</item>
+        <item name="android:showDividers">middle</item>
+        <item name="android:divider">@color/primary_dark</item>
     </style>
 
 </resources>

--- a/mifosng-android/src/main/res/values/styles_text.xml
+++ b/mifosng-android/src/main/res/values/styles_text.xml
@@ -34,6 +34,7 @@
         <item name="android:layout_marginTop">6dp</item>
         <item name="android:layout_marginBottom">6dp</item>
         <item name="android:textColor">@color/secondary_text</item>
+        <item name="android:paddingLeft">2dp</item>
     </style>
 
     <style name="TextView.Row.Value" parent="TextView.Row">
@@ -42,6 +43,7 @@
         <item name="android:layout_marginTop">6dp</item>
         <item name="android:layout_marginBottom">6dp</item>
         <item name="android:textColor">@color/primary_text</item>
+        <item name="android:paddingRight">32dp</item>
     </style>
 
     <style name="TextView.Client" parent="TextView.Base">


### PR DESCRIPTION
Fixes #1601 

**Changes**
1. Added table row background.
2. Improved padding between heading and tables.
3. Added margin and padding in tableRow content.

**Screenshots**
<img width='333' alt='ss' src='https://user-images.githubusercontent.com/31315800/101289037-dbefce80-381f-11eb-960c-d103ae51057b.jpeg'>


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.