### PR TITLE
Fixed #1611: BackPressed error removed

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DashboardActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DashboardActivity.java
@@ -346,17 +346,22 @@ public class DashboardActivity extends MifosBaseActivity
                 setMenuCreateClient(true);
                 setMenuCreateCentre(true);
                 setMenuCreateGroup(true);
-                super.onBackPressed();
+                finish();
                 return;
             }
-            this.doubleBackToExitPressedOnce = true;
-            Toast.makeText(this, R.string.back_again, Toast.LENGTH_SHORT).show();
-            new Handler().postDelayed(new Runnable() {
-                @Override
-                public void run() {
-                    doubleBackToExitPressedOnce = false;
-                }
-            }, 2000);
+            if (itemClient && itemGroup && itemCenter) {
+                this.doubleBackToExitPressedOnce = true;
+                Toast.makeText(this, R.string.back_again, Toast.LENGTH_SHORT)
+                        .show();
+                new Handler().postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        doubleBackToExitPressedOnce = false;
+                    }
+                }, 2000);
+            } else {
+                super.onBackPressed();
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #1611 

Check added that ensure proper working and only shows toast when on SearchFragment

![GIF-201209_175855 1](https://user-images.githubusercontent.com/70195106/101631108-d70e6300-3a49-11eb-8ec4-dcc3a7ef8691.gif)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.