### PR TITLE
Fixed #1050: Stop tracking in notification fixed along with start/stop tracking button Preference

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/utils/Constants.java
+++ b/mifosng-android/src/main/java/com/mifos/utils/Constants.java
@@ -215,6 +215,11 @@ public class Constants {
     public static final int USER_OFFLINE = 1;
 
     /**
+     * Constant used for PathTracking Notification ID*/
+    public static final int PATH_TRACKER_NOTIFICATION_ID = 101;
+
+
+    /**
      * Constants to determine in the generic DataTableListFragment, the type of query that
      * has to be forwarded after showing the datatables and adding the values
      * to the corresponding payload.


### PR DESCRIPTION
Fixes #1050 

Stop tracking fixed with notification id added, also when tracking is stopped from notification SERVICE STATUS prefernce wasn't updated that caused stop symbol when user opens activity.

![GIF-201211_131033 1](https://user-images.githubusercontent.com/70195106/101877233-af3b0e80-3bb3-11eb-8ddb-a3f955cacab6.gif)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.