### PR TITLE
Fixed #1619: Bug that didn't changed selected flag of checkerTask list items fixed.

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/checkerinbox/CheckerInboxFragment.kt
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/checkerinbox/CheckerInboxFragment.kt
@@ -31,6 +31,11 @@ class CheckerInboxFragment : MifosBaseFragment(), TextWatcher,
         view_flipper.showNext()
         if (inBadgeProcessingMode) {
             tv_no_of_selected_tasks.text = "0"
+            for (task in selectedCheckerTaskList){
+                if (checkerTaskList.contains(task)){
+                    checkerTaskList[checkerTaskList.indexOf(task)].selectedFlag = false
+                }
+            }
             selectedCheckerTaskList.clear()
             inBadgeProcessingMode = false
             checkerTaskListAdapter.notifyDataSetChanged()
@@ -382,6 +387,11 @@ class CheckerInboxFragment : MifosBaseFragment(), TextWatcher,
         iv_deselect_all.setOnClickListener {
             view_flipper.showNext()
             tv_no_of_selected_tasks.text = "0"
+            for (task in selectedCheckerTaskList){
+                if (checkerTaskList.contains(task)){
+                    checkerTaskList[checkerTaskList.indexOf(task)].selectedFlag = false
+                }
+            }
             selectedCheckerTaskList.clear()
             inBadgeProcessingMode = false
             checkerTaskListAdapter.notifyDataSetChanged()


### PR DESCRIPTION
Fixes #1619 
Bug fixed which didn't changed selected flag in checkTask list item. Now it resets selected flag in both onLong press and dismiss button click.

![fix_checker_1](https://user-images.githubusercontent.com/70195106/101906377-dc50e680-3bde-11eb-9a41-9314bf6b9fd6.gif)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.