### PR TITLE
Fixes #1621 : Fixed bug of visibility change of  checker options on item or checkbox click

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/adapters/CheckerTaskListAdapter.kt
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/adapters/CheckerTaskListAdapter.kt
@@ -103,18 +103,22 @@ class CheckerTaskListAdapter : ListAdapter<CheckerTask,
         init {
             view.setOnClickListener {
                 mListener?.let {
+                    val llCheckerTaskOptions =
+                            view.findViewById<LinearLayout>(R.id.ll_checker_task_options)
                     val position = adapterPosition
                     if (position != RecyclerView.NO_POSITION)
-                        mListener.onItemClick(position)
+                        if (mBadgeProcessMode.isInBadgeProcessingMode()) {
+                            view.cb_checker_task.isChecked = !view.cb_checker_task.isChecked
+                            mBadgeProcessMode.onItemSelectedOrDeselcted(view, adapterPosition)
+                        } else {
+                            mListener.onItemClick(position)
+                            if (llCheckerTaskOptions.visibility == View.GONE) {
+                                llCheckerTaskOptions.visibility = View.VISIBLE
+                            } else {
+                                llCheckerTaskOptions.visibility = View.GONE
+                            }
+                        }
                 }
-                val llCheckerTaskOptions =
-                        view.findViewById<LinearLayout>(R.id.ll_checker_task_options)
-                if (llCheckerTaskOptions.visibility == View.GONE) {
-                    llCheckerTaskOptions.visibility = View.VISIBLE
-                } else {
-                    llCheckerTaskOptions.visibility = View.GONE
-                }
-
             }
 
             view.setOnLongClickListener {

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/checkerinbox/CheckerInboxFragment.kt
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/checkerinbox/CheckerInboxFragment.kt
@@ -19,6 +19,7 @@ import com.mifos.mifosxdroid.core.MifosBaseFragment
 import com.mifos.mifosxdroid.dialogfragments.checkertaskfilterdialog.CheckerTaskFilterDialogFragment
 import com.mifos.objects.CheckerTask
 import kotlinx.android.synthetic.main.checker_inbox_fragment.*
+import kotlinx.android.synthetic.main.item_checker_task.view.*
 import java.sql.Timestamp
 import javax.inject.Inject
 
@@ -446,7 +447,7 @@ class CheckerInboxFragment : MifosBaseFragment(), TextWatcher,
      */
     override fun onItemSelectedOrDeselcted(view: View, position: Int) {
         val task = checkerTaskList[position]
-        if ((view as CheckBox).isChecked) {
+        if (view.cb_checker_task.isChecked) {
             task.selectedFlag = true
             checkerTaskListAdapter.notifyItemChanged(position)
             selectedCheckerTaskList.add(task)


### PR DESCRIPTION
Fixes #1621 

Bug of visibility change of  checker options on item or checkbox click fixed. Now it checker task item is clicked checkbox is checked and if checkbox is checked or unchecked it has no effect on options Linear layout visibility

![checker_fix_3](https://user-images.githubusercontent.com/70195106/101907665-e542b780-3be0-11eb-861e-a46a9029aa07.gif)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.