### PR TITLE
Checker Inbox progress bar bug fixed

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/checkerinbox/CheckerInboxFragment.kt
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/checkerinbox/CheckerInboxFragment.kt
@@ -606,4 +606,14 @@ class CheckerInboxFragment : MifosBaseFragment(), TextWatcher,
         checkerTaskList.addAll(updatedList)
         checkerTaskListAdapter.submitList(checkerTaskList)
     }
+
+    override fun onPause() {
+        super.onPause()
+        hideMifosProgressBar()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        hideMifosProgressBar()
+    }
 }


### PR DESCRIPTION
Fixes #1625 

Checker Inbox progress bar bug fixed. Now progress bar hide when activity is paused or stopped.

![GIF-201212_125520 1](https://user-images.githubusercontent.com/70195106/101978260-94cb6880-3c79-11eb-9d13-3ae5d85cabad.gif)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.