### PR TITLE
Overscroll effect in navigation bar disabled

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DashboardActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DashboardActivity.java
@@ -167,6 +167,7 @@ public class DashboardActivity extends MifosBaseActivity
         mNavigationHeader = mNavigationView.getHeaderView(0);
         setupUserStatusToggle();
         mNavigationView.setNavigationItemSelectedListener(this);
+        mNavigationView.getChildAt(0).setOverScrollMode(View.OVER_SCROLL_NEVER);
 
         // setup drawer layout and sync to toolbar
         ActionBarDrawerToggle actionBarDrawerToggle = new ActionBarDrawerToggle(this,


### PR DESCRIPTION
Fixes #1627 

Overscroll effect of menu in navigation bar is disabled as it isn't meant there and has no meaning until menu is not scrolling.

In video attached below nothing you will find no activity but actually i was scrolling vertically.
![GIF-201212_130543 1](https://user-images.githubusercontent.com/70195106/101978471-38694880-3c7b-11eb-9f27-d9cb3e701d90.gif)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.