### PR TITLE
Feature #1343: Added feature of PDF from Account Summary

### DIFF
--- a/mifosng-android/src/main/AndroidManifest.xml
+++ b/mifosng-android/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 
     <uses-feature
         android:glEsVersion="0x00020000"

--- a/mifosng-android/src/main/java/com/mifos/utils/Constants.java
+++ b/mifosng-android/src/main/java/com/mifos/utils/Constants.java
@@ -278,4 +278,5 @@ public class Constants {
     public static final String R_OVERDUE_X = "R_overdueX";
     public static final String R_OVERDUE_Y = "R_overdueY";
     public static final String ACTION_REPORT = "report";
+    public static final String SAVE_AS_PDF = "Save Account Summary as PDF";
 }

--- a/mifosng-android/src/main/res/layout/fragment_savings_account_summary.xml
+++ b/mifosng-android/src/main/res/layout/fragment_savings_account_summary.xml
@@ -20,6 +20,13 @@
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:paddingBottom="@dimen/default_vertical_padding">
+
+    <RelativeLayout
+        android:id="@+id/savings_account_summary_pdf_rl"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
         android:padding="@dimen/default_vertical_padding">
 
         <LinearLayout
@@ -200,12 +207,14 @@
             android:text="@string/transactions"
             android:textAppearance="?android:attr/textAppearanceMedium" />
 
+    </RelativeLayout>
+
         <ListView
             android:id="@+id/lv_savings_transactions"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_above="@+id/buttons"
-            android:layout_below="@id/savings_transactions" />
+            android:layout_below="@id/savings_account_summary_pdf_rl" />
 
         <LinearLayout
             android:id="@+id/buttons"


### PR DESCRIPTION
Feature #1343  

Added new feature of generating PDF from Saving Account Summary. It askes for **read and write permissions** and also checks for permission before making pdf then it  generates PDF in **Mifos Docs** directory in internal storage with file name as client name. Check for no transactions also added.

**Generating PDF**
![GIF-201214_213829 1](https://user-images.githubusercontent.com/70195106/102105313-4246a380-3e55-11eb-95cb-80f058afa295.gif)

**Sample PDF **
[ok_123.pdf](https://github.com/openMF/android-client/files/5690070/ok_123.1.pdf)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.