### PR TITLE
Fixes #1634: ClientDetailsFragment menu and progress bar bug fixed

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientdetails/ClientDetailsFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientdetails/ClientDetailsFragment.java
@@ -296,7 +296,7 @@ public class ClientDetailsFragment extends MifosBaseFragment implements ClientDe
     @Override
     public void onPrepareOptionsMenu(Menu menu) {
         menu.clear();
-        if (isClientActive) {
+        if (isClientActive && pb_imageProgressBar.getVisibility() != VISIBLE) {
             menu.add(Menu.NONE, MENU_ITEM_DATA_TABLES, Menu.NONE, getString(R.string.more_info));
             menu.add(Menu.NONE, MENU_ITEM_PIN_POINT, Menu.NONE, getString(R.string.pinpoint));
             menu.add(Menu.NONE, MENU_ITEM_CLIENT_CHARGES, Menu.NONE, getString(R.string.charges));
@@ -843,5 +843,17 @@ public class ClientDetailsFragment extends MifosBaseFragment implements ClientDe
                 }
             }
         }
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        showProgressbar(false);
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        showProgressbar(false);
     }
 }


### PR DESCRIPTION
Fixes #1634 

Now menu does not inflate till client details are loading i.e. progress bar is visible and also onPause and onStop added so progress bar is made GONE when fragment is stopped or paused

![GIF-201215_210600 1](https://user-images.githubusercontent.com/70195106/102237031-34a72180-3f1a-11eb-9bb2-fdfdbb6d2621.gif)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.