### PR TITLE
Fix #1648: Error in Loan Transactions icon fixed

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/adapters/LoanTransactionAdapter.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/adapters/LoanTransactionAdapter.java
@@ -14,6 +14,7 @@ import android.widget.TextView;
 
 import com.joanzapata.iconify.Iconify;
 import com.joanzapata.iconify.fonts.MaterialIcons;
+import com.joanzapata.iconify.widget.IconTextView;
 import com.mifos.mifosxdroid.R;
 import com.mifos.objects.accounts.loan.Transaction;
 import com.mifos.objects.accounts.loan.Type;
@@ -109,11 +110,9 @@ public class LoanTransactionAdapter extends BaseExpandableListAdapter {
         MaterialIcons contractedIconValue = MaterialIcons.md_add_circle_outline;
         MaterialIcons expandedIconValue = MaterialIcons.md_remove_circle_outline;
         if (!isExpanded) {
-            reusableParentViewHolder.tv_arrow.setText(String.valueOf(contractedIconValue
-                    .character()));
+            reusableParentViewHolder.tv_arrow.setText("{" + contractedIconValue.key() + "}");
         } else {
-            reusableParentViewHolder.tv_arrow.setText(String.valueOf(expandedIconValue.character
-                    ()));
+            reusableParentViewHolder.tv_arrow.setText("{" + expandedIconValue.key() + "}");
         }
 
         Iconify.addIcons(reusableParentViewHolder.tv_arrow);
@@ -165,7 +164,7 @@ public class LoanTransactionAdapter extends BaseExpandableListAdapter {
     public static class ReusableParentViewHolder {
 
         @BindView(R.id.tv_arrow)
-        TextView tv_arrow;
+        IconTextView tv_arrow;
         @BindView(R.id.tv_transaction_date)
         TextView tv_transactionDate;
         @BindView(R.id.tv_transaction_type)

--- a/mifosng-android/src/main/res/layout/row_loan_transaction_item.xml
+++ b/mifosng-android/src/main/res/layout/row_loan_transaction_item.xml
@@ -14,19 +14,13 @@
     android:paddingRight="4dp"
     android:paddingTop="8dp">
 
-    <TextView
+    <com.joanzapata.iconify.widget.IconTextView
         android:id="@+id/tv_arrow"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginRight="8dp"
-        android:shadowColor="#22000000"
-        android:shadowDx="3"
-        android:shadowDy="3"
-        android:shadowRadius="1"
-        android:text="{fa-android}"
-        android:textColor="@color/black"
-        android:textSize="20sp" />
-
+        android:layout_marginRight="5dp"
+        android:textColor="@color/secondary_text"
+        android:layout_marginEnd="5dp" />
 
     <TextView
         android:id="@+id/tv_transaction_date"


### PR DESCRIPTION
Fixes #1648 
Icons are fixed with + and - sign in circle for collapsed and expanded respectively.

https://user-images.githubusercontent.com/70195106/102696808-1eb99980-4257-11eb-8f58-69e1f68d7683.mp4

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.