### PR TITLE
Fix_#1658: Error handling added to SavingsAccountSummaryFragment

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/savingaccountsummary/SavingsAccountSummaryFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/savingaccountsummary/SavingsAccountSummaryFragment.java
@@ -19,9 +19,11 @@ import android.widget.AdapterView;
 import android.widget.Button;
 import android.widget.ListView;
 import android.widget.QuickContactBadge;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.github.therajanmaurya.sweeterror.SweetUIErrorHandler;
 import com.mifos.api.GenericResponse;
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.adapters.SavingsAccountTransactionsListAdapter;
@@ -98,12 +100,14 @@ public class SavingsAccountSummaryFragment extends ProgressableFragment
     @Inject
     SavingsAccountSummaryPresenter mSavingAccountSummaryPresenter;
 
+    private RelativeLayout mainLayout;
+    private SweetUIErrorHandler sweetUIErrorHandler;
     // Cached List of all savings account transactions
     // that are used for inflation of rows in
     // Infinite Scroll View
     List<Transaction> listOfAllTransactions = new ArrayList<Transaction>();
     SavingsAccountTransactionsListAdapter savingsAccountTransactionsListAdapter;
-    private View rootView;
+    private View rootView, layoutError;
     private int processSavingTransactionAction = -1;
     private SavingsAccountWithAssociations savingsAccountWithAssociations;
     private boolean parentFragment = true;
@@ -148,7 +152,9 @@ public class SavingsAccountSummaryFragment extends ProgressableFragment
         ((MifosBaseActivity) getActivity()).getActivityComponent().inject(this);
         ButterKnife.bind(this, rootView);
         mSavingAccountSummaryPresenter.attachView(this);
-
+        mainLayout = rootView.findViewById(R.id.saving_account_summary_rl);
+        layoutError = rootView.findViewById(R.id.saving_account_summary_layout_error);
+        sweetUIErrorHandler = new SweetUIErrorHandler(getActivity(), rootView);
         mSavingAccountSummaryPresenter
                 .loadSavingAccount(savingsAccountType.getEndpoint(), savingsAccountNumber);
         return rootView;
@@ -432,8 +438,17 @@ public class SavingsAccountSummaryFragment extends ProgressableFragment
 
     @Override
     public void showFetchingError(int s) {
+        sweetUIErrorHandler.showSweetErrorUI(String.valueOf(s), R.drawable.ic_error_black_24dp,
+                mainLayout, layoutError);
         Toast.makeText(getActivity(), s, Toast.LENGTH_SHORT).show();
 
+    }
+
+    @OnClick(R.id.btn_try_again)
+    public void reloadOnError() {
+        sweetUIErrorHandler.hideSweetErrorLayoutUI(mainLayout, layoutError);
+        mSavingAccountSummaryPresenter
+                .loadSavingAccount(savingsAccountType.getEndpoint(), savingsAccountNumber);
     }
 
     @Override

--- a/mifosng-android/src/main/res/layout/fragment_savings_account_summary.xml
+++ b/mifosng-android/src/main/res/layout/fragment_savings_account_summary.xml
@@ -18,6 +18,7 @@
         android:layout_gravity="center" />
 
     <RelativeLayout
+        android:id="@+id/saving_account_summary_rl"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:padding="@dimen/default_vertical_padding">
@@ -234,4 +235,11 @@
 
         </LinearLayout>
     </RelativeLayout>
+
+    <include
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        layout="@layout/layout_sweet_exception_handler"
+        android:visibility="gone"
+        android:id="@+id/saving_account_summary_layout_error"/>
 </ViewFlipper>


### PR DESCRIPTION
Fixes #1658 

Now if accidentally error occurs in loading Saving or Recurring account then instead of showing empty details page it will show error page that will give more clear idea to user of what happened

https://user-images.githubusercontent.com/70195106/102806525-10988400-43e3-11eb-867f-90de71d04e3f.mp4

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.