### PR TITLE
Fixes_#1660: Progress bar error in CreateNewCenterFragment fixed

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/createnewcenter/CreateNewCenterFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/createnewcenter/CreateNewCenterFragment.java
@@ -302,4 +302,16 @@ public class CreateNewCenterFragment extends MifosBaseFragment
     public void onDetach() {
         super.onDetach();
     }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        showProgressbar(false);
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        showProgressbar(false);
+    }
 }


### PR DESCRIPTION
Fixes #1660 
Now progress bar is dismissed as soon as CreateNewCenterFragment is paused or stopped.

https://user-images.githubusercontent.com/70195106/102808945-2a3bca80-43e7-11eb-893c-f19be4fea91b.mp4

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.