### PR TITLE
Fix_#1662: Error handling added in LoanAccountSummaryFragment

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/loanaccountsummary/LoanAccountSummaryFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/loanaccountsummary/LoanAccountSummaryFragment.java
@@ -17,9 +17,11 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.QuickContactBadge;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.github.therajanmaurya.sweeterror.SweetUIErrorHandler;
 import com.mifos.mifosxdroid.R;
 import com.mifos.mifosxdroid.core.MifosBaseActivity;
 import com.mifos.mifosxdroid.core.ProgressableFragment;
@@ -147,8 +149,10 @@ public class LoanAccountSummaryFragment extends ProgressableFragment
     @Inject
     LoanAccountSummaryPresenter mLoanAccountSummaryPresenter;
 
+    private RelativeLayout mainLayout;
+    private SweetUIErrorHandler sweetUIErrorHandler;
     List<Charges> chargesList = new ArrayList<Charges>();
-    private View rootView;
+    private View rootView, layoutError;
     // Action Identifier in the onProcessTransactionClicked Method
     private int processLoanTransactionAction = -1;
     private boolean parentFragment = true;
@@ -190,7 +194,9 @@ public class LoanAccountSummaryFragment extends ProgressableFragment
 
         ButterKnife.bind(this, rootView);
         mLoanAccountSummaryPresenter.attachView(this);
-
+        mainLayout = rootView.findViewById(R.id.loan_account_summary_rl);
+        layoutError = rootView.findViewById(R.id.loan_account_summary_layout_error);
+        sweetUIErrorHandler = new SweetUIErrorHandler(getActivity(), rootView);
         inflateLoanAccountSummary();
 
         return rootView;
@@ -437,7 +443,15 @@ public class LoanAccountSummaryFragment extends ProgressableFragment
 
     @Override
     public void showFetchingError(String s) {
+        sweetUIErrorHandler.showSweetErrorUI(s, R.drawable.ic_error_black_24dp,
+                mainLayout, layoutError);
         Toast.makeText(getActivity(), s, Toast.LENGTH_SHORT).show();
+    }
+
+    @OnClick(R.id.btn_try_again)
+    public void reloadOnError() {
+        sweetUIErrorHandler.hideSweetErrorLayoutUI(mainLayout, layoutError);
+        mLoanAccountSummaryPresenter.loadLoanById(loanAccountNumber);
     }
 
     @Override

--- a/mifosng-android/src/main/res/layout/fragment_loan_account_summary.xml
+++ b/mifosng-android/src/main/res/layout/fragment_loan_account_summary.xml
@@ -23,6 +23,7 @@
         android:padding="@dimen/default_vertical_padding">
 
         <RelativeLayout
+            android:id="@+id/loan_account_summary_rl"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
@@ -497,4 +498,11 @@
 
         </RelativeLayout>
     </ScrollView>
+
+    <include
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        layout="@layout/layout_sweet_exception_handler"
+        android:visibility="gone"
+        android:id="@+id/loan_account_summary_layout_error"/>
 </ViewFlipper>


### PR DESCRIPTION
Fixes #1662
Now if accidentally error occurs in loading Saving or Recurring account then instead of showing empty details page it will show error page that will give more clear idea to user of what happened

https://user-images.githubusercontent.com/70195106/102812559-37f44e80-43ed-11eb-9adc-f0cf73e13d7b.mp4

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.