### PR TITLE
Fixes_#1668: Error handling added in CreateNewClientFragment

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/createnewclient/CreateNewClientFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/createnewclient/CreateNewClientFragment.java
@@ -32,10 +32,12 @@ import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.LinearLayout;
+import android.widget.ScrollView;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.github.therajanmaurya.sweeterror.SweetUIErrorHandler;
 import com.mifos.exceptions.InvalidTextInputException;
 import com.mifos.exceptions.RequiredFieldException;
 import com.mifos.mifosxdroid.R;
@@ -127,8 +129,10 @@ public class CreateNewClientFragment extends ProgressableFragment
     @Inject
     CreateNewClientPresenter createNewClientPresenter;
 
-    View rootView;
+    View rootView, layoutError;
     // It checks whether the user wants to create the new client with or without picture
+    private ScrollView mainLayout;
+    private SweetUIErrorHandler sweetUIErrorHandler;
     private boolean createClientWithImage = false;
     private boolean hasDataTables;
     private Integer returnedClientId;
@@ -185,6 +189,9 @@ public class CreateNewClientFragment extends ProgressableFragment
         ((MifosBaseActivity) getActivity()).getActivityComponent().inject(this);
         ButterKnife.bind(this, rootView);
         createNewClientPresenter.attachView(this);
+        mainLayout = rootView.findViewById(R.id.create_new_client_sl);
+        layoutError = rootView.findViewById(R.id.create_new_client_layout_error);
+        sweetUIErrorHandler = new SweetUIErrorHandler(getActivity(), rootView);
 
         showUserInterface();
 
@@ -432,6 +439,12 @@ public class CreateNewClientFragment extends ProgressableFragment
         staffAdapter.notifyDataSetChanged();
     }
 
+    @OnClick(R.id.btn_try_again)
+    public void reloadOnError() {
+        sweetUIErrorHandler.hideSweetErrorLayoutUI(mainLayout, layoutError);
+        createNewClientPresenter.loadClientTemplate();
+    }
+
     @Override
     public void showClientCreatedSuccessfully(int message) {
         Toaster.show(rootView, message);
@@ -445,6 +458,8 @@ public class CreateNewClientFragment extends ProgressableFragment
 
     @Override
     public void showMessage(int message) {
+        sweetUIErrorHandler.showSweetErrorUI(getStringMessage(message), R.drawable.ic_error_black_24dp,
+                mainLayout, layoutError);
         Toaster.show(rootView, message);
     }
 

--- a/mifosng-android/src/main/res/layout/fragment_create_new_client.xml
+++ b/mifosng-android/src/main/res/layout/fragment_create_new_client.xml
@@ -16,6 +16,7 @@
 
     <!-- Actual content -->
     <ScrollView
+        android:id="@+id/create_new_client_sl"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent">
 
@@ -328,4 +329,11 @@
 
         </LinearLayout>
     </ScrollView>
+
+    <include
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        layout="@layout/layout_sweet_exception_handler"
+        android:visibility="gone"
+        android:id="@+id/create_new_client_layout_error"/>
 </ViewFlipper>


### PR DESCRIPTION
Fixes #1668 

Now if accidentally error occurs in loading Saving or Recurring account then instead of showing empty details page it will show error page that will give more clear idea to user of what happened

https://user-images.githubusercontent.com/70195106/102922162-9552d300-44b3-11eb-9abd-bf720d044584.mp4

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.