### PR TITLE
Fixes_#1672: Padding applied to table header in LoanRepaymentScheduleFragment

### DIFF
--- a/mifosng-android/src/main/res/layout/fragment_loan_repayment_schedule.xml
+++ b/mifosng-android/src/main/res/layout/fragment_loan_repayment_schedule.xml
@@ -33,7 +33,8 @@
                 android:id="@+id/tableRow3"
                 android:layout_width="fill_parent"
                 android:layout_height="fill_parent"
-                android:background="@color/transaction_detail_table_header_bg">
+                android:background="@color/transaction_detail_table_header_bg"
+                android:padding="8dp">
 
                 <LinearLayout
                     android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #1672 
Padding applied to table header in LoanRepaymentScheduleFragment. Now it look better than before

<img src="https://user-images.githubusercontent.com/70195106/103139730-3c7a7900-4705-11eb-974c-55a0b20bd6e9.jpeg" width="333" alt="ss">

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.