### PR TITLE
Fixes_#1674: Top padding added to Group name in fragment_group_details.xml

### DIFF
--- a/mifosng-android/src/main/res/layout/fragment_group_details.xml
+++ b/mifosng-android/src/main/res/layout/fragment_group_details.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_marginStart="@dimen/default_padding"
@@ -11,7 +12,16 @@
 
         <LinearLayout style="@style/LinearLayout.Base">
 
-            <LinearLayout style="@style/LinearLayout.Width">
+            <LinearLayout style="@style/LinearLayout.Width"
+                android:paddingTop="@dimen/layout_padding_16dp">
+
+                <androidx.appcompat.widget.AppCompatImageView
+                    android:id="@+id/iv_clientImage"
+                    android:layout_width="50dp"
+                    android:layout_height="50dp"
+                    android:padding="5dp"
+                    app:srcCompat="@drawable/ic_group_black_24dp"
+                    android:layout_gravity="center"/>
 
                 <TextView
                     android:id="@+id/tv_groupsName"


### PR DESCRIPTION
Fixes #1674 
Top padding added to Group name in fragment_group_details.xml

<img src="https://user-images.githubusercontent.com/70195106/103440719-06417a00-4c6e-11eb-92cd-b5151da396c1.jpeg" alt="ss" width="333">

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.