### PR TITLE
Fix #1676: GroupDetailsFragment menu and progress bar bug fixed

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/groupdetails/GroupDetailsFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/groupdetails/GroupDetailsFragment.java
@@ -315,7 +315,6 @@ public class GroupDetailsFragment extends MifosBaseFragment implements GroupDeta
         }
     }
 
-
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         inflater.inflate(R.menu.menu_group, menu);
@@ -324,28 +323,41 @@ public class GroupDetailsFragment extends MifosBaseFragment implements GroupDeta
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.more_group_info:
-                loadGroupDataTables();
-                break;
-            case R.id.documents:
-                loadDocuments();
-                break;
-            case R.id.add_group_savings_account:
-                addGroupSavingsAccount();
-                break;
-            case R.id.add_group_loan:
-                addGroupLoanAccount();
-                break;
-            case R.id.group_clients:
-                mGroupDetailsPresenter.loadGroupAssociateClients(groupId);
-                break;
-            case R.id.group_notes:
-                loadNotes();
-                break;
-
+        if (rlGroup.getVisibility() == VISIBLE) {
+            switch (item.getItemId()) {
+                case R.id.more_group_info:
+                    loadGroupDataTables();
+                    break;
+                case R.id.documents:
+                    loadDocuments();
+                    break;
+                case R.id.add_group_savings_account:
+                    addGroupSavingsAccount();
+                    break;
+                case R.id.add_group_loan:
+                    addGroupLoanAccount();
+                    break;
+                case R.id.group_clients:
+                    mGroupDetailsPresenter.loadGroupAssociateClients(groupId);
+                    break;
+                case R.id.group_notes:
+                    loadNotes();
+                    break;
+            }
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        showProgressbar(false);
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        showProgressbar(false);
     }
 
     @Override


### PR DESCRIPTION
Fixes #1676
GroupDetailsFragment menu and progress bar bug fixed. Now if user clickes menu item when details are loading, that click on item will have no effect.

https://user-images.githubusercontent.com/70195106/103141350-2f678500-4719-11eb-9369-b49501539cb6.mp4

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.