### PR TITLE
Fixes_#1679: BackPress problem in fragments fixed

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DashboardActivity.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/DashboardActivity.java
@@ -342,21 +342,26 @@ public class DashboardActivity extends MifosBaseActivity
         if (mDrawerLayout != null && mDrawerLayout.isDrawerOpen(GravityCompat.START)) {
             mDrawerLayout.closeDrawer(GravityCompat.START);
         } else {
-            if (doubleBackToExitPressedOnce) {
-                setMenuCreateClient(true);
-                setMenuCreateCentre(true);
-                setMenuCreateGroup(true);
-                super.onBackPressed();
-                return;
-            }
-            this.doubleBackToExitPressedOnce = true;
-            Toast.makeText(this, R.string.back_again, Toast.LENGTH_SHORT).show();
-            new Handler().postDelayed(new Runnable() {
-                @Override
-                public void run() {
-                    doubleBackToExitPressedOnce = false;
+            Fragment fragment = getSupportFragmentManager().findFragmentById(R.id.container);
+            if (fragment instanceof SearchFragment) {
+                if (doubleBackToExitPressedOnce) {
+                    setMenuCreateClient(true);
+                    setMenuCreateCentre(true);
+                    setMenuCreateGroup(true);
+                    finish();
+                    return;
                 }
-            }, 2000);
+                this.doubleBackToExitPressedOnce = true;
+                Toast.makeText(this, R.string.back_again, Toast.LENGTH_SHORT).show();
+                new Handler().postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        doubleBackToExitPressedOnce = false;
+                    }
+                }, 2000);
+            } else {
+                replaceFragment(new SearchFragment(), false, R.id.container);
+            }
         }
     }
 
@@ -401,16 +406,16 @@ public class DashboardActivity extends MifosBaseActivity
     }
 
     public void openCreateClient() {
-        replaceFragment(CreateNewClientFragment.newInstance(), true, R.id.container);
+        replaceFragment(CreateNewClientFragment.newInstance(), false, R.id.container);
     }
 
     public void openCreateCenter() {
-        replaceFragment(CreateNewCenterFragment.newInstance(), true, R.id.container);
+        replaceFragment(CreateNewCenterFragment.newInstance(), false, R.id.container);
 
     }
 
     public void openCreateGroup() {
-        replaceFragment(CreateNewGroupFragment.newInstance(), true, R.id.container);
+        replaceFragment(CreateNewGroupFragment.newInstance(), false, R.id.container);
     }
 
     @VisibleForTesting


### PR DESCRIPTION
Fixes #1679 
Now if search fragment is current fragment then only toast message is shown or else current fragment or activity is replaced by `new SearchFragment()`.

https://user-images.githubusercontent.com/70195106/103147154-52755180-4778-11eb-8677-901da48cc396.mp4

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.