### PR TITLE
Fixes #1708: Visibility check added to list of accounts in GroupDetailsFragment

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/groupdetails/GroupDetailsFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/groupdetails/GroupDetailsFragment.java
@@ -266,6 +266,8 @@ public class GroupDetailsFragment extends MifosBaseFragment implements GroupDeta
                     mListener.loadLoanAccountSummary(adapter.getItem(i).getId());
                 }
             });
+        } else {
+            getActivity().findViewById(R.id.account_accordion_section_loans).setVisibility(GONE);
         }
 
         if (groupAccounts.getNonRecurringSavingsAccounts().size() > 0) {
@@ -281,6 +283,8 @@ public class GroupDetailsFragment extends MifosBaseFragment implements GroupDeta
                             adapter.getItem(i).getDepositType());
                 }
             });
+        } else {
+            getActivity().findViewById(R.id.account_accordion_section_savings).setVisibility(GONE);
         }
 
         if (groupAccounts.getRecurringSavingsAccounts().size() > 0) {
@@ -296,6 +300,9 @@ public class GroupDetailsFragment extends MifosBaseFragment implements GroupDeta
                             adapter.getItem(i).getDepositType());
                 }
             });
+        } else {
+            getActivity().findViewById(R.id.account_accordion_section_recurring)
+                    .setVisibility(GONE);
         }
     }
 


### PR DESCRIPTION
Fixes #1708 
Now if accounts are not associated with group then that section list is not visible. 

https://user-images.githubusercontent.com/70195106/103679899-76703880-4fab-11eb-9849-0fc06626cae5.mp4


- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.