### PR TITLE
Fixes #1712: Drawables added to LoginActivity edittexts

### DIFF
--- a/mifosng-android/src/main/res/drawable/ic_lock_black_24dp.xml
+++ b/mifosng-android/src/main/res/drawable/ic_lock_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM12,17c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2zM15.1,8L8.9,8L8.9,6c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2z"/>
+</vector>

--- a/mifosng-android/src/main/res/drawable/ic_wrapped_lock_black_24dp.xml
+++ b/mifosng-android/src/main/res/drawable/ic_wrapped_lock_black_24dp.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_lock_black_24dp"/>
+</layer-list>

--- a/mifosng-android/src/main/res/drawable/ic_wrapped_person_black_24dp.xml
+++ b/mifosng-android/src/main/res/drawable/ic_wrapped_person_black_24dp.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_person_black_24dp"/>
+</layer-list>

--- a/mifosng-android/src/main/res/layout/activity_login.xml
+++ b/mifosng-android/src/main/res/layout/activity_login.xml
@@ -33,7 +33,10 @@
                 <EditText
                     android:id="@+id/et_username"
                     style="@style/EditText.Username"
-                    android:nextFocusDown="@+id/et_password" />
+                    android:nextFocusDown="@+id/et_password"
+                    android:drawableLeft="@drawable/ic_wrapped_person_black_24dp"
+                    android:drawablePadding="8dp"
+                    android:drawableStart="@drawable/ic_wrapped_person_black_24dp" />
 
             </com.google.android.material.textfield.TextInputLayout>
 
@@ -46,7 +49,10 @@
                 <EditText
                     android:id="@+id/et_password"
                     style="@style/EditText.Password"
-                    android:imeOptions="actionNext" />
+                    android:imeOptions="actionNext"
+                    android:drawableLeft="@drawable/ic_wrapped_lock_black_24dp"
+                    android:drawablePadding="8dp"
+                    android:drawableStart="@drawable/ic_wrapped_lock_black_24dp" />
             </com.google.android.material.textfield.TextInputLayout>
 
 


### PR DESCRIPTION
Fixes #1712 

<img width="333" src="https://user-images.githubusercontent.com/70195106/104354728-aa110c80-552f-11eb-85a1-fe678f3c6f7c.jpeg">


- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.