### PR TITLE
FIxes #1720 : Added padding in Center details fragment

### DIFF
--- a/mifosng-android/src/main/res/layout/fragment_center_details.xml
+++ b/mifosng-android/src/main/res/layout/fragment_center_details.xml
@@ -20,12 +20,15 @@
                 android:layout_height="wrap_content"
                 android:layout_width="wrap_content"
                 android:gravity="center_horizontal"
+                android:padding="@dimen/layout_padding_16dp"
                 style="@style/TextView.Client"
                 android:textColor="@color/black"
                 android:text="@string/center_details"/>
 
             <TableRow
                 android:id="@+id/row_activation_date"
+                android:paddingStart="@dimen/layout_padding_16dp"
+                android:paddingEnd="@dimen/layout_padding_16dp"
                 style="@style/TableRow">
 
                 <TextView
@@ -39,6 +42,8 @@
 
             <TableRow
                 android:id="@+id/row_meeting_date"
+                android:paddingStart="@dimen/layout_padding_16dp"
+                android:paddingEnd="@dimen/layout_padding_16dp"
                 style="@style/TableRow">
 
                 <TextView
@@ -52,6 +57,8 @@
 
             <TableRow
                 android:id="@+id/row_meeting_frequency"
+                android:paddingStart="@dimen/layout_padding_16dp"
+                android:paddingEnd="@dimen/layout_padding_16dp"
                 style="@style/TableRow">
 
                 <TextView
@@ -66,6 +73,9 @@
 
             <TableRow
                 android:id="@+id/row_staff_name"
+                android:paddingStart="@dimen/layout_padding_16dp"
+                android:paddingEnd="@dimen/layout_padding_16dp"
+                android:paddingBottom="@dimen/layout_padding_16dp"
                 style="@style/TableRow">
 
                 <TextView
@@ -88,13 +98,15 @@
                 android:layout_height="wrap_content"
                 android:layout_width="wrap_content"
                 android:gravity="center_horizontal"
-                android:paddingTop="16dp"
+                android:padding="16dp"
                 style="@style/TextView.Client"
                 android:textColor="@color/black"
                 android:text="@string/summary_info"/>
 
             <TableRow
                 android:id="@+id/row_active_clients"
+                android:paddingStart="@dimen/layout_padding_16dp"
+                android:paddingEnd="@dimen/layout_padding_16dp"
                 style="@style/TableRow">
 
                 <TextView
@@ -108,6 +120,8 @@
 
             <TableRow
                 android:id="@+id/row_active_group_loans"
+                android:paddingStart="@dimen/layout_padding_16dp"
+                android:paddingEnd="@dimen/layout_padding_16dp"
                 style="@style/TableRow">
 
                 <TextView
@@ -121,6 +135,8 @@
 
             <TableRow
                 android:id="@+id/row_active_client_loans"
+                android:paddingStart="@dimen/layout_padding_16dp"
+                android:paddingEnd="@dimen/layout_padding_16dp"
                 style="@style/TableRow">
 
                 <TextView
@@ -135,6 +151,8 @@
 
             <TableRow
                 android:id="@+id/row_active_group_borrowers"
+                android:paddingStart="@dimen/layout_padding_16dp"
+                android:paddingEnd="@dimen/layout_padding_16dp"
                 style="@style/TableRow">
 
                 <TextView
@@ -148,6 +166,8 @@
 
             <TableRow
                 android:id="@+id/row_active_client_borrowers"
+                android:paddingStart="@dimen/layout_padding_16dp"
+                android:paddingEnd="@dimen/layout_padding_16dp"
                 style="@style/TableRow">
 
                 <TextView
@@ -161,6 +181,8 @@
 
             <TableRow
                 android:id="@+id/row_active_overdue_group_loans"
+                android:paddingStart="@dimen/layout_padding_16dp"
+                android:paddingEnd="@dimen/layout_padding_16dp"
                 style="@style/TableRow">
 
                 <TextView
@@ -174,6 +196,8 @@
 
             <TableRow
                 android:id="@+id/row_active_overdue_client_loans"
+                android:paddingStart="@dimen/layout_padding_16dp"
+                android:paddingEnd="@dimen/layout_padding_16dp"
                 style="@style/TableRow">
 
                 <TextView


### PR DESCRIPTION
Fixes #1720

<img src = "https://user-images.githubusercontent.com/52701183/104844829-5d934b80-58f8-11eb-9dea-6cd1e6644fff.jpg" width = "300" height = "900">


- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.