### PR TITLE
Fixes #1728: String error fixed in Datatables

### DIFF
--- a/mifosng-android/src/main/res/values/strings.xml
+++ b/mifosng-android/src/main/res/values/strings.xml
@@ -700,7 +700,7 @@
     <string name="failed_to_fetch_loan_products">Failed to fetch LoanProducts</string>
     <string name="failed_to_fetch_loan_template">Failed to fetch Loan Template</string>
     <string name="failed_to_fetch_center_info">Failed to fetch center info</string>
-    <string name="failed_to_fetch_datatable_info">Failed to fetch DataTableInfo</string>
+    <string name="failed_to_fetch_datatable_info">Failed to fetch DataTable Info</string>
     <string name="failed_to_fetch_loan_transaction_template">Failed to fetch loan transaction
         template</string>
     <string name="generic_failure_message">Request failed. Please try again.</string>


### PR DESCRIPTION
Fixes #1728 
String error fixed

https://user-images.githubusercontent.com/70195106/105811706-09acf480-5fd3-11eb-9dc2-b3af658b6675.mp4

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.