### PR TITLE
Fixes #1730: Text Error in FormToggleButton fixed

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/formwidgets/FormToggleButton.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/formwidgets/FormToggleButton.java
@@ -38,10 +38,7 @@ public class FormToggleButton extends FormWidget {
         switchButton.setLayoutParams(weightedLayoutParams);
         switchButton.setGravity(Gravity.CENTER_HORIZONTAL);
         switchButton.setSwitchMinWidth(50);
-        switchButton.setShowText(true);
         switchButton.setChecked(false);
-        switchButton.setTextOn("True");
-        switchButton.setTextOff("False");
         switchButton.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton compoundButton, boolean b) {


### PR DESCRIPTION
Fixes #1730 
Now simple toggle button is visible. 

https://user-images.githubusercontent.com/70195106/105815668-4d0a6180-5fd9-11eb-8d17-133bc9a4e4bc.mp4


- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.