### PR TITLE
Fixes #1738 : Previous search results unnecessarily showing error fixed

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/search/SearchFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/search/SearchFragment.java
@@ -131,6 +131,8 @@ public class SearchFragment extends MifosBaseFragment implements SearchMvpView,
 
     @Override
     public void showNoResultFound() {
+        searchedEntities.clear();
+        searchAdapter.notifyDataSetChanged();
         showAlertDialog(getString(R.string.dialog_message),
                 getString(R.string.no_search_result_found));
     }


### PR DESCRIPTION
Fixes #1738 

Previous search results cleared if no current search results are found in Search Fragment.

https://user-images.githubusercontent.com/67901968/106143596-03687500-6199-11eb-97b4-6c269fb7b12f.mp4

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.