### PR TITLE
Fixes_#1742: Charges text view reformatted in Payment Details

### DIFF
--- a/mifosng-android/src/main/res/layout/add_payment_detail.xml
+++ b/mifosng-android/src/main/res/layout/add_payment_detail.xml
@@ -67,7 +67,7 @@
                 android:layout_height="wrap_content"
                 android:orientation="horizontal">
                 <TextView
-                    android:layout_width="120dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
                     android:textStyle="bold"
@@ -75,7 +75,7 @@
                     android:text="@string/total_charges"/>
 
                 <TextView
-                    android:layout_width="match_parent"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:id="@+id/tv_total_charges"
                     android:layout_marginTop="16dp"


### PR DESCRIPTION
Fixes #1742 

Text view dimensions are edited and bottom padding is added.

<img src="https://user-images.githubusercontent.com/70195106/106758611-b7657680-6657-11eb-98b5-2d6ca4e1830f.jpeg" width="333">

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.