### PR TITLE
Fixes #1748 : Lag on adding savings account fixed.

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/savingsaccount/SavingsAccountFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/savingsaccount/SavingsAccountFragment.java
@@ -16,6 +16,7 @@ import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
+import android.widget.LinearLayout;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -102,6 +103,9 @@ public class SavingsAccountFragment extends ProgressableDialogFragment implement
     @BindView(R.id.btn_submit)
     Button btnSubmit;
 
+    @BindView(R.id.ll_add_savings_account)
+    LinearLayout llAddSavingsAccount;
+
     @Inject
     SavingsAccountPresenter mSavingsAccountPresenter;
 
@@ -154,6 +158,8 @@ public class SavingsAccountFragment extends ProgressableDialogFragment implement
 
         ButterKnife.bind(this, rootView);
         mSavingsAccountPresenter.attachView(this);
+
+        llAddSavingsAccount.setVisibility(View.INVISIBLE);
 
         inflateSubmissionDate();
         inflateSavingsSpinners();
@@ -279,6 +285,8 @@ public class SavingsAccountFragment extends ProgressableDialogFragment implement
         tvInterestPeriod.setText(savingProductsTemplate.getInterestPostingPeriodType().getValue());
         tvDaysInYear.setText(savingProductsTemplate.
                 getInterestCalculationDaysInYearType().getValue());
+
+        llAddSavingsAccount.setVisibility(View.VISIBLE);
     }
 
     @Override

--- a/mifosng-android/src/main/res/layout/fragment_add_savings_account.xml
+++ b/mifosng-android/src/main/res/layout/fragment_add_savings_account.xml
@@ -17,7 +17,9 @@
         android:layout_width="fill_parent"
         android:layout_height="fill_parent">
 
-        <LinearLayout style="@style/LinearLayout.Base">
+        <LinearLayout
+            android:id="@+id/ll_add_savings_account"
+            style="@style/LinearLayout.Base">
 
             <TextView
                 style="@style/TextView.CreateSavingsAccount"


### PR DESCRIPTION
Fixes #1748 

This issue occurs since there are 2  times notifyDataSetChanged() called for 2 adapters in code at different times and in different functions (one for saving products and other for field officers) which is necessary though.        
So, I think the best we can do is just hide this from the user.

https://user-images.githubusercontent.com/67901968/107019972-527d5e00-67c8-11eb-8d22-18a0e8dc4a60.mp4

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.