### PR TITLE
Fixes #1750 : Lag on adding loan account fixed

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/grouploanaccount/GroupLoanAccountFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/grouploanaccount/GroupLoanAccountFragment.java
@@ -17,6 +17,7 @@ import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
+import android.widget.LinearLayout;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -131,6 +132,9 @@ public class GroupLoanAccountFragment extends ProgressableDialogFragment
     @BindView(R.id.sp_linking_options)
     Spinner spLinkingOptions;
 
+    @BindView(R.id.ll_add_loan)
+    LinearLayout llAddLoan;
+
     @Inject
     GroupLoanAccountPresenter mGroupLoanAccountPresenter;
 
@@ -226,6 +230,9 @@ public class GroupLoanAccountFragment extends ProgressableDialogFragment
 
         ButterKnife.bind(this, rootView);
         mGroupLoanAccountPresenter.attachView(this);
+
+        // Hiding it now so it will be visible once everything is loaded for users
+        llAddLoan.setVisibility(View.INVISIBLE);
 
         //Linking Options not yet implemented for Groups but the layout file is shared.
         //So, hiding the widgets
@@ -506,6 +513,9 @@ public class GroupLoanAccountFragment extends ProgressableDialogFragment
         }
 
         showDefaultValues();
+
+        // Making it visible since everything is ready now
+        llAddLoan.setVisibility(View.VISIBLE);
     }
 
     @Override

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/loanaccount/LoanAccountFragment.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/loanaccount/LoanAccountFragment.java
@@ -18,6 +18,7 @@ import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
+import android.widget.LinearLayout;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -142,6 +143,9 @@ public class LoanAccountFragment extends ProgressableDialogFragment
     @BindView(R.id.btn_loan_submit)
     Button btnLoanSubmit;
 
+    @BindView(R.id.ll_add_loan)
+    LinearLayout llAddLoan;
+
     @Inject
     LoanAccountPresenter mLoanAccountPresenter;
 
@@ -231,6 +235,8 @@ public class LoanAccountFragment extends ProgressableDialogFragment
         ButterKnife.bind(this, rootView);
         mLoanAccountPresenter.attachView(this);
 
+        // Hiding it now so it will be visible once everything is loaded for users
+        llAddLoan.setVisibility(View.INVISIBLE);
 
         inflateSubmissionDate();
         inflateDisbursementDate();
@@ -570,6 +576,9 @@ public class LoanAccountFragment extends ProgressableDialogFragment
         mInterestTypeOptionsAdapter.notifyDataSetChanged();
 
         showDefaultValues();
+
+        // Making it visible since everything is ready now
+        llAddLoan.setVisibility(View.VISIBLE);
 
     }
 

--- a/mifosng-android/src/main/res/layout/fragment_add_loan.xml
+++ b/mifosng-android/src/main/res/layout/fragment_add_loan.xml
@@ -17,7 +17,9 @@
         android:layout_width="fill_parent"
         android:layout_height="fill_parent">
 
-        <LinearLayout style="@style/LinearLayout.Base">
+        <LinearLayout
+            android:id="@+id/ll_add_loan"
+            style="@style/LinearLayout.Base">
 
             <TextView
                 style="@style/TextView.CreateLoanAccount"


### PR DESCRIPTION
Fixes #1750 

This issue occurs since there are many times notifyDataSetChanged() called for many adapters in code at different times and in different functions (for different spinners) which is necessary though.
So, I think the best we can do is just hide this from the user.

https://user-images.githubusercontent.com/67901968/107121187-15dc6000-68b7-11eb-8696-c62dae82ffee.mp4

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.