### PR TITLE
Fixes #1794: No Task view added to CheckerInboxFragment

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/checkerinbox/CheckerInboxFragment.kt
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/checkerinbox/CheckerInboxFragment.kt
@@ -602,6 +602,13 @@ class CheckerInboxFragment : MifosBaseFragment(), TextWatcher,
      * @param updatedList List<CheckerTask>
      */
     private fun updateRecyclerViewWithNewList(updatedList: List<CheckerTask>) {
+        if (updatedList.isEmpty()){
+            rv_checker_inbox.visibility = View.GONE
+            ll_error.visibility = View.VISIBLE
+        } else {
+            rv_checker_inbox.visibility = View.VISIBLE
+            ll_error.visibility = View.GONE
+        }
         checkerTaskList.clear()
         checkerTaskList.addAll(updatedList)
         checkerTaskListAdapter.submitList(checkerTaskList)

--- a/mifosng-android/src/main/res/layout/checker_inbox_fragment.xml
+++ b/mifosng-android/src/main/res/layout/checker_inbox_fragment.xml
@@ -142,9 +142,37 @@
     </ViewFlipper>
 
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rv_checker_inbox"
+    <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_checker_inbox"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+        <LinearLayout
+            android:id="@+id/ll_error"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <ImageView
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:layout_gravity="center"
+                app:srcCompat="@drawable/ic_error_black_24dp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="@string/no_tasks_checker_inbox" />
+
+        </LinearLayout>
+
+    </RelativeLayout>
 
 </LinearLayout>

--- a/mifosng-android/src/main/res/values/strings.xml
+++ b/mifosng-android/src/main/res/values/strings.xml
@@ -834,5 +834,6 @@
     <string name="something_went_wrong">Something went wrong</string>
     <string name="entry">ENTRY</string>
     <string name="network_issue">Network Issue</string>
+    <string name="no_tasks_checker_inbox">No Tasks found</string>
 
 </resources>


### PR DESCRIPTION
Fixes #1794 
It works for both keyboard input and filters. It will solve both #1794  and #1764 

https://user-images.githubusercontent.com/70195106/109268485-2a19da00-7831-11eb-987b-4d077dc1f761.mp4



- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.