### PR TITLE
Fixes #1570 : (Fixed) Swipe Refresh Layout is refreshing when pressed back button(twice) while creating groups

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/groupslist/GroupsListFragment.kt
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/groupslist/GroupsListFragment.kt
@@ -264,7 +264,6 @@ class GroupsListFragment : MifosBaseFragment(), GroupsListMvpView, RecyclerItemC
      * @param show Status of Progressbar or SwipeRefreshLayout
      */
     override fun showProgressbar(show: Boolean) {
-        swipeRefreshLayout!!.isRefreshing = show
         if (show && mGroupListAdapter!!.itemCount == 0) {
             pb_groups!!.visibility = View.VISIBLE
             swipeRefreshLayout!!.isRefreshing = false


### PR DESCRIPTION
Fixes #1570 :
✓    Apply the MifosStyle.xml style template to your code in Android Studio.
✓    Run the unit tests with ./gradlew check to make sure you didn't break anything

✓    If you have multiple commits please combine them into one commit by squashing them.

