### PR TITLE
mifos-android-sdk-arch dependency added, with major fixes in dependency clashes

### DIFF
--- a/mifosng-android/build.gradle
+++ b/mifosng-android/build.gradle
@@ -122,6 +122,7 @@ android {
         exclude 'LICENSE.txt'
         exclude 'META-INF/LICENSE.txt'
         exclude 'META-INF/dbflow-kotlinextensions-compileReleaseKotlin.kotlin_module'
+        exclude 'META-INF/rxjava.properties'
     }
     useLibrary 'org.apache.http.legacy'
 
@@ -131,6 +132,11 @@ android {
             events 'passed', 'skipped', 'failed', 'standardOut', 'standardError'
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
 }
 
 task buildAndEMailAPK(type: Exec, description: 'Builds and Generates a Signed APK and emails it') {
@@ -154,7 +160,9 @@ dependencies {
 
     implementation fileTree(dir: 'src/main/libs', include: ['*.jar'])
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"){
+        force = true
+    }
 
     //DBFlow dependencies
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
@@ -209,7 +217,7 @@ dependencies {
     implementation "com.squareup.okhttp3:logging-interceptor:$rootProject.okHttp3Version"
     implementation "com.jakewharton.fliptables:fliptables:$rootProject.flipTableVersion"
     implementation 'com.github.therajanmaurya:Sweet-Error:1.0.0'
-    implementation 'javax.annotation:jsr250-api:1.0@jar'
+    //implementation ('javax.annotation:jsr250-api:1.0@jar')
 
     implementation 'io.reactivex:rxandroid:1.1.0'
     implementation 'io.reactivex:rxjava:1.1.4'
@@ -256,6 +264,8 @@ dependencies {
     implementation 'androidx.cardview:cardview:1.0.0'
     //preferences
     implementation "androidx.preference:preference:$preference"
+
+    implementation 'com.github.danishjamal104:mifos-android-sdk-arch:2.1.1-alpha'
 }
 
 /*

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/injection/component/ApplicationComponent.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/injection/component/ApplicationComponent.java
@@ -40,6 +40,8 @@ import com.mifos.mifosxdroid.offlinejobs.OfflineSyncGroup;
 import com.mifos.mifosxdroid.offlinejobs.OfflineSyncLoanRepayment;
 import com.mifos.mifosxdroid.offlinejobs.OfflineSyncSavingsAccount;
 
+import org.mifos.core.sharedpreference.UserPreferences;
+
 import javax.inject.Singleton;
 
 import dagger.Component;
@@ -89,6 +91,11 @@ public interface ApplicationComponent {
     DatabaseHelperSavings databaseHelperSavings();
     DatabaseHelperSurveys databaseHelperSurveys();
     DatabaseHelperNote databaseHelperNote();
+
+    UserPreferences userPreferences();
+    org.mifos.core.apimanager.BaseApiManager baseApiManager();
+    org.mifos.core.datamanager.auth.DataManagerAuth sdkDataManagerAuth();
+
 
     void inject(OfflineSyncCenter offlineSyncCenter);
 

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/injection/module/ApplicationModule.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/injection/module/ApplicationModule.java
@@ -6,6 +6,9 @@ import android.content.Context;
 import com.mifos.api.BaseApiManager;
 import com.mifos.mifosxdroid.injection.ApplicationContext;
 
+import org.mifos.core.datamanager.auth.DataManagerAuth;
+import org.mifos.core.sharedpreference.UserPreferences;
+
 import javax.inject.Singleton;
 
 import dagger.Module;
@@ -38,6 +41,25 @@ public class ApplicationModule {
     @Singleton
     BaseApiManager provideBaseApiManager() {
         return new BaseApiManager();
+    }
+
+    @Provides
+    @Singleton
+    UserPreferences provideSdkUserPreferences(Application application) {
+        return new UserPreferences(application);
+    }
+
+    @Provides
+    @Singleton
+    org.mifos.core.apimanager.BaseApiManager provideSdkBaseApiManager(UserPreferences preferences) {
+        return org.mifos.core.apimanager.BaseApiManager.Companion.getInstance(preferences);
+    }
+
+    @Provides
+    @Singleton
+    DataManagerAuth providesSdkDataManagerAuth(org.mifos.core.apimanager.BaseApiManager apiManager)
+    {
+        return DataManagerAuth.Companion.getInstance(apiManager);
     }
 
 }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/login/LoginPresenter.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/login/LoginPresenter.java
@@ -21,6 +21,8 @@ public class LoginPresenter extends BasePresenter<LoginMvpView> {
 
     private final DataManagerAuth dataManagerAuth;
     private Subscription subscription;
+    @Inject
+    org.mifos.core.datamanager.auth.DataManagerAuth sdkDataManagerAuth;
 
     @Inject
     public LoginPresenter(DataManagerAuth dataManager) {
@@ -43,6 +45,7 @@ public class LoginPresenter extends BasePresenter<LoginMvpView> {
         if (subscription != null && !subscription.isUnsubscribed()) {
             subscription.unsubscribe();
         }
+
         subscription = dataManagerAuth.login(username, password)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribeOn(Schedulers.io())

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientcharge/ClientChargePresenter.kt
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientcharge/ClientChargePresenter.kt
@@ -42,7 +42,7 @@ class ClientChargePresenter @Inject constructor(private val mDataManagerCharge: 
                         mvpView!!.showProgressbar(false)
                         try {
                             if (e is HttpException) {
-                                val errorMessage = e.response().errorBody()
+                                val errorMessage = e.response()!!.errorBody()!!
                                         .string()
                                 mvpView!!.showFetchingErrorCharges(MFErrorParser
                                         .parseError(errorMessage)

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientdetails/ClientDetailsPresenter.kt
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientdetails/ClientDetailsPresenter.kt
@@ -5,6 +5,7 @@ import com.mifos.api.datamanager.DataManagerDataTable
 import com.mifos.mifosxdroid.base.BasePresenter
 import com.mifos.objects.zipmodels.ClientAndClientAccounts
 import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import okhttp3.ResponseBody
@@ -36,7 +37,7 @@ class ClientDetailsPresenter @Inject constructor(private val mDataManagerDataTab
         val imagePath = pngFile.absolutePath
 
         // create RequestBody instance from file
-        val requestFile = RequestBody.create(MediaType.parse("image/png"), pngFile)
+        val requestFile = RequestBody.create("image/png".toMediaTypeOrNull(), pngFile)
 
         // MultipartBody.Part is used to send also the actual file name
         val body = MultipartBody.Part.createFormData("file", pngFile.name, requestFile)

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/collectionsheetindividual/NewIndividualCollectionSheetPresenter.kt
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/collectionsheetindividual/NewIndividualCollectionSheetPresenter.kt
@@ -49,7 +49,7 @@ class NewIndividualCollectionSheetPresenter @Inject internal constructor(private
                         mvpView!!.showProgressbar(false)
                         if (e is HttpException) {
                             try {
-                                val errorMessage = e.response().errorBody()
+                                val errorMessage = e.response()!!.errorBody()!!
                                         .string()
                                 mvpView!!.showError(MFErrorParser.parseError(errorMessage)
                                         .errors[0].defaultUserMessage)
@@ -84,7 +84,7 @@ class NewIndividualCollectionSheetPresenter @Inject internal constructor(private
                         mvpView!!.showProgressbar(false)
                         try {
                             if (e is HttpException) {
-                                val errorMessage = e.response().errorBody()
+                                val errorMessage = e.response()!!.errorBody()!!
                                         .string()
                                 mvpView!!.showError(MFErrorParser.parseError(errorMessage)
                                         .errors[0].defaultUserMessage)
@@ -113,7 +113,7 @@ class NewIndividualCollectionSheetPresenter @Inject internal constructor(private
                         mvpView!!.showProgressbar(false)
                         try {
                             if (e is HttpException) {
-                                val errorMessage = e.response().errorBody()
+                                val errorMessage = e.response()!!.errorBody()!!
                                         .string()
                                 mvpView!!.showError(MFErrorParser.parseError(errorMessage)
                                         .errors[0].defaultUserMessage)

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/collectionsheetindividualdetails/IndividualCollectionSheetDetailsPresenter.kt
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/collectionsheetindividualdetails/IndividualCollectionSheetDetailsPresenter.kt
@@ -47,7 +47,7 @@ class IndividualCollectionSheetDetailsPresenter @Inject internal constructor(pri
                         mvpView!!.showProgressbar(false)
                         try {
                             if (e is HttpException) {
-                                val errorMessage = e.response().errorBody()
+                                val errorMessage = e.response()!!.errorBody()!!
                                         .string()
                                 mvpView!!.showError(MFErrorParser.parseError(errorMessage)
                                         .errors[0].defaultUserMessage)

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/createnewclient/CreateNewClientPresenter.kt
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/createnewclient/CreateNewClientPresenter.kt
@@ -13,6 +13,7 @@ import com.mifos.objects.templates.clients.ClientsTemplate
 import com.mifos.objects.templates.clients.Options
 import com.mifos.utils.MFErrorParser
 import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import okhttp3.ResponseBody
@@ -122,7 +123,7 @@ class CreateNewClientPresenter @Inject constructor(private val mDataManagerClien
                         mvpView!!.showProgressbar(false)
                         try {
                             if (e is HttpException) {
-                                val errorMessage = e.response().errorBody()
+                                val errorMessage = e.response()!!.errorBody()!!
                                         .string()
                                 mvpView!!.showMessage(MFErrorParser.parseError(errorMessage)
                                         .errors[0].defaultUserMessage)
@@ -176,7 +177,7 @@ class CreateNewClientPresenter @Inject constructor(private val mDataManagerClien
         val imagePath = pngFile.absolutePath
 
         // create RequestBody instance from file
-        val requestFile = RequestBody.create(MediaType.parse("image/png"), pngFile)
+        val requestFile = RequestBody.create("image/png".toMediaTypeOrNull(), pngFile)
 
         // MultipartBody.Part is used to send also the actual file name
         val body = MultipartBody.Part.createFormData("file", pngFile.name, requestFile)

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/loanaccountapproval/LoanAccountApprovalPresenter.kt
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/loanaccountapproval/LoanAccountApprovalPresenter.kt
@@ -40,7 +40,7 @@ class LoanAccountApprovalPresenter @Inject constructor(private val mDataManager:
                         mvpView!!.showProgressbar(false)
                         try {
                             if (e is HttpException) {
-                                val errorMessage = e.response().errorBody()
+                                val errorMessage = e.response()!!.errorBody()!!
                                         .string()
                                 mvpView!!.showLoanApproveFailed(
                                         MFErrorParser.parseError(errorMessage)

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/loancharge/LoanChargePresenter.kt
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/loancharge/LoanChargePresenter.kt
@@ -39,7 +39,7 @@ class LoanChargePresenter @Inject constructor(private val mDataManager: DataMana
                         mvpView!!.showProgressbar(false)
                         try {
                             if (e is HttpException) {
-                                val errorMessage = e.response().errorBody()
+                                val errorMessage = e.response()!!.errorBody()!!
                                         .string()
                                 mvpView!!.showFetchingError(MFErrorParser
                                         .parseError(errorMessage)

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/sign/SignaturePresenter.kt
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/sign/SignaturePresenter.kt
@@ -5,6 +5,7 @@ import com.mifos.api.datamanager.DataManagerDocument
 import com.mifos.mifosxdroid.R
 import com.mifos.mifosxdroid.base.BasePresenter
 import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import rx.Subscriber
@@ -54,7 +55,7 @@ class SignaturePresenter @Inject constructor(private val mDataManagerDocument: D
 
     private fun getRequestFileBody(file: File?): MultipartBody.Part {
         // create RequestBody instance from file
-        val requestFile = RequestBody.create(MediaType.parse("multipart/form-data"), file)
+        val requestFile = RequestBody.create("multipart/form-data".toMediaTypeOrNull(), file!!)
 
         // MultipartBody.Part is used to send also the actual file name
         return MultipartBody.Part.createFormData("file", file!!.name, requestFile)


### PR DESCRIPTION
**Below are the changes**
- Added mifos-sdk-arch dependency.
- Resolved the dependency clash.
- Added new UserPreferences, BaseApiManager and DataManagerAuth in dependency graph,
- Injected the DatamanagerAuth instance in `LoginPresenter`.
- Null asserted call added after altering the version of Kotlin.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.