### PR TITLE
Fixes 1817 : mifos sdk auth integrated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,5 +26,5 @@ ext {
     butterKnifeVersion = '8.0.1'
     mifosPasscodeVersion = '0.3.0'
     preference = '1.1.0'
-
+    mifosSdkVersion = '1.0.0-alpha'
 }

--- a/mifosng-android/build.gradle
+++ b/mifosng-android/build.gradle
@@ -265,7 +265,7 @@ dependencies {
     //preferences
     implementation "androidx.preference:preference:$preference"
 
-    implementation 'com.github.danishjamal104:mifos-android-sdk-arch:2.3.2-alpha'
+    implementation "com.github.openMF:mifos-android-sdk-arch:$mifosSdkVersion"
 }
 
 /*

--- a/mifosng-android/src/main/java/com/mifos/api/datamanager/DataManagerAuth.java
+++ b/mifosng-android/src/main/java/com/mifos/api/datamanager/DataManagerAuth.java
@@ -1,7 +1,9 @@
 package com.mifos.api.datamanager;
 
 import com.mifos.api.BaseApiManager;
+import com.mifos.api.mappers.UserMapper;
 import com.mifos.objects.user.User;
+import com.mifos.utils.PrefManager;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -15,10 +17,13 @@ import rx.Observable;
 public class DataManagerAuth {
 
     private final BaseApiManager baseApiManager;
+    private final org.mifos.core.apimanager.BaseApiManager sdkBaseApiManager;
 
     @Inject
-    public DataManagerAuth(BaseApiManager baseApiManager) {
+    public DataManagerAuth(BaseApiManager baseApiManager,
+                           org.mifos.core.apimanager.BaseApiManager sdkBaseApiManager) {
         this.baseApiManager = baseApiManager;
+        this.sdkBaseApiManager = sdkBaseApiManager;
     }
 
     /**
@@ -27,6 +32,12 @@ public class DataManagerAuth {
      * @return Basic OAuth
      */
     public Observable<User> login(String username, String password) {
-        return baseApiManager.getAuthApi().authenticate(username, password);
+        sdkBaseApiManager.createService(username, password,
+                PrefManager.INSTANCE.getInstanceUrl(),
+                PrefManager.INSTANCE.getTenant());
+        String body = String.format("{\"username\": \"%s\", \"password\": \"%s\"}",
+                username, password);
+        return sdkBaseApiManager.getAuthApi().authenticate(true, body)
+                .map(UserMapper.INSTANCE::mapFromEntity);
     }
 }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/injection/module/ApplicationModule.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/injection/module/ApplicationModule.java
@@ -40,4 +40,10 @@ public class ApplicationModule {
         return new BaseApiManager();
     }
 
+    @Provides
+    @Singleton
+    org.mifos.core.apimanager.BaseApiManager provideSdkBaseApiManager() {
+        return org.mifos.core.apimanager.BaseApiManager.Companion.getInstance();
+    }
+
 }

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/login/LoginPresenter.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/login/LoginPresenter.java
@@ -4,7 +4,6 @@ import com.mifos.api.datamanager.DataManagerAuth;
 import com.mifos.mifosxdroid.base.BasePresenter;
 import com.mifos.objects.user.User;
 import com.mifos.utils.MFErrorParser;
-
 import javax.inject.Inject;
 
 import retrofit2.adapter.rxjava.HttpException;

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientdetails/ClientDetailsPresenter.kt
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/clientdetails/ClientDetailsPresenter.kt
@@ -5,7 +5,6 @@ import com.mifos.api.datamanager.DataManagerDataTable
 import com.mifos.mifosxdroid.base.BasePresenter
 import com.mifos.objects.zipmodels.ClientAndClientAccounts
 import okhttp3.MediaType
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import okhttp3.ResponseBody
@@ -37,7 +36,7 @@ class ClientDetailsPresenter @Inject constructor(private val mDataManagerDataTab
         val imagePath = pngFile.absolutePath
 
         // create RequestBody instance from file
-        val requestFile = RequestBody.create("image/png".toMediaTypeOrNull(), pngFile)
+        val requestFile = RequestBody.create(MediaType.parse("image/png"), pngFile)
 
         // MultipartBody.Part is used to send also the actual file name
         val body = MultipartBody.Part.createFormData("file", pngFile.name, requestFile)

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/createnewclient/CreateNewClientPresenter.kt
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/createnewclient/CreateNewClientPresenter.kt
@@ -13,7 +13,6 @@ import com.mifos.objects.templates.clients.ClientsTemplate
 import com.mifos.objects.templates.clients.Options
 import com.mifos.utils.MFErrorParser
 import okhttp3.MediaType
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import okhttp3.ResponseBody
@@ -177,7 +176,7 @@ class CreateNewClientPresenter @Inject constructor(private val mDataManagerClien
         val imagePath = pngFile.absolutePath
 
         // create RequestBody instance from file
-        val requestFile = RequestBody.create("image/png".toMediaTypeOrNull(), pngFile)
+        val requestFile = RequestBody.create(MediaType.parse("image/png"), pngFile)
 
         // MultipartBody.Part is used to send also the actual file name
         val body = MultipartBody.Part.createFormData("file", pngFile.name, requestFile)

--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/sign/SignaturePresenter.kt
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/online/sign/SignaturePresenter.kt
@@ -5,7 +5,6 @@ import com.mifos.api.datamanager.DataManagerDocument
 import com.mifos.mifosxdroid.R
 import com.mifos.mifosxdroid.base.BasePresenter
 import okhttp3.MediaType
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import rx.Subscriber
@@ -55,7 +54,7 @@ class SignaturePresenter @Inject constructor(private val mDataManagerDocument: D
 
     private fun getRequestFileBody(file: File?): MultipartBody.Part {
         // create RequestBody instance from file
-        val requestFile = RequestBody.create("multipart/form-data".toMediaTypeOrNull(), file!!)
+        val requestFile = RequestBody.create(MediaType.parse("multipart/form-data"), file!!)
 
         // MultipartBody.Part is used to send also the actual file name
         return MultipartBody.Part.createFormData("file", file!!.name, requestFile)


### PR DESCRIPTION
Fixes #1817 

**Changes this PR introduces**
- Added `implementation 'com.github.openMF:mifos-android-sdk-arch:1.0.0-alpha'` dependency.
- Injected SDK's `BaseApiManager` as Application Module.
- Modified DataManagerAuth
    - Injected new SDK's `BaseApiManager`
    - Modified `login(String username, String password)` function to use above injected manager for api request.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.