### PR TITLE
Alert Dialog Fixed

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/core/MaterialDialog.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/core/MaterialDialog.java
@@ -5,6 +5,7 @@ import android.content.DialogInterface;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AlertDialog;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.mifos.mifosxdroid.R;
 
 /**
@@ -15,18 +16,18 @@ public final class MaterialDialog  {
 
     public static class Builder {
 
-        private AlertDialog.Builder mMaterialDialogBuilder;
+        private MaterialAlertDialogBuilder mMaterialDialogBuilder;
 
         //This is the Default Builder Initialization with Material Style
         public Builder init(Context context) {
             mMaterialDialogBuilder =
-                    new AlertDialog.Builder(context, R.style.MaterialAlertDialogStyle);
+                    new MaterialAlertDialogBuilder(context, R.style.MaterialAlertDialogStyle);
             return this;
         }
 
         //This method set the custom Material Style
         public Builder init(Context context, int theme) {
-            mMaterialDialogBuilder = new AlertDialog.Builder(context, theme);
+            mMaterialDialogBuilder = new MaterialAlertDialogBuilder(context, theme);
             return this;
         }
 

--- a/mifosng-android/src/main/res/values/styles.xml
+++ b/mifosng-android/src/main/res/values/styles.xml
@@ -51,7 +51,8 @@
         <item name="android:textColor">@color/primary_text</item>
     </style>
 
-    <style name="MaterialAlertDialogStyle" parent="Theme.AppCompat.Light.Dialog.Alert">
+    <style name="MaterialAlertDialogStyle" parent="Theme.MaterialComponents.Dialog.Alert">
+        <item name="colorPrimary">@color/primary</item>
         <item name="colorAccent">@color/primary</item>
         <item name="android:textColorPrimary">@color/black</item>
         <item name="android:background">@color/white</item>


### PR DESCRIPTION
Fixes #1943

The app uses `DialogBuilder`  class to create all the alerts used in the app. The `DialogBuilder` used `Appcompat.Alertdialog` but this is now changed to `MaterialAlertDialogBuilder` and uses same styling. Modifying `DialogBuilder` class will fix all the alert dialogs in the app.

[checker_inbox_solution.webm](https://user-images.githubusercontent.com/67843799/232235604-9834b904-5dbe-41c4-ab70-def0ec4de7dc.webm)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.