### PR TITLE
Fixes Use of implicit PendingIntents vulnerability detected by CodeQL

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/activity/pathtracking/PathTrackingService.java
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/activity/pathtracking/PathTrackingService.java
@@ -224,7 +224,7 @@ public class PathTrackingService extends Service implements GoogleApiClient.Conn
         Intent resultIntent = new Intent();
         resultIntent.setAction(Constants.STOP_TRACKING);
         PendingIntent intentBroadCast = PendingIntent.getBroadcast(this, 0, resultIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT);
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
         notification.addAction(R.drawable.ic_assignment_turned_in_black_24dp,
                 getString(R.string.stop_tracking), intentBroadCast);
 


### PR DESCRIPTION
Fixes #1979 
By setting the FLAG_IMMUTABLE, we're telling Android that once the PendingIntent is created, it can't be changed by any other app. This makes it much more difficult for a malicious app to exploit the PendingIntent.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.