### PR TITLE
docs: updated slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This is an Android Application built on top of the [MifosX](https://mifosforge.j
 
 ## Join Us on Slack
 
-Mifos boasts an active and vibrant contributor community, Please join us on [slack](https://mifos.slack.com/). Once you've joined the mifos slack community, please join the `#android-client` channel to engage with android-client development.
+Mifos boasts an active and vibrant contributor community, Please join us on [slack](https://join.slack.com/t/mifos/shared_invite/zt-2f4nr6tk3-ZJlHMi1lc0R19FFEHxdvng). Once you've joined the mifos slack community, please join the `#android-client` channel to engage with android-client development.
 
 ## Demo credentials
 Fineract Instance: gsoc.mifos.community


### PR DESCRIPTION
Fixes #2084

I see people are not able to join the slack community with https://mifos.slack.com/ because its not a invitation link and just a workspace link.
Updated the slack link to https://join.slack.com/t/mifos/shared_invite/zt-2f4nr6tk3-ZJlHMi1lc0R19FFEHxdvng which is a invitation link of workspace whose expiry sets to never.
