### PR TITLE
Minor Ui changes to HomeNavigation file

### DIFF
--- a/mifosng-android/src/main/java/com/mifos/mifosxdroid/navigation/HomeNavigation.kt
+++ b/mifosng-android/src/main/java/com/mifos/mifosxdroid/navigation/HomeNavigation.kt
@@ -142,7 +142,9 @@ fun HomeNavigation() {
                             contentDescription = null
                         )
                         Text(
-                            text = "Mifos", color = Color.White,
+                            text = "Mifos",
+                            modifier = Modifier.padding(top = 12.dp, start = 4.dp),
+                            color = Color.White,
                             style = TextStyle(
                                 fontSize = 14.sp,
                                 fontWeight = FontWeight.Medium,
@@ -157,6 +159,7 @@ fun HomeNavigation() {
                         ) {
                             Text(
                                 text = "Offline Mode", color = Color.White,
+                                modifier = Modifier.padding(start = 4.dp),
                                 style = TextStyle(
                                     fontSize = 14.sp,
                                     fontWeight = FontWeight.Medium,


### PR DESCRIPTION
Fixes #Issue_Number
The string "Mifos " lacked padding and stuck to the profile picture as shown in the below screenshot. Hence, some  padding has been added to it. The strings have also been aligned with the profile picture.

No other implementation has been tampered with.

Before
![WhatsApp Image 2024-10-31 at 16 50 55_e7ee10e3](https://github.com/user-attachments/assets/26ef0a9d-0db9-4299-b3aa-e4daffa5696f)

After:
![WhatsApp Image 2024-10-31 at 16 50 56_49618cb0](https://github.com/user-attachments/assets/2e692f12-9471-4bd0-bd75-03001a971d83)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [ ] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.