### PR TITLE
fix(feature:client): resolve early empty state and dialog layout in identifiers

### DIFF
--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientIdentifiers/ClientIdentifiersScreen.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientIdentifiers/ClientIdentifiersScreen.kt
@@ -227,7 +227,6 @@ private fun ClientIdentifiersItem(
     onDocumentClicked: (Int) -> Unit,
 ) {
     var showMenu by remember { mutableStateOf(false) }
-    val lightGreen = MaterialTheme.colorScheme.tertiaryContainer // Or define a custom one
 
     ElevatedCard(
         modifier = Modifier.padding(8.dp),

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientIdentifiers/ClientIdentifiersViewModel.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientIdentifiers/ClientIdentifiersViewModel.kt
@@ -21,7 +21,6 @@ import com.mifos.core.data.repository.ClientIdentifiersRepository
 import com.mifos.core.domain.useCases.DeleteIdentifierUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 
 class ClientIdentifiersViewModel(
@@ -47,18 +46,21 @@ class ClientIdentifiersViewModel(
     }
 
     fun loadIdentifiers(clientId: Int) = viewModelScope.launch {
-        _clientIdentifiersUiState.value =
-            ClientIdentifiersUiState.Loading
-        clientIdentifiersRepository.getClientIdentifiers(clientId)
-            .catch {
-                _clientIdentifiersUiState.value =
-                    ClientIdentifiersUiState.Error(
-                        Res.string.feature_client_failed_to_load_client_identifiers,
-                    )
-            }.collect {
-                _clientIdentifiersUiState.value =
-                    ClientIdentifiersUiState.ClientIdentifiers(it.data ?: emptyList())
+        clientIdentifiersRepository.getClientIdentifiers(clientId).collect { result ->
+            when (result) {
+                is DataState.Error ->
+                    _clientIdentifiersUiState.value =
+                        ClientIdentifiersUiState.Error(Res.string.feature_client_failed_to_load_client_identifiers)
+
+                is DataState.Loading ->
+                    _clientIdentifiersUiState.value =
+                        ClientIdentifiersUiState.Loading
+
+                is DataState.Success ->
+                    _clientIdentifiersUiState.value =
+                        ClientIdentifiersUiState.ClientIdentifiers(result.data)
             }
+        }
     }
 
     fun deleteIdentifier(clientId: Int, identifierId: Int) = viewModelScope.launch {

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientIdentifiersDialog/ClientIdentifiersDialogScreen.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientIdentifiersDialog/ClientIdentifiersDialogScreen.kt
@@ -19,6 +19,7 @@ import androidclient.feature.client.generated.resources.feature_client_identifie
 import androidclient.feature.client.generated.resources.feature_client_identifier_message_field_required
 import androidclient.feature.client.generated.resources.feature_client_identifier_submit
 import androidclient.feature.client.generated.resources.feature_client_identifier_unique_id
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -111,6 +112,10 @@ internal fun ClientIdentifiersDialogScreen(
             color = MaterialTheme.colorScheme.surface,
         ) {
             Box(
+                modifier = Modifier
+                    .height(425.dp)
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.surface),
                 contentAlignment = Alignment.Center,
             ) {
                 Column(modifier = Modifier.padding(20.dp)) {

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientList/ClientListScreen.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientList/ClientListScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.backhandler.BackHandler
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.PagingData
 import com.mifos.core.designsystem.component.MifosScaffold
 import com.mifos.core.designsystem.component.MifosSweetError
@@ -85,7 +86,7 @@ internal fun ClientListScreen(
     LaunchedEffect(key1 = true) {
         viewModel.getClientList()
     }
-    val isRefreshing by viewModel.isRefreshing.collectAsState()
+    val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
     val pullToRefreshState = rememberPullToRefreshState()
 
     val snackbarHostState = remember { SnackbarHostState() }


### PR DESCRIPTION
Fixes - [Jira-#461](https://mifosforge.jira.com/browse/MIFOSAC-461)

Summary of changes:
1. Prevented the temporary "There is no identifier to show" screen from appearing before the actual identifier list is loaded.
2. Fixed a UI issue where the create identifier dialog briefly stretched vertically before rendering correctly.

Before the fix:

[Before-bug-fixes.webm](https://github.com/user-attachments/assets/26dc73ab-20cb-48eb-ae9e-51cf2366700c)

After the fix:

[After-bug-fixes.webm](https://github.com/user-attachments/assets/8dcfea4b-b06b-4674-9943-64fa79385c7d)

Client Identifiers All Features:
User flow:
1. Client Details → ⋮ → Identifiers → On Identifier ⋮ → Delete Identifier → Identifiers Screen 
2. Identifiers Screen →  ⋮ “+” icon → Create Identifier → Identifier Screen

[client-identifiers-all-features.webm](https://github.com/user-attachments/assets/78370983-601f-4ffa-9ad1-fae1ba52c02d)


- [X] Run the static analysis check `./gradlew check` or `ci-prepush.sh` to make sure you didn't break anything

- [X] If you have multiple commits please combine them into one commit by squashing them.