### PR TITLE
fix(feature:client): fix signature reset issue and enforce white canvas background

### DIFF
--- a/core/designsystem/src/commonMain/kotlin/com/mifos/core/designsystem/component/DrawingState.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/mifos/core/designsystem/component/DrawingState.kt
@@ -40,4 +40,9 @@ class DrawingState {
     fun resetCurrentPath() {
         currentPath.value = Path()
     }
+
+    fun clear() {
+        paths.clear()
+        resetCurrentPath()
+    }
 }

--- a/feature/client/src/androidMain/kotlin/com/mifos/feature/client/clientSignature/SignatureScreen.android.kt
+++ b/feature/client/src/androidMain/kotlin/com/mifos/feature/client/clientSignature/SignatureScreen.android.kt
@@ -32,7 +32,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -40,7 +39,6 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.boundsInRoot
@@ -49,12 +47,12 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.graphics.applyCanvas
 import androidx.core.graphics.createBitmap
+import com.mifos.core.designsystem.component.DrawingState
 import com.mifos.core.designsystem.component.MifosCircularProgress
 import com.mifos.core.designsystem.component.MifosDrawingCanvas
 import com.mifos.core.designsystem.component.MifosScaffold
 import com.mifos.core.designsystem.component.MifosSweetError
 import com.mifos.core.designsystem.icon.MifosIcons
-import com.mifos.core.designsystem.utility.PathState
 import io.github.vinceglb.filekit.PlatformFile
 import org.jetbrains.compose.resources.stringResource
 import java.io.ByteArrayOutputStream
@@ -80,7 +78,7 @@ internal actual fun SignatureScreen(
     val drawColor = Color.Black
     val drawBrush = 5f
 
-    val paths = remember { mutableStateListOf<PathState>() }
+    val drawingState = remember { DrawingState() }
 
     val galleryLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent(),
@@ -121,7 +119,7 @@ internal actual fun SignatureScreen(
                         onClick = {
                             navigationSelectedItem = index
                             when (index) {
-                                0 -> paths.clear()
+                                0 -> drawingState.clear()
                                 1 -> galleryLauncher.launch("image/*")
                             }
                         },
@@ -152,8 +150,6 @@ internal actual fun SignatureScreen(
                 }
 
                 is SignatureUiState.Initial -> {
-                    paths.add(PathState(Path(), drawColor, drawBrush))
-
                     // Force white background here instead of relying on MaterialTheme
                     // Required to maintain consistent white canvas in both light and dark modes
                     // for legibility and official document compliance.
@@ -162,7 +158,11 @@ internal actual fun SignatureScreen(
                             .fillMaxSize()
                             .background(Color.White),
                     ) {
-                        MifosDrawingCanvas(drawColor = drawColor, drawBrush = drawBrush)
+                        MifosDrawingCanvas(
+                            drawColor = drawColor,
+                            drawBrush = drawBrush,
+                            drawingState = drawingState,
+                        )
                     }
                 }
             }

--- a/feature/client/src/androidMain/kotlin/com/mifos/feature/client/clientSignature/SignatureScreen.android.kt
+++ b/feature/client/src/androidMain/kotlin/com/mifos/feature/client/clientSignature/SignatureScreen.android.kt
@@ -18,7 +18,10 @@ import androidclient.feature.client.generated.resources.feature_client_signature
 import androidclient.feature.client.generated.resources.feature_client_signature_uploaded_successfully
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -150,7 +153,17 @@ internal actual fun SignatureScreen(
 
                 is SignatureUiState.Initial -> {
                     paths.add(PathState(Path(), drawColor, drawBrush))
-                    MifosDrawingCanvas(drawColor = drawColor, drawBrush = drawBrush)
+
+                    // Force white background here instead of relying on MaterialTheme
+                    // Required to maintain consistent white canvas in both light and dark modes
+                    // for legibility and official document compliance.
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Color.White),
+                    ) {
+                        MifosDrawingCanvas(drawColor = drawColor, drawBrush = drawBrush)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes - [Jira-#478](https://mifosforge.jira.com/browse/MIFOSAC-478)

Change Summary:

- Forced canvas background to white in all themes to ensure black ink signatures are visible and export-ready.
- Fixed reset button not clearing the canvas by using a shared DrawingState and adding a clear() method.

Before Fix (Dark Mode):

https://github.com/user-attachments/assets/06779685-8240-4281-8397-45f7d2ee01b0

After Fix (Dark Mode):

https://github.com/user-attachments/assets/849ff681-6aba-4b99-9426-ef1a73ab600c

Light Mode: 

https://github.com/user-attachments/assets/d0bc05e2-43d2-41bd-82e3-b2d670d36ba6

Signature Reset and Upload from Gallery:

https://github.com/user-attachments/assets/2cd62890-25b7-4b2d-8b79-e97b5a4a16b4


- [X] Run the static analysis check `./gradlew check` or `ci-prepush.sh` to make sure you didn't break anything

- [X] If you have multiple commits please combine them into one commit by squashing them.