### PR TITLE
498. Remove the visible DialogBox after Identifier creation submission

### DIFF
--- a/feature/client/src/main/java/com/mifos/feature/client/clientIdentifiersDialog/ClientIdentifiersDialogScreen.kt
+++ b/feature/client/src/main/java/com/mifos/feature/client/clientIdentifiersDialog/ClientIdentifiersDialogScreen.kt
@@ -93,6 +93,14 @@ internal fun ClientIdentifiersDialogScreen(
     onRetry: () -> Unit,
     onCreate: (IdentifierPayload) -> Unit,
 ) {
+    if (state is ClientIdentifierDialogUiState.IdentifierCreatedSuccessfully) {
+        Toast.makeText(
+            LocalContext.current,
+            stringResource(id = R.string.feature_client_identifier_created_successfully),
+            Toast.LENGTH_SHORT,
+        ).show()
+        onIdentifierCreated()
+    }
     Dialog(
         onDismissRequest = { onDismiss() },
     ) {


### PR DESCRIPTION
Fixes - [MIFSOAC-498](https://mifosforge.jira.com/browse/MIFOSAC-498)

Before : 

[MIFOSAC-498_Before.webm](https://github.com/user-attachments/assets/dfa658c1-76bd-4375-964d-90a3d4e33fd5)

There exists this dialog box (at 8 seconds in above video) even after successful creation of the identifier
<img width="370" height="795" alt="MIFOSAC-498_DialogBox" src="https://github.com/user-attachments/assets/bbe220a1-cda1-4e7c-a4c3-9a7dc9583479" />

After : 

[MIFOSAC-498_After.webm](https://github.com/user-attachments/assets/1a04cd6c-e1c6-4dbc-a708-04264272a4fd)

Changes:
- Added a check for ```ClientIdentifierDialogUiState.IdentifierCreatedSuccessfully``` and not display the dialog if successful.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the static analysis check `./gradlew check` or `ci-prepush.sh` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.