### PR TITLE
feat: sort identifiers with Active first and ascending order

### DIFF
--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientIdentifiers/ClientIdentifiersViewModel.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientIdentifiers/ClientIdentifiersViewModel.kt
@@ -46,12 +46,12 @@ class ClientIdentifiersViewModel(
     private fun <T> sortByActiveThenAscending(
         list: List<T>,
         isActive: (T) -> Boolean,
-        label: (T) -> String
+        label: (T) -> String,
     ): List<T> {
         return list.sortedWith(
             compareByDescending<T> { isActive(it) }
-                .then(compareBy { label(it).lowercase() })
-            )
+                .then(compareBy { label(it).lowercase() }),
+        )
     }
 
     private val _showCreateDialog = MutableStateFlow(false)
@@ -97,9 +97,10 @@ class ClientIdentifiersViewModel(
                         ClientIdentifiersUiState.Loading
                 }
                 is DataState.Success -> {
-                    val sorted = sortByActiveThenAscending(result.data,
+                    val sorted = sortByActiveThenAscending(
+                        result.data,
                         isActive = { it.status.equals("ACTIVE", ignoreCase = true) },
-                        label = { it.description ?: "" }
+                        label = { it.description ?: "" },
                     )
                     _clientIdentifiersUiState.value =
                         ClientIdentifiersUiState.ClientIdentifiers(sorted)
@@ -121,9 +122,10 @@ class ClientIdentifiersViewModel(
                         ClientIdentifiersUiState.Loading
 
                 is DataState.Success -> {
-                    val sorted = sortByActiveThenAscending(result.data,
+                    val sorted = sortByActiveThenAscending(
+                        result.data,
                         isActive = { it.status.equals("ACTIVE", ignoreCase = true) },
-                        label = { it.description ?: "" }
+                        label = { it.description ?: "" },
                     )
                     _clientIdentifiersUiState.value =
                         ClientIdentifiersUiState.ClientIdentifiers(sorted)

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientIdentifiers/ClientIdentifiersViewModel.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientIdentifiers/ClientIdentifiersViewModel.kt
@@ -43,6 +43,17 @@ class ClientIdentifiersViewModel(
 
     val clientId = savedStateHandle.getStateFlow(key = Constants.CLIENT_ID, initialValue = 0)
 
+    private fun <T> sortByActiveThenAscending(
+        list: List<T>,
+        isActive: (T) -> Boolean,
+        label: (T) -> String
+    ): List<T> {
+        return list.sortedWith(
+            compareByDescending<T> { isActive(it) }
+                .then(compareBy { label(it).lowercase() })
+            )
+    }
+
     private val _showCreateDialog = MutableStateFlow(false)
     val showCreateDialog = _showCreateDialog.asStateFlow()
 
@@ -86,8 +97,12 @@ class ClientIdentifiersViewModel(
                         ClientIdentifiersUiState.Loading
                 }
                 is DataState.Success -> {
+                    val sorted = sortByActiveThenAscending(result.data,
+                        isActive = { it.status.equals("ACTIVE", ignoreCase = true) },
+                        label = { it.description ?: "" }
+                    )
                     _clientIdentifiersUiState.value =
-                        ClientIdentifiersUiState.ClientIdentifiers(result.data)
+                        ClientIdentifiersUiState.ClientIdentifiers(sorted)
                     _isRefreshing.value = false
                 }
             }
@@ -105,9 +120,14 @@ class ClientIdentifiersViewModel(
                     _clientIdentifiersUiState.value =
                         ClientIdentifiersUiState.Loading
 
-                is DataState.Success ->
+                is DataState.Success -> {
+                    val sorted = sortByActiveThenAscending(result.data,
+                        isActive = { it.status.equals("ACTIVE", ignoreCase = true) },
+                        label = { it.description ?: "" }
+                    )
                     _clientIdentifiersUiState.value =
-                        ClientIdentifiersUiState.ClientIdentifiers(result.data)
+                        ClientIdentifiersUiState.ClientIdentifiers(sorted)
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes - [MIFOSAC-590] (https://mifosforge.jira.com/browse/MIFOSAC-)


### Summary
This PR sorts the identifiers list to improve usability:
- Active identifiers are always displayed first.
- Within Active/Inactive groups, identifiers are shown in ascending alphabetical order.
- Ensures consistent ordering across devices.

### Screenshots
| Before | After |
|--------|-------|

### Checklist
- [] Run the static analysis check `./gradlew check` or `ci-prepush.sh`
- [] Squash multiple commits into one


[MIFOSAC-590]: https://mifosforge.jira.com/browse/MIFOSAC-590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ