### PR TITLE
Improve Material Design spacing in LoanAccountSummaryScreen

### DIFF
--- a/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/loanAccountSummary/LoanAccountSummaryScreen.kt
+++ b/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/loanAccountSummary/LoanAccountSummaryScreen.kt
@@ -273,7 +273,7 @@ private fun LoanAccountSummaryContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(vertical = 12.dp),
-                    text = loanWithAssociations.clientName,
+            text = loanWithAssociations.clientName,
             style = MaterialTheme.typography.bodyLarge,
         )
 
@@ -287,7 +287,7 @@ private fun LoanAccountSummaryContent(
                 modifier = Modifier
                     .size(22.dp)
                     .padding(top = 8.dp, end = 8.dp),
-                        contentDescription = "",
+                contentDescription = "",
                 onDraw = {
                     drawRect(
                         color = when {

--- a/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/loanAccountSummary/LoanAccountSummaryScreen.kt
+++ b/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/loanAccountSummary/LoanAccountSummaryScreen.kt
@@ -266,14 +266,14 @@ private fun LoanAccountSummaryContent(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 24.dp)
+            .padding(horizontal = 16.dp)
             .verticalScroll(scrollState),
     ) {
         Text(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 8.dp, bottom = 8.dp),
-            text = loanWithAssociations.clientName,
+                .padding(vertical = 12.dp),
+                    text = loanWithAssociations.clientName,
             style = MaterialTheme.typography.bodyLarge,
         )
 
@@ -286,8 +286,8 @@ private fun LoanAccountSummaryContent(
             Canvas(
                 modifier = Modifier
                     .size(22.dp)
-                    .padding(top = 4.dp, end = 4.dp),
-                contentDescription = "",
+                    .padding(top = 8.dp, end = 8.dp),
+                        contentDescription = "",
                 onDraw = {
                     drawRect(
                         color = when {
@@ -320,7 +320,7 @@ private fun LoanAccountSummaryContent(
         HorizontalDivider(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 2.dp),
+                .padding(top = 8.dp),
         )
 
         LoanSummaryFarApartTextItem(
@@ -337,7 +337,6 @@ private fun LoanAccountSummaryContent(
             title = stringResource(Res.string.feature_loan_disbursed_date),
             value = if (inflateLoanSummary) getActualDisbursementDateInStringFormat() else "",
         )
-
         LoanSummaryFarApartTextItem(
             title = stringResource(Res.string.feature_loan_loan_in_arrears),
             value = if (inflateLoanSummary) {
@@ -353,21 +352,21 @@ private fun LoanAccountSummaryContent(
             value = loanWithAssociations.loanOfficerName,
         )
 
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(12.dp))
 
         LoanSummaryDataTable(
             loanSummary = loanWithAssociations.summary,
             inflateLoanSummary = inflateLoanSummary,
         )
 
-        Spacer(modifier = Modifier.height(4.dp))
+        Spacer(modifier = Modifier.height(12.dp))
 
         Button(
             enabled = getButtonActiveStatus(loanWithAssociations.status),
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 8.dp)
-                .height(45.dp),
+                .padding(horizontal = 16.dp)
+                .height(48.dp),
             onClick = when {
                 loanWithAssociations.status.active == true -> {
                     { makeRepayment.invoke() }


### PR DESCRIPTION
### Summary
This PR improves spacing and layout consistency in the Loan Account Summary screen by aligning paddings, spacers, and component sizes with Material Design guidelines.

### Changes
- Standardized horizontal and vertical paddings
- Improved spacing between UI sections for better readability
- Updated button height to match Material Design recommendations
- Reduced use of arbitrary spacing values for a cleaner layout

### Motivation
The previous layout used inconsistent spacing values (e.g. 2dp, 4dp, 6dp), which affected visual consistency and readability. These changes make the screen more polished and consistent with modern Compose UI practices.

### Testing
- Built and ran the app locally
- Verified Loan Account Summary screen layout visually
- No functional behavior was changed

### Screenshots
N/A (visual spacing improvement only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined spacing and padding across the Loan Account Summary screen for improved visual hierarchy—reduced content inset, increased vertical spacing for client name and dividers, and larger spacer gaps.
  * Updated button sizing and horizontal padding for more consistent touch targets and better visual balance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->