### PR TITLE
fix: Client profile photo and details not refreshing after update

### DIFF
--- a/core/data/src/commonMain/kotlin/com/mifos/core/data/repository/ClientDetailsRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/mifos/core/data/repository/ClientDetailsRepository.kt
@@ -72,4 +72,7 @@ interface ClientDetailsRepository {
         collateralId: Int,
         quantity: String,
     ): DataState<Unit>
+
+    val clientUpdateEvents: Flow<Unit>
+    suspend fun triggerClientUpdate()
 }

--- a/core/data/src/commonMain/kotlin/com/mifos/core/data/repositoryImp/ClientDetailsRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/com/mifos/core/data/repositoryImp/ClientDetailsRepositoryImp.kt
@@ -23,6 +23,8 @@ import com.mifos.room.entities.accounts.ClientAccounts
 import com.mifos.room.entities.client.ClientEntity
 import io.ktor.client.request.forms.MultiPartFormDataContent
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 
 /**
  * Created by Aditya Gupta on 06/08/23.
@@ -30,6 +32,14 @@ import kotlinx.coroutines.flow.Flow
 class ClientDetailsRepositoryImp(
     private val dataManagerClient: DataManagerClient,
 ) : ClientDetailsRepository {
+
+    private val _clientUpdateEvents = MutableSharedFlow<Unit>(replay = 0)
+
+    override val clientUpdateEvents: Flow<Unit> = _clientUpdateEvents.asSharedFlow()
+
+    override suspend fun triggerClientUpdate() {
+        _clientUpdateEvents.emit(Unit)
+    }
 
     override suspend fun uploadClientImage(clientId: Int, image: MultiPartFormDataContent) {
         dataManagerClient.uploadClientImage(clientId, image)

--- a/core/data/src/commonMain/kotlin/com/mifos/core/data/repositoryImp/ClientDetailsRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/com/mifos/core/data/repositoryImp/ClientDetailsRepositoryImp.kt
@@ -22,6 +22,7 @@ import com.mifos.core.network.model.StaffOption
 import com.mifos.room.entities.accounts.ClientAccounts
 import com.mifos.room.entities.client.ClientEntity
 import io.ktor.client.request.forms.MultiPartFormDataContent
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -33,7 +34,7 @@ class ClientDetailsRepositoryImp(
     private val dataManagerClient: DataManagerClient,
 ) : ClientDetailsRepository {
 
-    private val _clientUpdateEvents = MutableSharedFlow<Unit>(replay = 0)
+    private val _clientUpdateEvents = MutableSharedFlow<Unit>(replay = 0, extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
 
     override val clientUpdateEvents: Flow<Unit> = _clientUpdateEvents.asSharedFlow()
 

--- a/core/ui/src/commonMain/kotlin/com/mifos/core/ui/components/MifosStatusDialog.kt
+++ b/core/ui/src/commonMain/kotlin/com/mifos/core/ui/components/MifosStatusDialog.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
@@ -31,7 +30,6 @@ import com.mifos.core.designsystem.component.MifosButton
 import com.mifos.core.designsystem.theme.DesignToken
 import com.mifos.core.designsystem.theme.MifosTheme
 import com.mifos.core.designsystem.theme.MifosTypography
-import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 

--- a/core/ui/src/commonMain/kotlin/com/mifos/core/ui/components/MifosStatusDialog.kt
+++ b/core/ui/src/commonMain/kotlin/com/mifos/core/ui/components/MifosStatusDialog.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.text.style.TextAlign
 import com.mifos.core.designsystem.component.MifosButton
 import com.mifos.core.designsystem.theme.DesignToken

--- a/core/ui/src/commonMain/kotlin/com/mifos/core/ui/components/MifosStatusDialog.kt
+++ b/core/ui/src/commonMain/kotlin/com/mifos/core/ui/components/MifosStatusDialog.kt
@@ -44,6 +44,7 @@ fun MifosStatusDialog(
     successMessage: String,
     failureTitle: String,
     failureMessage: String,
+    showButton: Boolean = true,
     modifier: Modifier = Modifier,
 ) {
     val (title, message, icon) = when (status) {
@@ -57,13 +58,6 @@ fun MifosStatusDialog(
             failureMessage,
             painterResource(Res.drawable.ic_icon_error),
         )
-    }
-
-    if (status == ResultStatus.SUCCESS) {
-        LaunchedEffect(Unit) {
-            delay(1500)
-            onConfirm()
-        }
     }
 
     Column(
@@ -95,7 +89,7 @@ fun MifosStatusDialog(
             )
         }
 
-        if (status == ResultStatus.FAILURE) {
+        if (showButton) {
             MifosButton(
                 onClick = onConfirm,
                 text = {

--- a/core/ui/src/commonMain/kotlin/com/mifos/core/ui/components/MifosStatusDialog.kt
+++ b/core/ui/src/commonMain/kotlin/com/mifos/core/ui/components/MifosStatusDialog.kt
@@ -15,19 +15,24 @@ import androidclient.core.ui.generated.resources.ic_icon_success
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.text.style.TextAlign
 import com.mifos.core.designsystem.component.MifosButton
 import com.mifos.core.designsystem.theme.DesignToken
 import com.mifos.core.designsystem.theme.MifosTheme
 import com.mifos.core.designsystem.theme.MifosTypography
+import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -53,6 +58,13 @@ fun MifosStatusDialog(
             failureMessage,
             painterResource(Res.drawable.ic_icon_error),
         )
+    }
+
+    if (status == ResultStatus.SUCCESS) {
+        LaunchedEffect(Unit) {
+            delay(1500)
+            onConfirm()
+        }
     }
 
     Column(
@@ -83,18 +95,23 @@ fun MifosStatusDialog(
                 textAlign = TextAlign.Center,
             )
         }
-        MifosButton(
-            onClick = onConfirm,
-            text = {
-                Text(
-                    text = btnText,
-                    style = MifosTypography.labelLarge,
-                )
-            },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = DesignToken.padding.small),
-        )
+
+        if (status == ResultStatus.FAILURE) {
+            MifosButton(
+                onClick = onConfirm,
+                text = {
+                    Text(
+                        text = btnText,
+                        style = MifosTypography.labelLarge,
+                    )
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = DesignToken.padding.small),
+            )
+        } else {
+            Spacer(modifier = Modifier.height(DesignToken.spacing.large))
+        }
     }
 }
 

--- a/core/ui/src/commonMain/kotlin/com/mifos/core/ui/components/MifosStatusDialog.kt
+++ b/core/ui/src/commonMain/kotlin/com/mifos/core/ui/components/MifosStatusDialog.kt
@@ -13,14 +13,12 @@ import androidclient.core.ui.generated.resources.Res
 import androidclient.core.ui.generated.resources.ic_icon_error
 import androidclient.core.ui.generated.resources.ic_icon_success
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -57,48 +55,46 @@ fun MifosStatusDialog(
         )
     }
 
-    Box(
-        modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .padding(DesignToken.padding.largeIncreasedExtra),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
     ) {
+        Image(
+            painter = icon,
+            contentDescription = null,
+            modifier = Modifier.size(DesignToken.sizes.profile),
+        )
         Column(
-            Modifier.fillMaxWidth().padding(horizontal = DesignToken.padding.large),
             horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.small),
         ) {
-            Image(
-                painter = icon,
-                contentDescription = null,
-                modifier = Modifier.size(DesignToken.sizes.avatarLargeLarge),
-            )
-            Spacer(Modifier.height(DesignToken.padding.largeIncreasedExtra))
-
             Text(
                 text = title,
                 style = MifosTypography.titleLargeEmphasized,
                 textAlign = TextAlign.Center,
             )
-
-            Spacer(Modifier.height(DesignToken.padding.small))
-
             Text(
                 text = message,
-                style = MifosTypography.bodySmall,
+                style = MifosTypography.bodyMedium,
                 textAlign = TextAlign.Center,
             )
-
-            Spacer(Modifier.height(DesignToken.padding.extraLargeIncreased))
-
-            MifosButton(
-                onClick = onConfirm,
-                text = {
-                    Text(
-                        text = btnText,
-                        style = MifosTypography.labelLarge,
-                    )
-                },
-                modifier = Modifier.fillMaxWidth(),
-            )
         }
+        MifosButton(
+            onClick = onConfirm,
+            text = {
+                Text(
+                    text = btnText,
+                    style = MifosTypography.labelLarge,
+                )
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = DesignToken.padding.small),
+        )
     }
 }
 
@@ -114,25 +110,9 @@ private fun MifosSuccessStatusDialogPreview() {
         MifosStatusDialog(
             status = ResultStatus.SUCCESS,
             onConfirm = {},
-            btnText = "OK",
+            btnText = "Continue",
             successTitle = "Success",
-            successMessage = "Operation Successful",
-            failureTitle = "Failure",
-            failureMessage = "Operation Failed",
-        )
-    }
-}
-
-@Composable
-@Preview
-private fun MifosFailureStatusDialogPreview() {
-    MifosTheme {
-        MifosStatusDialog(
-            status = ResultStatus.FAILURE,
-            onConfirm = {},
-            btnText = "OK",
-            successTitle = "Success",
-            successMessage = "Operation Successful",
+            successMessage = "Profile photo updated successfully",
             failureTitle = "Failure",
             failureMessage = "Operation Failed",
         )

--- a/feature/client/src/commonMain/composeResources/values/strings.xml
+++ b/feature/client/src/commonMain/composeResources/values/strings.xml
@@ -472,6 +472,8 @@
     <string name="client_profile_loan_account">Loan Account</string>
     <string name="client_profile_photo_updated_success">Profile photo updated successfully</string>
     <string name="client_profile_photo_updated_failure">Unknown Error</string>
+    <string name="client_profile_edit_success_title">Success</string>
+    <string name="client_profile_edit_failure_title">Error</string>
 
     <string name="client_identifiers_click_on_plus_button_to_add_an_item">Click on “+” Button to add an item.</string>
     <string name="client_identifiers_not_available">Not available</string>

--- a/feature/client/src/commonMain/composeResources/values/strings.xml
+++ b/feature/client/src/commonMain/composeResources/values/strings.xml
@@ -470,6 +470,8 @@
     <string name="client_profile_select_account_type">Select Account Type</string>
     <string name="client_profile_savings_account">Savings Account</string>
     <string name="client_profile_loan_account">Loan Account</string>
+    <string name="client_profile_photo_updated_success">Profile photo updated successfully</string>
+    <string name="client_profile_photo_updated_failure">Unknown Error</string>
 
     <string name="client_identifiers_click_on_plus_button_to_add_an_item">Click on “+” Button to add an item.</string>
     <string name="client_identifiers_not_available">Not available</string>

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientDetailsProfile/ClientProfileDetailsViewModel.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientDetailsProfile/ClientProfileDetailsViewModel.kt
@@ -62,10 +62,10 @@ internal class ClientProfileDetailsViewModel(
 
     init {
         getClientAndObserveNetwork()
-        observeGlobalUpdates()
+        observeClientUpdates()
     }
 
-    private fun observeGlobalUpdates() {
+    private fun observeClientUpdates() {
         viewModelScope.launch {
             clientDetailsRepo.clientUpdateEvents.collect {
                 loadClientDetailsAndImage(route.id)

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientDetailsProfile/ClientProfileDetailsViewModel.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientDetailsProfile/ClientProfileDetailsViewModel.kt
@@ -62,6 +62,15 @@ internal class ClientProfileDetailsViewModel(
 
     init {
         getClientAndObserveNetwork()
+        observeGlobalUpdates()
+    }
+
+    private fun observeGlobalUpdates() {
+        viewModelScope.launch {
+            clientDetailsRepo.clientUpdateEvents.collect {
+                loadClientDetailsAndImage(route.id)
+            }
+        }
     }
 
     private fun getClientAndObserveNetwork() {

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditDetails/ClientEditDetailsViewModel.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditDetails/ClientEditDetailsViewModel.kt
@@ -19,6 +19,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.mifos.core.common.utils.DataState
 import com.mifos.core.data.repository.ClientDetailsEditRepository
+import com.mifos.core.data.repository.ClientDetailsRepository
 import com.mifos.core.data.repository.CreateNewClientRepository
 import com.mifos.core.domain.useCases.GetClientDetailsUseCase
 import com.mifos.core.ui.components.ResultStatus
@@ -38,6 +39,7 @@ internal class ClientEditDetailsViewModel(
     private val repository: ClientDetailsEditRepository,
     private val newClientRepository: CreateNewClientRepository,
     private val getClientDetailsUseCase: GetClientDetailsUseCase,
+    private val clientDetailsRepo: ClientDetailsRepository,
 ) : BaseViewModel<ClientEditDetailsState, ClientEditDetailsEvent, ClientEditDetailsAction>(
     initialState = ClientEditDetailsState(),
 ) {
@@ -154,6 +156,7 @@ internal class ClientEditDetailsViewModel(
             }
             try {
                 val clientId = repository.updateClient(clientId = route.id, clientPayload = clientPayload)
+                clientDetailsRepo.triggerClientUpdate()
                 mutableStateFlow.update {
                     it.copy(
                         id = clientId ?: -1,

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditProfile/ClientProfileEditScreen.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditProfile/ClientProfileEditScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.mifos.core.designsystem.component.BasicDialogState
@@ -278,7 +279,11 @@ private fun ClientProfileEditDialogs(
                 }
             }
             Dialog(
-                onDismissRequest = { onAction(ClientProfileEditAction.OnNext) },
+                onDismissRequest = {},
+                properties = DialogProperties(
+                    dismissOnBackPress = false,
+                    dismissOnClickOutside = false,
+                ),
             ) {
                 Surface(
                     shape = DesignToken.shapes.extraLarge,

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditProfile/ClientProfileEditScreen.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditProfile/ClientProfileEditScreen.kt
@@ -14,8 +14,8 @@ import androidclient.feature.client.generated.resources.account_number_prefix
 import androidclient.feature.client.generated.resources.arrow_up
 import androidclient.feature.client.generated.resources.cancel
 import androidclient.feature.client.generated.resources.choose_from_option
-import androidclient.feature.client.generated.resources.client_identifiers_error_text
-import androidclient.feature.client.generated.resources.client_identifiers_identities_success_text
+import androidclient.feature.client.generated.resources.client_profile_edit_failure_title
+import androidclient.feature.client.generated.resources.client_profile_edit_success_title
 import androidclient.feature.client.generated.resources.delete_dialog_message
 import androidclient.feature.client.generated.resources.delete_dialog_title
 import androidclient.feature.client.generated.resources.delete_photo
@@ -45,7 +45,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
@@ -272,8 +271,8 @@ private fun ClientProfileEditDialogs(
         }
 
         is ClientProfileEditState.DialogState.ShowStatusDialog -> {
-            if (state.dialogState.status == ResultStatus.SUCCESS) {
-                LaunchedEffect(Unit) {
+            LaunchedEffect(state.dialogState.status) {
+                if (state.dialogState.status == ResultStatus.SUCCESS) {
                     delay(1500)
                     onAction(ClientProfileEditAction.OnNext)
                 }
@@ -298,9 +297,9 @@ private fun ClientProfileEditDialogs(
                             onAction(ClientProfileEditAction.OnNext)
                         },
                         btnText = stringResource(Res.string.dialog_continue),
-                        successTitle = stringResource(Res.string.client_identifiers_identities_success_text),
+                        successTitle = stringResource(Res.string.client_profile_edit_success_title),
                         successMessage = state.dialogState.msg,
-                        failureTitle = stringResource(Res.string.client_identifiers_error_text),
+                        failureTitle = stringResource(Res.string.client_profile_edit_failure_title),
                         failureMessage = state.dialogState.msg,
                         showButton = state.dialogState.status == ResultStatus.FAILURE,
                     )

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditProfile/ClientProfileEditScreen.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditProfile/ClientProfileEditScreen.kt
@@ -14,9 +14,12 @@ import androidclient.feature.client.generated.resources.account_number_prefix
 import androidclient.feature.client.generated.resources.arrow_up
 import androidclient.feature.client.generated.resources.cancel
 import androidclient.feature.client.generated.resources.choose_from_option
+import androidclient.feature.client.generated.resources.client_identifiers_error_text
+import androidclient.feature.client.generated.resources.client_identifiers_identities_success_text
 import androidclient.feature.client.generated.resources.delete_dialog_message
 import androidclient.feature.client.generated.resources.delete_dialog_title
 import androidclient.feature.client.generated.resources.delete_photo
+import androidclient.feature.client.generated.resources.dialog_continue
 import androidclient.feature.client.generated.resources.edit_profile_title
 import androidclient.feature.client.generated.resources.from_camera
 import androidclient.feature.client.generated.resources.from_gallery
@@ -35,6 +38,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -44,6 +48,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.mifos.core.designsystem.component.BasicDialogState
@@ -57,6 +62,7 @@ import com.mifos.core.designsystem.theme.MifosTypography
 import com.mifos.core.ui.components.MifosBreadcrumbNavBar
 import com.mifos.core.ui.components.MifosErrorComponent
 import com.mifos.core.ui.components.MifosProgressIndicator
+import com.mifos.core.ui.components.MifosStatusDialog
 import com.mifos.core.ui.components.MifosUserImage
 import com.mifos.core.ui.util.EventsEffect
 import network.chaintech.cmpimagepickncrop.CMPImagePickNCropDialog
@@ -259,6 +265,32 @@ private fun ClientProfileEditDialogs(
                 },
                 selectedImageFileCallback = {},
             )
+        }
+
+        is ClientProfileEditState.DialogState.ShowStatusDialog -> {
+            androidx.compose.ui.window.Dialog(
+                onDismissRequest = { onAction(ClientProfileEditAction.OnNext) },
+            ) {
+                androidx.compose.material3.Surface(
+                    shape = DesignToken.shapes.extraLarge,
+                    color = androidx.compose.material3.MaterialTheme.colorScheme.surface,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(DesignToken.padding.large),
+                ) {
+                    MifosStatusDialog(
+                        status = state.dialogState.status,
+                        onConfirm = {
+                            onAction(ClientProfileEditAction.OnNext)
+                        },
+                        btnText = stringResource(Res.string.dialog_continue),
+                        successTitle = stringResource(Res.string.client_identifiers_identities_success_text),
+                        successMessage = state.dialogState.msg,
+                        failureTitle = stringResource(Res.string.client_identifiers_error_text),
+                        failureMessage = state.dialogState.msg,
+                    )
+                }
+            }
         }
     }
 }

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditProfile/ClientProfileEditScreen.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditProfile/ClientProfileEditScreen.kt
@@ -297,7 +297,7 @@ private fun ClientProfileEditDialogs(
                         successMessage = state.dialogState.msg,
                         failureTitle = stringResource(Res.string.client_identifiers_error_text),
                         failureMessage = state.dialogState.msg,
-                        showButton = state.dialogState.status == ResultStatus.FAILURE
+                        showButton = state.dialogState.status == ResultStatus.FAILURE,
                     )
                 }
             }

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditProfile/ClientProfileEditScreen.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditProfile/ClientProfileEditScreen.kt
@@ -268,12 +268,12 @@ private fun ClientProfileEditDialogs(
         }
 
         is ClientProfileEditState.DialogState.ShowStatusDialog -> {
-            androidx.compose.ui.window.Dialog(
+            Dialog(
                 onDismissRequest = { onAction(ClientProfileEditAction.OnNext) },
             ) {
-                androidx.compose.material3.Surface(
+                Surface(
                     shape = DesignToken.shapes.extraLarge,
-                    color = androidx.compose.material3.MaterialTheme.colorScheme.surface,
+                    color = MaterialTheme.colorScheme.surface,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(DesignToken.padding.large),

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditProfile/ClientProfileEditScreen.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditProfile/ClientProfileEditScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -64,7 +65,9 @@ import com.mifos.core.ui.components.MifosErrorComponent
 import com.mifos.core.ui.components.MifosProgressIndicator
 import com.mifos.core.ui.components.MifosStatusDialog
 import com.mifos.core.ui.components.MifosUserImage
+import com.mifos.core.ui.components.ResultStatus
 import com.mifos.core.ui.util.EventsEffect
+import kotlinx.coroutines.delay
 import network.chaintech.cmpimagepickncrop.CMPImagePickNCropDialog
 import network.chaintech.cmpimagepickncrop.imagecropper.ImageAspectRatio
 import network.chaintech.cmpimagepickncrop.imagecropper.rememberImageCropper
@@ -268,6 +271,12 @@ private fun ClientProfileEditDialogs(
         }
 
         is ClientProfileEditState.DialogState.ShowStatusDialog -> {
+            if (state.dialogState.status == ResultStatus.SUCCESS) {
+                LaunchedEffect(Unit) {
+                    delay(1500)
+                    onAction(ClientProfileEditAction.OnNext)
+                }
+            }
             Dialog(
                 onDismissRequest = { onAction(ClientProfileEditAction.OnNext) },
             ) {
@@ -288,6 +297,7 @@ private fun ClientProfileEditDialogs(
                         successMessage = state.dialogState.msg,
                         failureTitle = stringResource(Res.string.client_identifiers_error_text),
                         failureMessage = state.dialogState.msg,
+                        showButton = state.dialogState.status == ResultStatus.FAILURE
                     )
                 }
             }

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditProfile/ClientProfileEditViewModel.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditProfile/ClientProfileEditViewModel.kt
@@ -17,6 +17,7 @@ import com.mifos.core.common.utils.DataState
 import com.mifos.core.data.repository.ClientDetailsRepository
 import com.mifos.core.data.util.NetworkMonitor
 import com.mifos.core.domain.useCases.UploadClientImageUseCase
+import com.mifos.core.ui.components.ResultStatus
 import com.mifos.core.ui.util.BaseViewModel
 import com.mifos.core.ui.util.imageToByteArray
 import com.mifos.core.ui.util.multipartRequestBody
@@ -87,6 +88,7 @@ internal class ClientProfileEditViewModel(
             is ClientProfileEditAction.OnImageSelected -> {
                 uploadImage(state.id, action.image)
             }
+            ClientProfileEditAction.OnNext -> sendEvent(ClientProfileEditEvent.NavigateBack)
         }
     }
 
@@ -95,15 +97,30 @@ internal class ClientProfileEditViewModel(
             clientDetailsRepo.getImage(clientId).collect { result ->
                 when (result) {
                     is DataState.Success -> mutableStateFlow.update {
-                        it.copy(
+                        val newDialogState = if (state.dialogState is ClientProfileEditState.DialogState.ShowStatusDialog) {
+                            state.dialogState
+                        } else {
+                            null
+                        }
+                        state.copy(
                             profileImage = imageToByteArray(result.data),
-                            dialogState = null,
+                            dialogState = newDialogState,
                         )
                     }
                     is DataState.Loading -> mutableStateFlow.update {
-                        it.copy(dialogState = ClientProfileEditState.DialogState.Loading)
+                        if (it.dialogState !is ClientProfileEditState.DialogState.ShowStatusDialog) {
+                            it.copy(dialogState = ClientProfileEditState.DialogState.Loading)
+                        } else {
+                            it
+                        }
                     }
-                    else -> Unit
+                    is DataState.Error -> mutableStateFlow.update {
+                        if (it.dialogState is ClientProfileEditState.DialogState.ShowStatusDialog) {
+                            it
+                        } else {
+                            it.copy(dialogState = null)
+                        }
+                    }
                 }
             }
         }
@@ -138,7 +155,17 @@ internal class ClientProfileEditViewModel(
                             openImagePicker = false,
                         )
                     }
+                    clientDetailsRepo.triggerClientUpdate()
                     loadImage(route.id)
+                    mutableStateFlow.update {
+                        it.copy(
+                            openImagePicker = false,
+                            dialogState = ClientProfileEditState.DialogState.ShowStatusDialog(
+                                status = ResultStatus.SUCCESS,
+                                msg = "Profile photo updated successfully",
+                            ),
+                        )
+                    }
                 }
             }
         }
@@ -148,6 +175,7 @@ internal class ClientProfileEditViewModel(
         viewModelScope.launch {
             try {
                 clientDetailsRepo.deleteClientImage(state.id)
+                clientDetailsRepo.triggerClientUpdate()
                 mutableStateFlow.update {
                     it.copy(
                         profileImage = null,
@@ -181,6 +209,7 @@ data class ClientProfileEditState(
         data object Loading : DialogState
         data object ShowDeleteDialog : DialogState
         data object ShowUploadOptions : DialogState
+        data class ShowStatusDialog(val status: ResultStatus, val msg: String = "") : DialogState
     }
 }
 
@@ -201,4 +230,5 @@ sealed interface ClientProfileEditAction {
     data object DismissModalBottomSheet : ClientProfileEditAction
     data class UpdateImagePicker(val status: Boolean) : ClientProfileEditAction
     data class OnImageSelected(val image: ImageBitmap) : ClientProfileEditAction
+    data object OnNext : ClientProfileEditAction
 }

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditProfile/ClientProfileEditViewModel.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditProfile/ClientProfileEditViewModel.kt
@@ -9,6 +9,9 @@
  */
 package com.mifos.feature.client.clientEditProfile
 
+import androidclient.feature.client.generated.resources.Res
+import androidclient.feature.client.generated.resources.client_profile_photo_updated_failure
+import androidclient.feature.client.generated.resources.client_profile_photo_updated_success
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
@@ -24,6 +27,7 @@ import com.mifos.core.ui.util.multipartRequestBody
 import com.mifos.feature.client.utils.toPlatformFile
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.getString
 
 internal class ClientProfileEditViewModel(
     savedStateHandle: SavedStateHandle,
@@ -162,7 +166,7 @@ internal class ClientProfileEditViewModel(
                             openImagePicker = false,
                             dialogState = ClientProfileEditState.DialogState.ShowStatusDialog(
                                 status = ResultStatus.SUCCESS,
-                                msg = "Profile photo updated successfully",
+                                msg = getString(Res.string.client_profile_photo_updated_success),
                             ),
                         )
                     }
@@ -186,7 +190,7 @@ internal class ClientProfileEditViewModel(
                 mutableStateFlow.update {
                     it.copy(
                         dialogState = ClientProfileEditState.DialogState.Error(
-                            e.message ?: "Unknown Error",
+                            e.message ?: getString(Res.string.client_profile_photo_updated_failure),
                         ),
                     )
                 }

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientProfile/ClientProfileViewModel.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientProfile/ClientProfileViewModel.kt
@@ -46,6 +46,14 @@ internal class ClientProfileViewModel(
 
     init {
         getClientAndObserveNetwork()
+        observeGlobalUpdates()
+    }
+    private fun observeGlobalUpdates() {
+        viewModelScope.launch {
+            clientDetailsRepo.clientUpdateEvents.collect {
+                loadClientDetailsAndImage(route.id)
+            }
+        }
     }
 
     private fun getClientAndObserveNetwork() {


### PR DESCRIPTION
**Fixes** - [Jira-#595](https://mifosforge.jira.com/browse/MIFOSAC-595)

**Description** - The client profile was not updating when navigating back from the edit screen. I implemented a repository-level broadcast flow so the profile screen listens for update signals and refreshes automatically.

Also added a status dialog box after photo uploads to confirm the changes.

**Video** - 

https://github.com/user-attachments/assets/760578b8-2f69-4f0d-bd1b-59a1f4395cf6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client profiles now auto-refresh via a global client update event; edits and photo changes broadcast updates.
  * Added an explicit trigger to emit client update events for reactive updates.

* **UI/UX Improvements**
  * Redesigned status dialog with centered icon, optional action button, and auto-confirm on success.
  * Added localized success/failure titles and messages for profile photo operations and persistent dialog feedback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->