### PR TITLE
fix: add missing gender, clientType and clientClassification in ClientProfileDetails screen

### DIFF
--- a/core/database/src/commonMain/kotlin/com/mifos/room/entities/client/ClientClassificationEntity.kt
+++ b/core/database/src/commonMain/kotlin/com/mifos/room/entities/client/ClientClassificationEntity.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/android-client/blob/master/LICENSE.md
+ */
+package com.mifos.room.entities.client
+
+import com.mifos.core.model.utils.Parcelable
+import com.mifos.core.model.utils.Parcelize
+import com.mifos.room.utils.Entity
+import com.mifos.room.utils.PrimaryKey
+import kotlinx.serialization.Serializable
+
+@Parcelize
+@Serializable
+@Entity(
+    indices = [],
+    inheritSuperIndices = false,
+    primaryKeys = [],
+    foreignKeys = [],
+    ignoredColumns = [],
+    tableName = "ClientClassification",
+)
+data class ClientClassificationEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Int = 0,
+
+    val name: String? = null,
+) : Parcelable

--- a/core/database/src/commonMain/kotlin/com/mifos/room/entities/client/ClientEntity.kt
+++ b/core/database/src/commonMain/kotlin/com/mifos/room/entities/client/ClientEntity.kt
@@ -111,4 +111,10 @@ data class ClientEntity(
     val emailAddress: String? = null,
 
     val legalForm: ClientStatusEntity? = null,
+
+    val gender: ClientGenderEntity? = null,
+
+    val clientType: ClientTypeEntity? = null,
+
+    val clientClassification: ClientClassificationEntity? = null,
 ) : Parcelable

--- a/core/database/src/commonMain/kotlin/com/mifos/room/entities/client/ClientGenderEntity.kt
+++ b/core/database/src/commonMain/kotlin/com/mifos/room/entities/client/ClientGenderEntity.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/android-client/blob/master/LICENSE.md
+ */
+package com.mifos.room.entities.client
+
+import com.mifos.core.model.utils.Parcelable
+import com.mifos.core.model.utils.Parcelize
+import com.mifos.room.utils.Entity
+import com.mifos.room.utils.PrimaryKey
+import kotlinx.serialization.Serializable
+
+@Parcelize
+@Serializable
+@Entity(
+    indices = [],
+    inheritSuperIndices = false,
+    primaryKeys = [],
+    foreignKeys = [],
+    ignoredColumns = [],
+    tableName = "Gender",
+)
+data class ClientGenderEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Int = 0,
+
+    val name: String? = null,
+) : Parcelable

--- a/core/database/src/commonMain/kotlin/com/mifos/room/entities/client/ClientTypeEntity.kt
+++ b/core/database/src/commonMain/kotlin/com/mifos/room/entities/client/ClientTypeEntity.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/android-client/blob/master/LICENSE.md
+ */
+package com.mifos.room.entities.client
+
+import com.mifos.core.model.utils.Parcelable
+import com.mifos.core.model.utils.Parcelize
+import com.mifos.room.utils.Entity
+import com.mifos.room.utils.PrimaryKey
+import kotlinx.serialization.Serializable
+
+@Parcelize
+@Serializable
+@Entity(
+    indices = [],
+    inheritSuperIndices = false,
+    primaryKeys = [],
+    foreignKeys = [],
+    ignoredColumns = [],
+    tableName = "ClientType",
+)
+data class ClientTypeEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Int = 0,
+
+    val name: String? = null,
+) : Parcelable

--- a/core/database/src/commonMain/kotlin/com/mifos/room/typeconverters/CustomTypeConverters.kt
+++ b/core/database/src/commonMain/kotlin/com/mifos/room/typeconverters/CustomTypeConverters.kt
@@ -44,8 +44,11 @@ import com.mifos.room.entities.accounts.savings.SavingsTransactionTypeEntity
 import com.mifos.room.entities.client.ChargeCalculationTypeEntity
 import com.mifos.room.entities.client.ChargeTimeTypeEntity
 import com.mifos.room.entities.client.ClientChargeCurrencyEntity
+import com.mifos.room.entities.client.ClientClassificationEntity
 import com.mifos.room.entities.client.ClientDateEntity
+import com.mifos.room.entities.client.ClientGenderEntity
 import com.mifos.room.entities.client.ClientStatusEntity
+import com.mifos.room.entities.client.ClientTypeEntity
 import com.mifos.room.entities.group.CenterDateEntity
 import com.mifos.room.entities.group.CenterEntity
 import com.mifos.room.entities.group.GroupDateEntity
@@ -179,6 +182,36 @@ class CustomTypeConverters {
     @TypeConverter
     fun toClientStatus(json: String?): ClientStatusEntity? {
         return json?.let { Json.decodeFromString(it) }
+    }
+
+    @TypeConverter
+    fun fromClientGenderEntity(gender: ClientGenderEntity?): String? {
+        return gender?.let { Json.encodeToString(it) }
+    }
+
+    @TypeConverter
+    fun toClientGenderEntity(json: String?): ClientGenderEntity? {
+        return json?.let { Json.decodeFromString<ClientGenderEntity>(it) }
+    }
+
+    @TypeConverter
+    fun fromClientTypeEntity(clientType: ClientTypeEntity?): String? {
+        return clientType?.let { Json.encodeToString(it) }
+    }
+
+    @TypeConverter
+    fun toClientTypeEntity(json: String?): ClientTypeEntity? {
+        return json?.let { Json.decodeFromString<ClientTypeEntity>(it) }
+    }
+
+    @TypeConverter
+    fun fromClientClassificationEntity(clientClassification: ClientClassificationEntity?): String? {
+        return clientClassification?.let { Json.encodeToString(it) }
+    }
+
+    @TypeConverter
+    fun toClientClassificationEntity(json: String?): ClientClassificationEntity? {
+        return json?.let { Json.decodeFromString<ClientClassificationEntity>(it) }
     }
 
     @TypeConverter

--- a/core/network/src/commonMain/kotlin/com/mifos/core/network/mappers/clients/ClientMapper.kt
+++ b/core/network/src/commonMain/kotlin/com/mifos/core/network/mappers/clients/ClientMapper.kt
@@ -10,10 +10,16 @@
 package com.mifos.core.network.mappers.clients
 
 import com.mifos.core.network.data.AbstractMapper
+import com.mifos.core.network.model.GetClientClassificationOptions
 import com.mifos.core.network.model.GetClientStatus
+import com.mifos.core.network.model.GetClientTypeOptions
 import com.mifos.core.network.model.GetClientsPageItemsResponse
+import com.mifos.core.network.model.GetGenderOptions
+import com.mifos.room.entities.client.ClientClassificationEntity
 import com.mifos.room.entities.client.ClientEntity
+import com.mifos.room.entities.client.ClientGenderEntity
 import com.mifos.room.entities.client.ClientStatusEntity
+import com.mifos.room.entities.client.ClientTypeEntity
 
 object ClientMapper : AbstractMapper<GetClientsPageItemsResponse, ClientEntity>() {
 
@@ -44,6 +50,24 @@ object ClientMapper : AbstractMapper<GetClientsPageItemsResponse, ClientEntity>(
                 value = entity.legalForm?.value,
             ),
             dateOfBirth = entity.dateOfBirth ?: emptyList(),
+            gender = entity.gender?.let {
+                ClientGenderEntity(
+                    id = it.id?.toInt() ?: -1,
+                    name = it.name,
+                )
+            },
+            clientType = entity.clientType?.let {
+                ClientTypeEntity(
+                    id = it.id?.toInt() ?: -1,
+                    name = it.name,
+                )
+            },
+            clientClassification = entity.clientClassification?.let {
+                ClientClassificationEntity(
+                    id = it.id?.toInt() ?: -1,
+                    name = it.name,
+                )
+            },
         )
     }
 
@@ -71,6 +95,24 @@ object ClientMapper : AbstractMapper<GetClientsPageItemsResponse, ClientEntity>(
                 value = domainModel.legalForm?.value,
             ),
             dateOfBirth = domainModel.dateOfBirth,
+            gender = domainModel.gender?.let {
+                GetGenderOptions(
+                    id = it.id?.toLong(),
+                    name = it.name,
+                )
+            },
+            clientType = domainModel.clientType?.let {
+                GetClientTypeOptions(
+                    id = it.id?.toLong(),
+                    name = it.name,
+                )
+            },
+            clientClassification = domainModel.clientClassification?.let {
+                GetClientClassificationOptions(
+                    id = it.id?.toLong(),
+                    name = it.name,
+                )
+            },
         )
     }
 }

--- a/core/network/src/commonMain/kotlin/com/mifos/core/network/model/GetClientClassificationOptions.kt
+++ b/core/network/src/commonMain/kotlin/com/mifos/core/network/model/GetClientClassificationOptions.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/android-client/blob/master/LICENSE.md
+ */
+package com.mifos.core.network.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ *
+ *
+ * @param id
+ * @param name
+ */
+
+@Serializable
+data class GetClientClassificationOptions(
+
+    val id: Long? = null,
+
+    val name: String? = null,
+)

--- a/core/network/src/commonMain/kotlin/com/mifos/core/network/model/GetClientClassificationOptions.kt
+++ b/core/network/src/commonMain/kotlin/com/mifos/core/network/model/GetClientClassificationOptions.kt
@@ -11,13 +11,6 @@ package com.mifos.core.network.model
 
 import kotlinx.serialization.Serializable
 
-/**
- *
- *
- * @param id
- * @param name
- */
-
 @Serializable
 data class GetClientClassificationOptions(
 

--- a/core/network/src/commonMain/kotlin/com/mifos/core/network/model/GetClientTypeOptions.kt
+++ b/core/network/src/commonMain/kotlin/com/mifos/core/network/model/GetClientTypeOptions.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/android-client/blob/master/LICENSE.md
+ */
+package com.mifos.core.network.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ *
+ *
+ * @param id
+ * @param name
+ */
+
+@Serializable
+data class GetClientTypeOptions(
+
+    val id: Long? = null,
+
+    val name: String? = null,
+
+)

--- a/core/network/src/commonMain/kotlin/com/mifos/core/network/model/GetClientTypeOptions.kt
+++ b/core/network/src/commonMain/kotlin/com/mifos/core/network/model/GetClientTypeOptions.kt
@@ -11,13 +11,6 @@ package com.mifos.core.network.model
 
 import kotlinx.serialization.Serializable
 
-/**
- *
- *
- * @param id
- * @param name
- */
-
 @Serializable
 data class GetClientTypeOptions(
 

--- a/core/network/src/commonMain/kotlin/com/mifos/core/network/model/GetClientsPageItemsResponse.kt
+++ b/core/network/src/commonMain/kotlin/com/mifos/core/network/model/GetClientsPageItemsResponse.kt
@@ -62,4 +62,11 @@ data class GetClientsPageItemsResponse(
     val savingAccountOptions: List<SavingAccountOption> = emptyList(),
 
     val shareAccounts: List<ShareAccounts> = emptyList(),
+
+    val gender: GetGenderOptions? = null,
+
+    val clientType: GetClientTypeOptions? = null,
+
+    val clientClassification: GetClientClassificationOptions? = null,
+
 )

--- a/core/network/src/commonMain/kotlin/com/mifos/core/network/model/GetGenderOptions.kt
+++ b/core/network/src/commonMain/kotlin/com/mifos/core/network/model/GetGenderOptions.kt
@@ -11,13 +11,6 @@ package com.mifos.core.network.model
 
 import kotlinx.serialization.Serializable
 
-/**
- *
- *
- * @param id
- * @param name
- */
-
 @Serializable
 data class GetGenderOptions(
 

--- a/core/network/src/commonMain/kotlin/com/mifos/core/network/model/GetGenderOptions.kt
+++ b/core/network/src/commonMain/kotlin/com/mifos/core/network/model/GetGenderOptions.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/android-client/blob/master/LICENSE.md
+ */
+package com.mifos.core.network.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ *
+ *
+ * @param id
+ * @param name
+ */
+
+@Serializable
+data class GetGenderOptions(
+
+    val id: Long? = null,
+
+    val name: String? = null,
+
+)

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientDetailsProfile/ClientProfileDetailsViewModel.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientDetailsProfile/ClientProfileDetailsViewModel.kt
@@ -147,7 +147,11 @@ internal class ClientProfileDetailsViewModel(
         if (client == null) return emptyList()
 
         val personalInfo = mapOf(
-            Res.string.gender to getString(Res.string.string_not_available),
+            Res.string.gender to (
+                client.gender?.name?.takeIf { it.isNotBlank() }
+                    ?: getString(Res.string.string_not_available)
+                ),
+
             Res.string.date_of_birth to
                 (
                     client.dateOfBirth.toDateString().takeIf { it.isNotBlank() }
@@ -175,8 +179,14 @@ internal class ClientProfileDetailsViewModel(
                 client.legalForm?.value?.takeIf { it.isNotBlank() }
                     ?: getString(Res.string.string_not_available)
                 ),
-            Res.string.client_type to getString(Res.string.string_not_available),
-            Res.string.client_classification to getString(Res.string.string_not_available),
+            Res.string.client_type to (
+                client.clientType?.name?.takeIf { it.isNotBlank() }
+                    ?: getString(Res.string.string_not_available)
+                ),
+            Res.string.client_classification to (
+                client.clientClassification?.name?.takeIf { it.isNotBlank() }
+                    ?: getString(Res.string.string_not_available)
+                ),
             Res.string.submission_date to (
                 client.timeline?.submittedOnDate?.toDateString()?.takeIf { it.isNotBlank() }
                     ?: getString(Res.string.string_not_available)

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditDetails/ClientEditDetailsScreen.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditDetails/ClientEditDetailsScreen.kt
@@ -490,7 +490,7 @@ private fun UpdateClientDetailsContent(
             Spacer(modifier = Modifier.height(DesignToken.spacing.small))
             clientTemplate.genderOptions?.let { list ->
                 MifosTextFieldDropdown(
-                    enabled = list.isNotEmpty(),
+                    enabled = gender.isNotEmpty(),
                     value = gender,
                     onValueChanged = { gender = it },
                     onOptionSelected = { index, value ->
@@ -498,7 +498,7 @@ private fun UpdateClientDetailsContent(
                         genderId = list[index].id
                     },
                     label = stringResource(Res.string.feature_client_gender),
-                    options = list.sortedBy { it.id }.map { it.name },
+                    options = list.map { it.name },
                     readOnly = true,
                 )
             }
@@ -628,7 +628,7 @@ private fun UpdateClientDetailsContent(
                         selectedClientTypeId = list[index].id
                     },
                     label = stringResource(Res.string.feature_client_client),
-                    options = list.sortedBy { it.id }.map { it.name },
+                    options = list.map { it.name },
                     readOnly = true,
                 )
             }
@@ -643,7 +643,7 @@ private fun UpdateClientDetailsContent(
                         selectedClientClassificationId = list[index].id
                     },
                     label = stringResource(Res.string.feature_client_client_classification),
-                    options = list.sortedBy { it.id }.map { it.name },
+                    options = list.map { it.name },
                     readOnly = true,
                 )
             }

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditDetails/ClientEditDetailsScreen.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditDetails/ClientEditDetailsScreen.kt
@@ -490,7 +490,7 @@ private fun UpdateClientDetailsContent(
             Spacer(modifier = Modifier.height(DesignToken.spacing.small))
             clientTemplate.genderOptions?.let { list ->
                 MifosTextFieldDropdown(
-                    enabled = gender.isNotEmpty(),
+                    enabled = list.isNotEmpty(),
                     value = gender,
                     onValueChanged = { gender = it },
                     onOptionSelected = { index, value ->
@@ -620,7 +620,7 @@ private fun UpdateClientDetailsContent(
 
             clientTemplate.clientTypeOptions?.let { list ->
                 MifosTextFieldDropdown(
-                    enabled = clientType.isNotEmpty(),
+                    enabled = list.isNotEmpty(),
                     value = clientType,
                     onValueChanged = { clientType = it },
                     onOptionSelected = { index, value ->
@@ -635,7 +635,7 @@ private fun UpdateClientDetailsContent(
 
             clientTemplate.clientClassificationOptions?.let { list ->
                 MifosTextFieldDropdown(
-                    enabled = clientClassification.isNotEmpty(),
+                    enabled = list.isNotEmpty(),
                     value = clientClassification,
                     onValueChanged = { clientClassification = it },
                     onOptionSelected = { index, value ->

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditDetails/ClientEditDetailsScreen.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditDetails/ClientEditDetailsScreen.kt
@@ -336,6 +336,12 @@ private fun UpdateClientDetailsContent(
             staff = client.staffName ?: ""
             selectedStaffId = client.staffId
             emailAddress = client.emailAddress ?: ""
+            genderId = client.gender?.id ?: 0
+            gender = client.gender?.name ?: ""
+            selectedClientTypeId = client.clientType?.id ?: 0
+            clientType = client.clientType?.name ?: ""
+            selectedClientClassificationId = client.clientClassification?.id ?: 0
+            clientClassification = client.clientClassification?.name ?: ""
 
             client.dateOfBirth.let { dateOfBirth = dateListToTimestamp(it) }
             client.activationDate.let { activationDate = dateListToTimestamp(it) }


### PR DESCRIPTION
Fixes - [Jira-#579](https://mifosforge.jira.com/browse/MIFOSAC-579)

- Created separate database entities for gender, client type, and client classification following the same pattern as ClientStatusEntity
- Added `ClientGenderEntity`, `ClientTypeEntity`, `ClientClassificationEntity` in core/database
- Register converters in the `CustomTypeConverters` for serializing/deserializing these entities to/from JSON
- Added `GetGenderOptions`, `GetClientTypeOptions`, `GetClientClassificationOptions` in `core/network` and updated the `ClientMapper` accordingly.  
- Updated ClientProfileDetailsViewModel to access data properly instead of hardcoded "Not Available" fallback

>[!Note]
`GenderOptions`, `ClientTypeOptions`, `ClientClassificationOptions.kt` though present in the `core/model/objects/organisations` was never used. For consistency we have added new models in the `core/network` and kept the old files as is.


| Before                                     | After                                  |
|--------------------------------------------|----------------------------------------|
|<img width="300" height="1600" alt="image" src="https://github.com/user-attachments/assets/441dac26-cc7c-42f1-92cc-5f0eb9a63aae" /> | <img width="300" height="1600" alt="image" src="https://github.com/user-attachments/assets/3ebe9306-d21d-4fef-bdf2-0c2e2183997e" /> |


### Also did respective changes in the ClientEditDetailsScreen
<img width="200" height="1600" alt="image" src="https://github.com/user-attachments/assets/482bf64d-d3a4-45c4-9e32-59901dff09e0" />
<img width="200" height="1600" alt="image" src="https://github.com/user-attachments/assets/34831aa6-9c33-4534-b5ca-ecb404a31f84" />

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the static analysis check `./gradlew check` or `ci-prepush.sh` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

> Related PR - #2517

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client gender, client type, and client classification fields across profiles and edit screens.
  * Profiles now display these attributes with "not available" fallbacks when missing.
  * Edit screens populate and enable dropdowns for these fields and include them in data sync.
  * Dropdown options are driven by available server-provided lists for each field.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->