### PR TITLE
feat(client): sort client list by status and persist filters on refresh

### DIFF
--- a/feature/client/src/androidMain/kotlin/com/mifos/feature/client/clientsList/ClientListScreen.android.kt
+++ b/feature/client/src/androidMain/kotlin/com/mifos/feature/client/clientsList/ClientListScreen.android.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.paging.LoadState
@@ -66,92 +67,89 @@ internal actual fun LazyColumnForClientListApi(
         is LoadState.NotLoading -> Unit
     }
 
-    if (sort != null) {
+    val displayList = remember(clientPagingList.itemSnapshotList, sort) {
         val currentItems = clientPagingList.itemSnapshotList.items
 
-        val sortedItems = when (sort) {
-            SortTypes.NAME -> {
-                currentItems.sortedBy { it.displayName?.lowercase() }
-            }
-            SortTypes.ACCOUNT_NUMBER -> {
-                currentItems.sortedBy { it.accountNo }
-            }
-            SortTypes.EXTERNAL_ID -> {
-                currentItems.sortedBy { it.externalId }
-            }
-            else -> currentItems
+        when (sort) {
+            SortTypes.NAME -> currentItems.sortedBy { it.displayName?.lowercase() }
+            SortTypes.ACCOUNT_NUMBER -> currentItems.sortedBy { it.accountNo }
+            SortTypes.EXTERNAL_ID -> currentItems.sortedBy { it.externalId }
+            else -> currentItems.sortedBy { getStatusOrder(it.status?.value) }
         }
+    }
 
-        LazyColumn(
-            modifier = modifier,
-        ) {
-            items(
-                items = sortedItems,
-                key = { client -> client.id },
-            ) { client ->
-                LaunchedEffect(client.id) {
-                    fetchImage(client.id)
-                }
-                ClientItem(
-                    client = client,
-                    byteArray = images[client.id],
-                    onClientClick = onClientSelect,
-                )
+    if (clientPagingList.itemCount > 0) {
+        LaunchedEffect(clientPagingList.itemCount, displayList.size) {
+            val lastRawIndex = clientPagingList.itemCount - 1
+            if ((displayList.isEmpty() || displayList.size < 10) && lastRawIndex >= 0) {
+                clientPagingList[lastRawIndex]
             }
         }
-    } else {
-        LazyColumn(
-            modifier = modifier,
-        ) {
-            items(
-                count = clientPagingList.itemCount,
-                key = { index -> clientPagingList[index]?.id ?: index },
-            ) { index ->
-                clientPagingList[index]?.let { client ->
-                    LaunchedEffect(client.id) {
-                        fetchImage(client.id)
+    }
+
+    LazyColumn(modifier = modifier) {
+        items(
+            items = displayList,
+            key = { client -> client.id },
+        ) { client ->
+            LaunchedEffect(client.id) { fetchImage(client.id) }
+
+            if (client == displayList.last()) {
+                LaunchedEffect(Unit) {
+                    val lastIndex = clientPagingList.itemCount - 1
+                    if (lastIndex >= 0) {
+                        clientPagingList[lastIndex]
                     }
-                    ClientItem(
-                        client = client,
-                        byteArray = images[client.id],
-                        onClientClick = onClientSelect,
-                    )
                 }
             }
 
-            when (clientPagingList.loadState.append) {
-                is LoadState.Error -> {
+            ClientItem(
+                client = client,
+                byteArray = images[client.id],
+                onClientClick = onClientSelect,
+            )
+        }
+
+        when (clientPagingList.loadState.append) {
+            is LoadState.Error -> {
+                item {
+                    MifosSweetError(message = stringResource(Res.string.feature_client_failed_to_more_clients)) {
+                        onRefresh()
+                    }
+                }
+            }
+
+            is LoadState.Loading -> {
+                item {
+                    MifosPagingAppendProgress()
+                }
+            }
+
+            is LoadState.NotLoading -> {
+                if (clientPagingList.loadState.append.endOfPaginationReached &&
+                    clientPagingList.itemCount > 0
+                ) {
                     item {
-                        MifosSweetError(message = stringResource(Res.string.feature_client_failed_to_more_clients)) {
-                            onRefresh()
-                        }
-                    }
-                }
-
-                is LoadState.Loading -> {
-                    item {
-                        MifosPagingAppendProgress()
-                    }
-                }
-
-                is LoadState.NotLoading -> {
-                    if (clientPagingList.loadState.append.endOfPaginationReached &&
-                        clientPagingList.itemCount > 0
-                    ) {
-                        item {
-                            Text(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(bottom = DesignToken.padding.extraExtraLarge)
-                                    .padding(bottom = DesignToken.padding.extraExtraLarge),
-                                text = stringResource(Res.string.feature_client_no_more_clients_available),
-                                style = MifosTypography.bodyMedium,
-                                textAlign = TextAlign.Center,
-                            )
-                        }
+                        Text(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(bottom = DesignToken.padding.extraExtraLarge)
+                                .padding(bottom = DesignToken.padding.extraExtraLarge),
+                            text = stringResource(Res.string.feature_client_no_more_clients_available),
+                            style = MifosTypography.bodyMedium,
+                            textAlign = TextAlign.Center,
+                        )
                     }
                 }
             }
         }
+    }
+}
+fun getStatusOrder(status: String?): Int {
+    return when (status?.lowercase()) {
+        "active" -> 1
+        "pending" -> 2
+        "closed" -> 3
+        else -> 4
     }
 }

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientsList/ClientListViewModel.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientsList/ClientListViewModel.kt
@@ -23,7 +23,6 @@ import com.mifos.core.ui.util.BaseViewModel
 import com.mifos.core.ui.util.imageToByteArray
 import com.mifos.room.entities.client.ClientEntity
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
@@ -149,23 +148,56 @@ internal class ClientListViewModel(
                 )
             }
 
-            is DataState.Success -> updateState {
-                val data = result.data.pageItems
-                if (data.isEmpty()) {
-                    it.copy(isEmpty = true, dialogState = null)
-                } else {
-                    it.copy(clients = data, dialogState = null, unfilteredClients = data)
+            is DataState.Success -> {
+                updateState { state ->
+                    val data = result.data.pageItems
+                    if (data.isEmpty()) {
+                        state.copy(isEmpty = true, dialogState = null)
+                    } else {
+                        val filteredData = data.filter { client ->
+                            val statusMatch = state.selectedStatus.isEmpty() || client.status?.value in state.selectedStatus
+                            val officeMatch = state.selectedOffices.isEmpty() || (client.officeName ?: "Null") in state.selectedOffices
+                            statusMatch && officeMatch
+                        }
+                        fun getStatusOrder(status: String?): Int {
+                            return when (status?.lowercase()) {
+                                "active" -> 1
+                                "pending" -> 2
+                                "closed" -> 3
+                                else -> 4
+                            }
+                        }
+                        val sortedList = when (state.sort) {
+                            SortTypes.NAME -> filteredData.sortedBy { it.displayName?.lowercase() }
+                            SortTypes.ACCOUNT_NUMBER -> filteredData.sortedBy { it.accountNo }
+                            SortTypes.EXTERNAL_ID -> filteredData.sortedBy { it.externalId }
+                            else -> filteredData.sortedBy { getStatusOrder(it.status?.value) }
+                        }
+                        state.copy(
+                            clients = sortedList,
+                            unfilteredClients = data,
+                            dialogState = null,
+                        )
+                    }
                 }
             }
         }
     }
 
     private fun handleClientResult(result: Flow<PagingData<ClientEntity>>) {
-        updateState {
+        updateState { state ->
+            val filteredFlow = result.map { pagingData ->
+                pagingData.filter { client ->
+                    val statusMatch = state.selectedStatus.isEmpty() || client.status?.value in state.selectedStatus
+                    val officeMatch = state.selectedOffices.isEmpty() || (client.officeName ?: "Null") in state.selectedOffices
+                    statusMatch && officeMatch
+                }
+            }
+
             state.copy(
-                clientsFlow = result,
-                dialogState = null,
+                clientsFlow = filteredFlow,
                 unfilteredClientsFlow = result,
+                dialogState = null,
             )
         }
     }


### PR DESCRIPTION
Fixes - [Jira-#631](https://mifosforge.jira.com/browse/MIFOSAC-631)

# Fix: Client List Sorting, Filter Persistence & Pagination Stall

## Overview
This PR addresses three core issues in the Client List feature to improve data presentation and user experience. It introduces a default business-logic sort order, ensures filters persist through refreshes, and fixes a critical bug where pagination would stop working when sorting and then filters were applied.

## Key Changes

### 1. Default "Business Logic" Sorting (Active → Pending → Closed)
* **The Change:** Implemented a default sort order that prioritizes clients by status: **Active** first, then **Pending**, then **Closed**. Consequently, the `if (sort != null)` conditional block was removed from the UI, as sorting logic is now always applied (either via the default business logic or user selection).
* **Behavior:** This sorting is applied client-side to the currently loaded pages. As the user scrolls and the Paging library fetches new pages, any newly discovered "Active" clients will automatically be sorted to the top of the list.
* **Technical Note / Limitation:** Since the backend API does not currently support server-side sorting for this data, this client-side approach is necessary. Users may initially perceive a limited number of "Active" users until they scroll down and trigger further pages to load. 

### Behavior Changes
| Before | After |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/b546e419-cf13-4d66-9c79-4225d4c04fc0" width="200" alt="Before"> | <img src="https://github.com/user-attachments/assets/d668e9a2-4725-4a0d-a9c8-6e2e9680494d" width="200" alt="After"> |

### 2. Fixed Filter Persistence on Refresh
* **The Issue:** Previously, triggering a refresh (e.g., when data failed to load) re-initialized the data flow in `loadClients()`, causing the active filters to be ignored or cleared.
* **The Fix:** Updated the `handleClientResult` logic to check the `ClientListState` immediately upon receiving new data. The new flow is now wrapped with the existing filter logic before being emitted to the UI, ensuring the user's context is preserved across reloads.

### Behavior Changes
| Before | After |
| :---: | :---: |
| <video src="https://github.com/user-attachments/assets/7447c0a8-5afa-498c-8d75-00375871b791" controls height="200"></video> | <video src="https://github.com/user-attachments/assets/de08c948-8310-405f-8ed0-9b0f5496192d" controls height="200"></video> |


### 3. Fixed "Pagination Stall" (Infinite Scroll Bug)
* **The Issue:** When a Sort and then Filter was applied, the displayed list often became shorter than the screen height (e.g., only 3 filtered items visible). Because the user could not scroll down to hit the Paging Library's "prefetch distance," the library assumed no more data was needed, and infinite scrolling stopped.
* **Technical Root Cause:** To support local client-side sorting, we must convert the live `LazyPagingItems` flow into a static `itemSnapshotList`. Accessing items in this static snapshot **does not** trigger the Paging Library's internal load mechanism (which normally auto-fetches data when indices are accessed). This disconnects the "live" trigger required for infinite scrolling.
* **The Fix:** Implemented a manual workaround in `LazyColumnForClientListApi` to bridge this gap:
    * **Auto-Fetch:** If the sorted/filtered list is empty or fails to fill the screen, the code programmatically triggers the Paging source to fetch the next page.
    * **Scroll Bridge:** Added logic to detect when the user reaches the bottom of the *sorted* list and triggers a load request on the *raw* list, ensuring seamless scrolling even when the sorted view differs from the API order.

### Behavior Changes
| Before | After |
| :---: | :---: |
| <video src="https://github.com/user-attachments/assets/570c1824-17e4-4b08-9b1c-a7bddd614c64" controls height="200"></video> | <video src="https://github.com/user-attachments/assets/a93ff9cb-fbee-413b-944d-893d69d89923" controls height="200"></video> |

## How to Test
1. **Sorting:** Open the client list. Verify that "Active" clients appear at the top by default. Scroll down and verify that new "Active" clients appearing in later pages jump to the correct position.
2. **Persistence:** Apply a status filter (e.g., "Pending"). Pull to refresh. Verify that the list reloads but the "Pending" filter remains active.
3. **Pagination:** Apply a sort and then filter that results in very few items (less than a full screen). Verify that the app automatically loads the next page to try and fill the screen. Scroll to the bottom of a sorted list and verify the next page loads correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic prefetch/loading of more clients when approaching list end

* **Improvements**
  * Unified, state-driven filtering applied consistently to local and remote client lists; preserves unfiltered data and clears dialogs
  * Default status-based sorting for predictable ordering
  * Consolidated, memoized single-list rendering for efficiency while preserving paging, loading/error states and lazy image loading
<!-- end of auto-generated comment: release notes by coderabbit.ai -->