### PR TITLE
fix(feature/loan): display Overpaid status for overpaid loan accounts

### DIFF
--- a/feature/loan/src/commonMain/composeResources/values/strings.xml
+++ b/feature/loan/src/commonMain/composeResources/values/strings.xml
@@ -108,6 +108,8 @@
     <string name="feature_loan_closed">Loan Closed</string>
     <string name="feature_loan_total_loan">Total Loan</string>
 
+    <string name="feature_loan_overpaid">Loan Overpaid</string>
+
     <string name="feature_loan_failed_to_load_loan_repayment">Failed to load loan repayment</string>
     <string name="feature_loan_repayment_make_sure_every_field_has_a_value">Make sure every field has a value</string>
     <string name="feature_loan_additional_payment">Additional Payment</string>

--- a/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/loanAccountSummary/LoanAccountSummaryScreen.kt
+++ b/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/loanAccountSummary/LoanAccountSummaryScreen.kt
@@ -36,6 +36,7 @@ import androidclient.feature.loan.generated.resources.feature_loan_loan_principa
 import androidclient.feature.loan.generated.resources.feature_loan_loan_rejected_message
 import androidclient.feature.loan.generated.resources.feature_loan_make_Repayment
 import androidclient.feature.loan.generated.resources.feature_loan_outstanding_balance
+import androidclient.feature.loan.generated.resources.feature_loan_overpaid
 import androidclient.feature.loan.generated.resources.feature_loan_repayment_schedule
 import androidclient.feature.loan.generated.resources.feature_loan_staff
 import androidclient.feature.loan.generated.resources.feature_loan_summary
@@ -706,6 +707,10 @@ fun getButtonText(status: LoanStatusEntity): String {
 
         status.waitingForDisbursal == true -> {
             stringResource(Res.string.feature_loan_disburse_loan)
+        }
+
+        status.overpaid == true -> {
+            stringResource(Res.string.feature_loan_overpaid)
         }
 
         else -> {


### PR DESCRIPTION
Fixes - [Jira-#Issue_Number](https://mifosforge.jira.com/browse/MIFOSAC-)

### Summary
Updated loan status handling to correctly display **Overpaid** for overpaid loan accounts in the Mobile App, aligning it with Web App behavior.

### Issue
For overpaid loan accounts, the Web App correctly shows **Overpaid**, but the Mobile App was incorrectly displaying **Loan Closed**.

### Fix
Added explicit handling for `status.overpaid == true` to ensure the correct button text/status is shown.

### Steps to Verify
1. Open the client loan list in the Web App → Account `000000016` shows **Overpaid**.
2. Open the same account in the Mobile App → Status now shows **Overpaid**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced loan status visibility: accounts that have exceeded payments now show an "Overpaid" label, and the loan account summary displays this status on the action button for clearer account standing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->