### PR TITLE
fix(client): enable loan repayment navigation from client loan accounts screen

### DIFF
--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientLoanAccounts/ClientLoanAccountsScreen.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientLoanAccounts/ClientLoanAccountsScreen.kt
@@ -241,7 +241,7 @@ private fun ClientLoanAccountsScreen(
                                                 ClientLoanAccountsAction.ViewAccount(loan.id ?: 0),
                                             )
                                             is Actions.MakeRepayment -> onAction(
-                                                ClientLoanAccountsAction.MakeRepayment,
+                                                ClientLoanAccountsAction.MakeRepayment(loan.id ?: 0),
                                             )
 
                                             else -> null

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientLoanAccounts/ClientLoanAccountsViewModel.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientLoanAccounts/ClientLoanAccountsViewModel.kt
@@ -39,7 +39,7 @@ class ClientLoanAccountsViewModel(
             }
 
             is ClientLoanAccountsAction.MakeRepayment -> {
-                sendEvent(ClientLoanAccountsEvent.MakeRepayment(state.clientId))
+                sendEvent(ClientLoanAccountsEvent.MakeRepayment(action.loanId))
             }
 
             ClientLoanAccountsAction.OnSearchClick -> {
@@ -231,7 +231,7 @@ sealed interface ClientLoanAccountsAction {
     data object NavigateBack : ClientLoanAccountsAction
     data object ToggleFilter : ClientLoanAccountsAction
     data object Refresh : ClientLoanAccountsAction
-    data object MakeRepayment : ClientLoanAccountsAction
+    data class MakeRepayment(val loanId: Int) : ClientLoanAccountsAction
     data class ViewAccount(val loanId: Int) : ClientLoanAccountsAction
     data class UpdateSearchValue(val query: String) : ClientLoanAccountsAction
     data object OnSearchClick : ClientLoanAccountsAction

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/navigation/ClientNavigation.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/navigation/ClientNavigation.kt
@@ -96,6 +96,7 @@ import com.mifos.feature.groups.navigation.navigateToGroupDetailsScreen
 import com.mifos.feature.loan.loanAccount.navigateToLoanAccountScreen
 import com.mifos.feature.loan.loanAccountProfile.navigateToLoanAccountProfileScreen
 import com.mifos.feature.loan.loanAccountSummary.navigateToLoanAccountSummaryScreen
+import com.mifos.feature.loan.loanRepayment.navigateToLoanRepaymentScreen
 import com.mifos.feature.loan.navigation.loanDestination
 import com.mifos.feature.loan.newLoanAccount.navigateToNewLoanAccountRoute
 import com.mifos.feature.note.navigation.noteDestination
@@ -336,7 +337,7 @@ fun NavGraphBuilder.clientNavGraph(
         clientLoanAccountsDestination(
             navigateBack = navController::popBackStack,
             navigateToViewAccount = navController::navigateToLoanAccountProfileScreen,
-            navigateToMakeRepayment = {},
+            navigateToMakeRepayment = navController::navigateToLoanRepaymentScreen,
             navController = navController,
             createAccount = { clientId, accountNo -> navController.navigateToNewLoanAccountRoute(clientId, accountNo) },
         )

--- a/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/loanRepayment/LoanRepaymentScreen.kt
+++ b/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/loanRepayment/LoanRepaymentScreen.kt
@@ -105,25 +105,34 @@ internal fun LoanRepaymentScreen(
     viewmodel: LoanRepaymentViewModel = koinViewModel(),
 ) {
     val uiState by viewmodel.loanRepaymentUiState.collectAsStateWithLifecycle()
+    val loanDetails by viewmodel.loanDetailsState.collectAsStateWithLifecycle()
 
     LaunchedEffect(key1 = Unit) {
-        viewmodel.checkDatabaseLoanRepaymentByLoanId()
+        if (loanDetails.loanAccountNumber.isNotEmpty()) {
+            viewmodel.checkDatabaseLoanRepaymentByLoanId()
+        }
     }
 
     LoanRepaymentScreen(
-        loanId = viewmodel.arg.loanId,
-        clientName = viewmodel.arg.clientName,
-        loanProductName = viewmodel.arg.loanProductName,
-        amountInArrears = viewmodel.arg.amountInArrears,
-        loanAccountNumber = viewmodel.arg.loanAccountNumber,
+        loanId = loanDetails.loanId,
+        clientName = loanDetails.clientName,
+        loanProductName = loanDetails.loanProductName,
+        amountInArrears = loanDetails.amountInArrears,
+        loanAccountNumber = loanDetails.loanAccountNumber,
         uiState = uiState,
         navigateBack = navigateBack,
-        onRetry = { viewmodel.checkDatabaseLoanRepaymentByLoanId() },
+        onRetry = {
+            if (loanDetails.loanAccountNumber.isEmpty()) {
+                viewmodel.loadLoanById()
+            } else {
+                viewmodel.checkDatabaseLoanRepaymentByLoanId()
+            }
+        },
         submitPayment = {
             viewmodel.submitPayment(it)
         },
         onLoanRepaymentDoesNotExistInDatabase = {
-            viewmodel.loanLoanRepaymentTemplate()
+            viewmodel.loadLoanRepaymentTemplate()
         },
         formatCurrency = viewmodel::formatCurrency,
         calculateTotal = viewmodel::calculateTotal,

--- a/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/loanRepayment/LoanRepaymentScreenRoute.kt
+++ b/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/loanRepayment/LoanRepaymentScreenRoute.kt
@@ -19,8 +19,8 @@ import kotlinx.serialization.Serializable
 data class LoanRepaymentScreenRoute(
     var clientName: String = "",
     var loanId: Int = 0,
-    var loanAccountNumber: String,
-    var loanProductName: String,
+    var loanAccountNumber: String = "",
+    var loanProductName: String = "",
     var amountInArrears: Double? = 0.0,
 )
 
@@ -42,6 +42,14 @@ fun NavController.navigateToLoanRepaymentScreen(loanWithAssociations: LoanWithAs
             loanAccountNumber = loanWithAssociations.accountNo,
             loanProductName = loanWithAssociations.loanProductName,
             amountInArrears = loanWithAssociations.summary.totalOverdue,
+        ),
+    )
+}
+
+fun NavController.navigateToLoanRepaymentScreen(loanId: Int) {
+    navigate(
+        LoanRepaymentScreenRoute(
+            loanId = loanId,
         ),
     )
 }

--- a/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/loanRepayment/LoanRepaymentViewModel.kt
+++ b/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/loanRepayment/LoanRepaymentViewModel.kt
@@ -12,34 +12,90 @@ package com.mifos.feature.loan.loanRepayment
 import androidclient.feature.loan.generated.resources.Res
 import androidclient.feature.loan.generated.resources.feature_loan_failed_to_load_loan_repayment
 import androidclient.feature.loan.generated.resources.feature_loan_payment_failed
+import androidclient.feature.loan.generated.resources.feature_loan_profile_error_details_not_found
+import androidclient.feature.loan.generated.resources.feature_loan_profile_failed_to_load_loan
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.mifos.core.common.utils.CurrencyFormatter
 import com.mifos.core.common.utils.DataState
+import com.mifos.core.data.repository.LoanAccountSummaryRepository
 import com.mifos.core.data.repository.LoanRepaymentRepository
 import com.mifos.room.entities.accounts.loans.LoanRepaymentRequestEntity
-import com.mifos.room.entities.templates.loans.LoanRepaymentTemplateEntity
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlin.math.round
 
 class LoanRepaymentViewModel(
     savedStateHandle: SavedStateHandle,
     private val repository: LoanRepaymentRepository,
+    private val summaryRepository: LoanAccountSummaryRepository,
 ) : ViewModel() {
 
-    val arg = savedStateHandle.toRoute<LoanRepaymentScreenRoute>()
+    private val args = savedStateHandle.toRoute<LoanRepaymentScreenRoute>()
+    private val _loanDetailsState = MutableStateFlow(LoanDetails())
+    val loanDetailsState = _loanDetailsState.asStateFlow()
 
     private val _loanRepaymentUiState =
         MutableStateFlow<LoanRepaymentUiState>(LoanRepaymentUiState.ShowProgressbar)
     val loanRepaymentUiState: StateFlow<LoanRepaymentUiState> get() = _loanRepaymentUiState
 
-    fun loanLoanRepaymentTemplate() {
+    init {
+        if (args.loanAccountNumber.isEmpty()) {
+            loadLoanById()
+        } else {
+            _loanDetailsState.value = _loanDetailsState.value.copy(
+                loanAccountNumber = args.loanAccountNumber,
+                loanId = args.loanId,
+                clientName = args.clientName,
+                loanProductName = args.loanProductName,
+                amountInArrears = args.amountInArrears,
+            )
+        }
+    }
+
+    fun loadLoanById() {
         viewModelScope.launch {
-            repository.getLoanRepayTemplate(arg.loanId).collect { state ->
+            summaryRepository.getLoanById(args.loanId).collect { dataState ->
+                when (dataState) {
+                    is DataState.Loading -> {
+                        _loanRepaymentUiState.value = LoanRepaymentUiState.ShowProgressbar
+                    }
+
+                    is DataState.Success -> {
+                        val loanWithAssociations = dataState.data
+                        if (loanWithAssociations == null) {
+                            _loanRepaymentUiState.value = LoanRepaymentUiState.ShowError(
+                                Res.string.feature_loan_profile_error_details_not_found,
+                            )
+                            return@collect
+                        }
+                        _loanDetailsState.value = _loanDetailsState.value.copy(
+                            loanId = loanWithAssociations.id,
+                            clientName = loanWithAssociations.clientName,
+                            loanProductName = loanWithAssociations.loanProductName,
+                            amountInArrears = loanWithAssociations.summary.totalOverdue,
+                            loanAccountNumber = loanWithAssociations.accountNo,
+                        )
+                        checkDatabaseLoanRepaymentByLoanId()
+                    }
+
+                    is DataState.Error -> {
+                        _loanRepaymentUiState.value = LoanRepaymentUiState.ShowError(
+                            Res.string.feature_loan_profile_failed_to_load_loan,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun loadLoanRepaymentTemplate() {
+        viewModelScope.launch {
+            repository.getLoanRepayTemplate(args.loanId).collect { state ->
                 when (state) {
                     is DataState.Error ->
                         _loanRepaymentUiState.value =
@@ -47,13 +103,20 @@ class LoanRepaymentViewModel(
                                 Res.string
                                     .feature_loan_failed_to_load_loan_repayment,
                             )
+
                     DataState.Loading ->
                         _loanRepaymentUiState.value = LoanRepaymentUiState.ShowProgressbar
-                    is DataState.Success ->
-                        _loanRepaymentUiState.value =
-                            LoanRepaymentUiState.ShowLoanRepayTemplate(
-                                state.data ?: LoanRepaymentTemplateEntity(),
+
+                    is DataState.Success -> {
+                        val template = state.data
+                        if (template == null) {
+                            _loanRepaymentUiState.value = LoanRepaymentUiState.ShowError(
+                                Res.string.feature_loan_failed_to_load_loan_repayment,
                             )
+                            return@collect
+                        }
+                        _loanRepaymentUiState.value = LoanRepaymentUiState.ShowLoanRepayTemplate(template)
+                    }
                 }
             }
         }
@@ -64,7 +127,7 @@ class LoanRepaymentViewModel(
             _loanRepaymentUiState.value = LoanRepaymentUiState.ShowProgressbar
 
             try {
-                val loanRepaymentResponse = repository.submitPayment(arg.loanId, request)
+                val loanRepaymentResponse = repository.submitPayment(args.loanId, request)
                 _loanRepaymentUiState.value =
                     LoanRepaymentUiState.ShowPaymentSubmittedSuccessfully(
                         loanRepaymentResponse,
@@ -78,7 +141,7 @@ class LoanRepaymentViewModel(
 
     fun checkDatabaseLoanRepaymentByLoanId() {
         viewModelScope.launch {
-            repository.getDatabaseLoanRepaymentByLoanId(arg.loanId).collect { state ->
+            repository.getDatabaseLoanRepaymentByLoanId(args.loanId).collect { state ->
                 when (state) {
                     is DataState.Error ->
                         _loanRepaymentUiState.value =
@@ -86,8 +149,10 @@ class LoanRepaymentViewModel(
                                 Res.string
                                     .feature_loan_failed_to_load_loan_repayment,
                             )
+
                     DataState.Loading ->
                         _loanRepaymentUiState.value = LoanRepaymentUiState.ShowProgressbar
+
                     is DataState.Success -> {
                         if (state.data != null) {
                             _loanRepaymentUiState.value =
@@ -111,6 +176,7 @@ class LoanRepaymentViewModel(
                 0.0
             }
         }
+
         val total = setValue(fees) + setValue(amount) + setValue(additionalPayment)
         return round(total * 100) / 100.0
     }
@@ -134,3 +200,11 @@ class LoanRepaymentViewModel(
         } && paymentType.isNotBlank()
     }
 }
+
+data class LoanDetails(
+    val clientName: String = "",
+    val loanId: Int = 0,
+    val loanAccountNumber: String = "",
+    val loanProductName: String = "",
+    val amountInArrears: Double? = 0.0,
+)


### PR DESCRIPTION
Fixes - [Jira-#MIFOSAC-640](https://mifosforge.jira.com/browse/MIFOSAC-640)

##Description

This PR fixes the broken navigation flow for loan repayments from the Client Loan Accounts screen and introduces a more flexible navigation mechanism to handle both full entity objects and individual loan IDs.

## Problem
1. **Empty Navigation Lambda**: The lambda responsible for navigating to the loan repayment screen from `ClientLoanAccountsScreen` was empty, making the "Make Repayment" action non-functional.
2. **Type Mismatch**: The existing navigation route required a `LoanWithAssociationsEntity`. While this works for the `LoanAccountSummaryScreen`, only the `loanId` (Int) is readily available in the context of the client loan list. 
3. **Dependency Constraints**: The `LoanWithAssociationsEntity` is deeply integrated into the current summary screen logic and could not be removed or replaced without breaking existing functionality.

### Behavior Changes
| Before | After |
| :---: | :---: |
| <video src="https://github.com/user-attachments/assets/0aaff9f1-900b-448f-a137-61d9526ff387" controls height="200"></video> | <video src="https://github.com/user-attachments/assets/0542972c-4087-49d1-896c-90ba8eb553f2" controls height="200"></video> |

## Solution & Implementation
To resolve this without breaking existing features, I implemented a dual-support navigation strategy:

### 1. Navigation Overloading
I overloaded the `navigateToLoanRepaymentScreen` function. It now supports:
- The original navigation using the full `LoanWithAssociationsEntity`.
- A new navigation path that only requires a `loanId: Int`.

### 2. Route & ViewModel Enhancements
- **Optional Route Parameters**: Updated `LoanRepaymentScreenRoute` to make fields like `loanAccountNumber` and `clientName` optional.
- **Data Fetching Logic**: Modified `LoanRepaymentViewModel` to handle cases where only a `loanId` is provided. If the loan details are missing on initialization, the ViewModel now uses the `LoanAccountSummaryRepository` to fetch the complete loan data by ID.
- **Action Update**: Updated `ClientLoanAccountsScreen` to correctly pass the `loanId` to the action handler.

## How I Managed the Constraints
Instead of refactoring the entire navigation system—which would have affected the `LoanAccountSummaryScreen`—I chose to **overload the navigation function**. This allows the app to "lazy-load" the necessary loan details in the `LoanRepaymentViewModel` if they weren't provided during navigation. This ensures a seamless user experience regardless of which screen the repayment flow is started from.

## Changes
- **`ClientNavigation.kt`**: Connected the navigation lambda to the repayment screen.
- **`LoanRepaymentScreenRoute.kt`**: Added `loanId` overload and default parameter values.
- **`LoanRepaymentViewModel.kt`**: Added logic to fetch loan details by ID if parameters are missing.
- **`ClientLoanAccountsScreen.kt` / `ViewModel.kt`**: Updated actions to pass `loanId`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected loan repayment process to properly identify the selected loan when initiating a repayment

* **Improvements**
  * Loan account details now automatically load when accessing the repayment screen, reducing manual data entry requirements
  * Simplified and optimized navigation flow for initiating loan repayments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->