### PR TITLE
fix(common): correct date format in formatDate() for API compatibility

### DIFF
--- a/core/common/src/commonMain/kotlin/com/mifos/core/common/utils/ApiDateFormatter.kt
+++ b/core/common/src/commonMain/kotlin/com/mifos/core/common/utils/ApiDateFormatter.kt
@@ -9,6 +9,7 @@
  */
 package com.mifos.core.common.utils
 
+import com.mifos.core.model.utils.DateConstants
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
@@ -25,8 +26,8 @@ import kotlinx.datetime.toLocalDateTime
  * ```kotlin
  * val payload = ClientPayload(
  *     activationDate = ApiDateFormatter.formatForApi(dateMillis),
- *     dateFormat = ApiDateFormatter.dateFormat,
- *     locale = ApiDateFormatter.locale
+ *     dateFormat = ApiDateFormatter.DATE_FORMAT,
+ *     locale = ApiDateFormatter.LOCALE
  * )
  * ```
  */
@@ -36,22 +37,12 @@ object ApiDateFormatter {
      * Standard date format for Fineract API: "dd MMMM yyyy"
      * Example: "18 February 2026"
      */
-    const val DATE_FORMAT = "dd MMMM yyyy"
+    const val DATE_FORMAT = DateConstants.DATE_FORMAT
 
     /**
      * Standard locale for Fineract API
      */
-    const val LOCALE = "en"
-
-    /**
-     * Alias for DATE_FORMAT - the dateFormat parameter value to send to API
-     */
-    val dateFormat: String get() = DATE_FORMAT
-
-    /**
-     * Alias for LOCALE - the locale parameter value to send to API
-     */
-    val locale: String get() = LOCALE
+    const val LOCALE = DateConstants.LOCALE
 
     /**
      * Format epoch milliseconds to API date string using standard format.

--- a/core/common/src/commonMain/kotlin/com/mifos/core/common/utils/ApiDateFormatter.kt
+++ b/core/common/src/commonMain/kotlin/com/mifos/core/common/utils/ApiDateFormatter.kt
@@ -89,14 +89,15 @@ object ApiDateFormatter {
     fun formatForApi(date: LocalDate, pattern: DateFormatPattern): String {
         val day = date.dayOfMonth.toString().padStart(2, '0')
         val month = date.month
+        val monthNumber = date.monthNumber.toString().padStart(2, '0')
         val year = date.year
 
         return when (pattern) {
             DateFormatPattern.FULL_MONTH -> "$day ${month.toFullName()} $year"
             DateFormatPattern.SHORT_MONTH -> "$day ${month.toShortName()} $year"
-            DateFormatPattern.NUMERIC_DASH -> "$day-${month.number.toString().padStart(2, '0')}-$year"
-            DateFormatPattern.NUMERIC_SLASH -> "$day/${month.number.toString().padStart(2, '0')}/$year"
-            DateFormatPattern.ISO -> "$year-${month.number.toString().padStart(2, '0')}-$day"
+            DateFormatPattern.NUMERIC_DASH -> "$day-$monthNumber-$year"
+            DateFormatPattern.NUMERIC_SLASH -> "$day/$monthNumber/$year"
+            DateFormatPattern.ISO -> "$year-$monthNumber-$day"
             DateFormatPattern.FULL_MONTH_WITH_TIME -> "$day ${month.toFullName()} $year 00:00"
         }
     }
@@ -145,6 +146,7 @@ object ApiDateFormatter {
     ): String {
         val day = dateTime.dayOfMonth.toString().padStart(2, '0')
         val month = dateTime.month
+        val monthNumber = dateTime.monthNumber.toString().padStart(2, '0')
         val year = dateTime.year
         val hour = dateTime.hour.toString().padStart(2, '0')
         val minute = dateTime.minute.toString().padStart(2, '0')
@@ -152,9 +154,9 @@ object ApiDateFormatter {
         return when (pattern) {
             DateFormatPattern.FULL_MONTH -> "$day ${month.toFullName()} $year"
             DateFormatPattern.SHORT_MONTH -> "$day ${month.toShortName()} $year"
-            DateFormatPattern.NUMERIC_DASH -> "$day-${month.number.toString().padStart(2, '0')}-$year"
-            DateFormatPattern.NUMERIC_SLASH -> "$day/${month.number.toString().padStart(2, '0')}/$year"
-            DateFormatPattern.ISO -> "$year-${month.number.toString().padStart(2, '0')}-$day"
+            DateFormatPattern.NUMERIC_DASH -> "$day-$monthNumber-$year"
+            DateFormatPattern.NUMERIC_SLASH -> "$day/$monthNumber/$year"
+            DateFormatPattern.ISO -> "$year-$monthNumber-$day"
             DateFormatPattern.FULL_MONTH_WITH_TIME -> "$day ${month.toFullName()} $year $hour:$minute"
         }
     }

--- a/core/common/src/commonMain/kotlin/com/mifos/core/common/utils/ApiDateFormatter.kt
+++ b/core/common/src/commonMain/kotlin/com/mifos/core/common/utils/ApiDateFormatter.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/android-client/blob/master/LICENSE.md
+ */
+package com.mifos.core.common.utils
+
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+/**
+ * Centralized date formatter for Fineract API requests.
+ *
+ * This object provides standardized date formatting methods to ensure
+ * consistency between the date strings sent to the API and the dateFormat
+ * parameter that specifies how they should be parsed.
+ *
+ * Usage:
+ * ```kotlin
+ * val payload = ClientPayload(
+ *     activationDate = ApiDateFormatter.formatForApi(dateMillis),
+ *     dateFormat = ApiDateFormatter.dateFormat,
+ *     locale = ApiDateFormatter.locale
+ * )
+ * ```
+ */
+object ApiDateFormatter {
+
+    /**
+     * Standard date format for Fineract API: "dd MMMM yyyy"
+     * Example: "18 February 2026"
+     */
+    const val DATE_FORMAT = "dd MMMM yyyy"
+
+    /**
+     * Standard locale for Fineract API
+     */
+    const val LOCALE = "en"
+
+    /**
+     * Alias for DATE_FORMAT - the dateFormat parameter value to send to API
+     */
+    val dateFormat: String get() = DATE_FORMAT
+
+    /**
+     * Alias for LOCALE - the locale parameter value to send to API
+     */
+    val locale: String get() = LOCALE
+
+    /**
+     * Format epoch milliseconds to API date string using standard format.
+     *
+     * @param millis Epoch milliseconds
+     * @return Date string in "dd MMMM yyyy" format (e.g., "18 February 2026")
+     */
+    fun formatForApi(millis: Long): String {
+        return formatForApi(millis, DateFormatPattern.FULL_MONTH)
+    }
+
+    /**
+     * Format epoch milliseconds to date string using specified pattern.
+     *
+     * @param millis Epoch milliseconds
+     * @param pattern The date format pattern to use
+     * @return Formatted date string
+     */
+    fun formatForApi(millis: Long, pattern: DateFormatPattern): String {
+        val dateTime = Instant
+            .fromEpochMilliseconds(millis)
+            .toLocalDateTime(TimeZone.currentSystemDefault())
+
+        return formatDateTime(dateTime, pattern)
+    }
+
+    /**
+     * Format LocalDate to API date string using standard format.
+     *
+     * @param date LocalDate to format
+     * @return Date string in "dd MMMM yyyy" format (e.g., "18 February 2026")
+     */
+    fun formatForApi(date: LocalDate): String {
+        return formatForApi(date, DateFormatPattern.FULL_MONTH)
+    }
+
+    /**
+     * Format LocalDate to date string using specified pattern.
+     *
+     * @param date LocalDate to format
+     * @param pattern The date format pattern to use
+     * @return Formatted date string
+     */
+    fun formatForApi(date: LocalDate, pattern: DateFormatPattern): String {
+        val day = date.dayOfMonth.toString().padStart(2, '0')
+        val month = date.month
+        val year = date.year
+
+        return when (pattern) {
+            DateFormatPattern.FULL_MONTH -> "$day ${month.toFullName()} $year"
+            DateFormatPattern.SHORT_MONTH -> "$day ${month.toShortName()} $year"
+            DateFormatPattern.NUMERIC_DASH -> "$day-${month.number.toString().padStart(2, '0')}-$year"
+            DateFormatPattern.NUMERIC_SLASH -> "$day/${month.number.toString().padStart(2, '0')}/$year"
+            DateFormatPattern.ISO -> "$year-${month.number.toString().padStart(2, '0')}-$day"
+            DateFormatPattern.FULL_MONTH_WITH_TIME -> "$day ${month.toFullName()} $year 00:00"
+        }
+    }
+
+    /**
+     * Format date components (day, month, year) to API date string.
+     *
+     * @param day Day of month (1-31)
+     * @param month Month number (1-12)
+     * @param year Year
+     * @return Date string in "dd MMMM yyyy" format
+     */
+    fun formatForApi(day: Int, month: Int, year: Int): String {
+        val dayStr = day.toString().padStart(2, '0')
+        val monthName = getMonthName(month)
+        return "$dayStr $monthName $year"
+    }
+
+    /**
+     * Format date from list of integers [year, month, day] to API date string.
+     *
+     * @param dateComponents List containing [year, month, day]
+     * @return Date string in "dd MMMM yyyy" format
+     */
+    fun formatFromList(dateComponents: List<Int>): String {
+        require(dateComponents.size >= 3) { "Date components list must have at least 3 elements" }
+        val year = dateComponents[0]
+        val month = dateComponents[1]
+        val day = dateComponents[2]
+        return formatForApi(day, month, year)
+    }
+
+    /**
+     * Get the date format pattern string for a given pattern enum.
+     *
+     * @param pattern The DateFormatPattern enum value
+     * @return The pattern string to send as dateFormat parameter
+     */
+    fun getDateFormatString(pattern: DateFormatPattern): String {
+        return pattern.pattern
+    }
+
+    private fun formatDateTime(
+        dateTime: kotlinx.datetime.LocalDateTime,
+        pattern: DateFormatPattern,
+    ): String {
+        val day = dateTime.dayOfMonth.toString().padStart(2, '0')
+        val month = dateTime.month
+        val year = dateTime.year
+        val hour = dateTime.hour.toString().padStart(2, '0')
+        val minute = dateTime.minute.toString().padStart(2, '0')
+
+        return when (pattern) {
+            DateFormatPattern.FULL_MONTH -> "$day ${month.toFullName()} $year"
+            DateFormatPattern.SHORT_MONTH -> "$day ${month.toShortName()} $year"
+            DateFormatPattern.NUMERIC_DASH -> "$day-${month.number.toString().padStart(2, '0')}-$year"
+            DateFormatPattern.NUMERIC_SLASH -> "$day/${month.number.toString().padStart(2, '0')}/$year"
+            DateFormatPattern.ISO -> "$year-${month.number.toString().padStart(2, '0')}-$day"
+            DateFormatPattern.FULL_MONTH_WITH_TIME -> "$day ${month.toFullName()} $year $hour:$minute"
+        }
+    }
+
+    private fun kotlinx.datetime.Month.toFullName(): String {
+        return name.lowercase().replaceFirstChar { it.uppercase() }
+    }
+
+    private fun kotlinx.datetime.Month.toShortName(): String {
+        return name.take(3).lowercase().replaceFirstChar { it.uppercase() }
+    }
+
+    private fun getMonthName(month: Int): String {
+        return when (month) {
+            1 -> "January"
+            2 -> "February"
+            3 -> "March"
+            4 -> "April"
+            5 -> "May"
+            6 -> "June"
+            7 -> "July"
+            8 -> "August"
+            9 -> "September"
+            10 -> "October"
+            11 -> "November"
+            12 -> "December"
+            else -> throw IllegalArgumentException("Invalid month: $month")
+        }
+    }
+}

--- a/core/common/src/commonMain/kotlin/com/mifos/core/common/utils/DateFormatPattern.kt
+++ b/core/common/src/commonMain/kotlin/com/mifos/core/common/utils/DateFormatPattern.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/android-client/blob/master/LICENSE.md
+ */
+package com.mifos.core.common.utils
+
+/**
+ * Enum representing standard date format patterns used in Fineract API.
+ *
+ * The Fineract API accepts dates as strings with a dateFormat parameter
+ * that specifies how the date should be parsed. This enum provides
+ * standardized patterns to ensure consistency across the application.
+ */
+enum class DateFormatPattern(val pattern: String) {
+    /**
+     * Full month name format: "dd MMMM yyyy" (e.g., "18 February 2026")
+     * This is the standard format used by Fineract API for most date fields.
+     */
+    FULL_MONTH("dd MMMM yyyy"),
+
+    /**
+     * Abbreviated month name format: "dd MMM yyyy" (e.g., "18 Feb 2026")
+     * Used in some specific API endpoints.
+     */
+    SHORT_MONTH("dd MMM yyyy"),
+
+    /**
+     * Numeric format with dashes: "dd-MM-yyyy" (e.g., "18-02-2026")
+     * Commonly used for display purposes.
+     */
+    NUMERIC_DASH("dd-MM-yyyy"),
+
+    /**
+     * Numeric format with slashes: "dd/MM/yyyy" (e.g., "18/02/2026")
+     * Used for display purposes only, not recommended for API calls.
+     */
+    NUMERIC_SLASH("dd/MM/yyyy"),
+
+    /**
+     * ISO 8601 format: "yyyy-MM-dd" (e.g., "2026-02-18")
+     * Standard international date format.
+     */
+    ISO("yyyy-MM-dd"),
+
+    /**
+     * Full month with time: "dd MMMM yyyy HH:mm" (e.g., "18 February 2026 14:30")
+     * Used for timestamps with date and time.
+     */
+    FULL_MONTH_WITH_TIME("dd MMMM yyyy HH:mm"),
+}

--- a/core/common/src/commonMain/kotlin/com/mifos/core/common/utils/FormatDate.kt
+++ b/core/common/src/commonMain/kotlin/com/mifos/core/common/utils/FormatDate.kt
@@ -9,19 +9,28 @@
  */
 package com.mifos.core.common.utils
 
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
-import kotlin.time.ExperimentalTime
-import kotlin.time.Instant
-
-@OptIn(ExperimentalTime::class)
+/**
+ * Format epoch milliseconds to API-compatible date string.
+ *
+ * Returns date in "dd MMMM yyyy" format (e.g., "18 February 2026")
+ * which matches the standard Fineract API dateFormat parameter.
+ *
+ * @param millis Epoch milliseconds
+ * @return Formatted date string for API usage
+ * @see ApiDateFormatter for more formatting options
+ */
 fun formatDate(millis: Long): String {
-    val dateTime = Instant
-        .fromEpochMilliseconds(millis)
-        .toLocalDateTime(TimeZone.currentSystemDefault())
+    return ApiDateFormatter.formatForApi(millis)
+}
 
-    val day = dateTime.day.toString().padStart(2, '0')
-    val monthName = dateTime.month.name.lowercase().replaceFirstChar { it.uppercase() }
-    val year = dateTime.year
-    return "$day $monthName $year"
+/**
+ * Format epoch milliseconds to date string using specified pattern.
+ *
+ * @param millis Epoch milliseconds
+ * @param pattern The date format pattern to use
+ * @return Formatted date string
+ * @see ApiDateFormatter for more formatting options
+ */
+fun formatDate(millis: Long, pattern: DateFormatPattern): String {
+    return ApiDateFormatter.formatForApi(millis, pattern)
 }

--- a/core/common/src/commonMain/kotlin/com/mifos/core/common/utils/FormatDate.kt
+++ b/core/common/src/commonMain/kotlin/com/mifos/core/common/utils/FormatDate.kt
@@ -10,7 +10,6 @@
 package com.mifos.core.common.utils
 
 import kotlinx.datetime.TimeZone
-import kotlinx.datetime.number
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
@@ -22,7 +21,7 @@ fun formatDate(millis: Long): String {
         .toLocalDateTime(TimeZone.currentSystemDefault())
 
     val day = dateTime.day.toString().padStart(2, '0')
-    val month = dateTime.month.number.toString().padStart(2, '0')
+    val monthName = dateTime.month.name.lowercase().replaceFirstChar { it.uppercase() }
     val year = dateTime.year
-    return "$day/$month/$year"
+    return "$day $monthName $year"
 }

--- a/core/database/src/commonMain/kotlin/com/mifos/room/entities/collectionsheet/CollectionSheetPayload.kt
+++ b/core/database/src/commonMain/kotlin/com/mifos/room/entities/collectionsheet/CollectionSheetPayload.kt
@@ -9,6 +9,7 @@
  */
 package com.mifos.room.entities.collectionsheet
 
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.core.model.objects.collectionsheets.BulkSavingsDueTransaction
 import com.mifos.core.model.utils.IgnoredOnParcel
 import com.mifos.core.model.utils.Parcelable
@@ -34,9 +35,9 @@ data class CollectionSheetPayload(
 
     var clientsAttendance: MutableList<ClientsAttendance> = ArrayList(),
 
-    var dateFormat: String = "dd MMMM yyyy",
+    var dateFormat: String = ApiDateFormatter.DATE_FORMAT,
 
-    var locale: String = "en",
+    var locale: String = ApiDateFormatter.LOCALE,
 
     var transactionDate: String? = null,
 

--- a/core/database/src/commonMain/kotlin/com/mifos/room/entities/collectionsheet/ProductiveCollectionSheetPayload.kt
+++ b/core/database/src/commonMain/kotlin/com/mifos/room/entities/collectionsheet/ProductiveCollectionSheetPayload.kt
@@ -9,6 +9,7 @@
  */
 package com.mifos.room.entities.collectionsheet
 
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.core.model.utils.Parcelable
 import com.mifos.core.model.utils.Parcelize
 import com.mifos.room.entities.noncore.BulkRepaymentTransactions
@@ -24,9 +25,9 @@ data class ProductiveCollectionSheetPayload(
 
     var calendarId: Int? = 0,
 
-    var dateFormat: String? = "dd MMMM yyyy",
+    var dateFormat: String? = ApiDateFormatter.DATE_FORMAT,
 
-    var locale: String? = "en",
+    var locale: String? = ApiDateFormatter.LOCALE,
 
     var transactionDate: String? = null,
 ) : Parcelable

--- a/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/account/loan/LoanApproval.kt
+++ b/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/account/loan/LoanApproval.kt
@@ -9,7 +9,7 @@
  */
 package com.mifos.core.model.objects.account.loan
 
-import com.mifos.core.common.utils.ApiDateFormatter
+import com.mifos.core.model.utils.DateConstants
 import com.mifos.core.model.utils.Parcelable
 import com.mifos.core.model.utils.Parcelize
 
@@ -23,7 +23,7 @@ class LoanApproval(
 
     var note: String? = null,
 
-    var locale: String = ApiDateFormatter.LOCALE,
+    var locale: String = DateConstants.LOCALE,
 
-    var dateFormat: String = ApiDateFormatter.DATE_FORMAT,
+    var dateFormat: String = DateConstants.DATE_FORMAT,
 ) : Parcelable

--- a/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/account/loan/LoanApproval.kt
+++ b/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/account/loan/LoanApproval.kt
@@ -9,6 +9,7 @@
  */
 package com.mifos.core.model.objects.account.loan
 
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.core.model.utils.Parcelable
 import com.mifos.core.model.utils.Parcelize
 
@@ -22,7 +23,7 @@ class LoanApproval(
 
     var note: String? = null,
 
-    var locale: String = "en",
+    var locale: String = ApiDateFormatter.LOCALE,
 
-    var dateFormat: String = "dd MMMM yyyy",
+    var dateFormat: String = ApiDateFormatter.DATE_FORMAT,
 ) : Parcelable

--- a/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/account/loan/LoanApprovalRequest.kt
+++ b/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/account/loan/LoanApprovalRequest.kt
@@ -9,7 +9,7 @@
  */
 package com.mifos.core.model.objects.account.loan
 
-import com.mifos.core.common.utils.ApiDateFormatter
+import com.mifos.core.model.utils.DateConstants
 import com.mifos.core.model.utils.Parcelable
 import com.mifos.core.model.utils.Parcelize
 
@@ -18,9 +18,9 @@ import com.mifos.core.model.utils.Parcelize
  */
 @Parcelize
 data class LoanApprovalRequest(
-    var locale: String = ApiDateFormatter.LOCALE,
+    var locale: String = DateConstants.LOCALE,
 
-    var dateFormat: String = ApiDateFormatter.DATE_FORMAT,
+    var dateFormat: String = DateConstants.DATE_FORMAT,
 
     var approvedOnDate: String? = null,
 

--- a/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/account/loan/LoanApprovalRequest.kt
+++ b/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/account/loan/LoanApprovalRequest.kt
@@ -9,6 +9,7 @@
  */
 package com.mifos.core.model.objects.account.loan
 
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.core.model.utils.Parcelable
 import com.mifos.core.model.utils.Parcelize
 
@@ -17,9 +18,9 @@ import com.mifos.core.model.utils.Parcelize
  */
 @Parcelize
 data class LoanApprovalRequest(
-    var locale: String = "en",
+    var locale: String = ApiDateFormatter.LOCALE,
 
-    var dateFormat: String = "dd MM yyyy",
+    var dateFormat: String = ApiDateFormatter.DATE_FORMAT,
 
     var approvedOnDate: String? = null,
 

--- a/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/account/loan/LoanDisbursement.kt
+++ b/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/account/loan/LoanDisbursement.kt
@@ -9,7 +9,7 @@
  */
 package com.mifos.core.model.objects.account.loan
 
-import com.mifos.core.common.utils.ApiDateFormatter
+import com.mifos.core.model.utils.DateConstants
 import com.mifos.core.model.utils.Parcelable
 import com.mifos.core.model.utils.Parcelize
 
@@ -23,7 +23,7 @@ data class LoanDisbursement(
 
     var paymentId: Int? = null,
 
-    var locale: String? = ApiDateFormatter.LOCALE,
+    var locale: String? = DateConstants.LOCALE,
 
-    var dateFormat: String? = ApiDateFormatter.DATE_FORMAT,
+    var dateFormat: String? = DateConstants.DATE_FORMAT,
 ) : Parcelable

--- a/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/account/loan/LoanDisbursement.kt
+++ b/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/account/loan/LoanDisbursement.kt
@@ -9,6 +9,7 @@
  */
 package com.mifos.core.model.objects.account.loan
 
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.core.model.utils.Parcelable
 import com.mifos.core.model.utils.Parcelize
 
@@ -22,7 +23,7 @@ data class LoanDisbursement(
 
     var paymentId: Int? = null,
 
-    var locale: String? = "en",
+    var locale: String? = ApiDateFormatter.LOCALE,
 
-    var dateFormat: String? = "dd MMMM yyyy",
+    var dateFormat: String? = ApiDateFormatter.DATE_FORMAT,
 ) : Parcelable

--- a/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/account/loan/SavingsApproval.kt
+++ b/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/account/loan/SavingsApproval.kt
@@ -9,6 +9,7 @@
  */
 package com.mifos.core.model.objects.account.loan
 
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.core.model.utils.Parcelable
 import com.mifos.core.model.utils.Parcelize
 import kotlinx.serialization.Serializable
@@ -16,9 +17,9 @@ import kotlinx.serialization.Serializable
 @Parcelize
 @Serializable
 data class SavingsApproval(
-    var locale: String = "en",
+    var locale: String = ApiDateFormatter.LOCALE,
 
-    var dateFormat: String = "dd MMMM yyyy",
+    var dateFormat: String = ApiDateFormatter.DATE_FORMAT,
 
     var approvedOnDate: String? = null,
 

--- a/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/account/loan/SavingsApproval.kt
+++ b/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/account/loan/SavingsApproval.kt
@@ -9,7 +9,7 @@
  */
 package com.mifos.core.model.objects.account.loan
 
-import com.mifos.core.common.utils.ApiDateFormatter
+import com.mifos.core.model.utils.DateConstants
 import com.mifos.core.model.utils.Parcelable
 import com.mifos.core.model.utils.Parcelize
 import kotlinx.serialization.Serializable
@@ -17,9 +17,9 @@ import kotlinx.serialization.Serializable
 @Parcelize
 @Serializable
 data class SavingsApproval(
-    var locale: String = ApiDateFormatter.LOCALE,
+    var locale: String = DateConstants.LOCALE,
 
-    var dateFormat: String = ApiDateFormatter.DATE_FORMAT,
+    var dateFormat: String = DateConstants.DATE_FORMAT,
 
     var approvedOnDate: String? = null,
 

--- a/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/collectionsheets/CollectionSheetRequestPayload.kt
+++ b/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/collectionsheets/CollectionSheetRequestPayload.kt
@@ -9,7 +9,7 @@
  */
 package com.mifos.core.model.objects.collectionsheets
 
-import com.mifos.core.common.utils.ApiDateFormatter
+import com.mifos.core.model.utils.DateConstants
 import com.mifos.core.model.utils.Parcelable
 import com.mifos.core.model.utils.Parcelize
 
@@ -20,9 +20,9 @@ import com.mifos.core.model.utils.Parcelize
 data class CollectionSheetRequestPayload(
     var calendarId: Int? = null,
 
-    var dateFormat: String = ApiDateFormatter.DATE_FORMAT,
+    var dateFormat: String = DateConstants.DATE_FORMAT,
 
-    var locale: String = ApiDateFormatter.LOCALE,
+    var locale: String = DateConstants.LOCALE,
 
     var transactionDate: String? = null,
 ) : Parcelable

--- a/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/collectionsheets/CollectionSheetRequestPayload.kt
+++ b/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/collectionsheets/CollectionSheetRequestPayload.kt
@@ -9,6 +9,7 @@
  */
 package com.mifos.core.model.objects.collectionsheets
 
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.core.model.utils.Parcelable
 import com.mifos.core.model.utils.Parcelize
 
@@ -19,9 +20,9 @@ import com.mifos.core.model.utils.Parcelize
 data class CollectionSheetRequestPayload(
     var calendarId: Int? = null,
 
-    var dateFormat: String = "dd MMMM yyyy",
+    var dateFormat: String = ApiDateFormatter.DATE_FORMAT,
 
-    var locale: String = "en",
+    var locale: String = ApiDateFormatter.LOCALE,
 
     var transactionDate: String? = null,
 ) : Parcelable

--- a/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/users/UserLocation.kt
+++ b/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/users/UserLocation.kt
@@ -9,8 +9,7 @@
  */
 package com.mifos.core.model.objects.users
 
-import com.mifos.core.common.utils.ApiDateFormatter
-import com.mifos.core.common.utils.DateFormatPattern
+import com.mifos.core.model.utils.DateConstants
 import com.mifos.core.model.utils.Parcelable
 import com.mifos.core.model.utils.Parcelize
 import kotlinx.serialization.Serializable
@@ -35,7 +34,7 @@ data class UserLocation(
 
     var endAddress: String? = null,
 
-    var dateFormat: String? = DateFormatPattern.FULL_MONTH_WITH_TIME.pattern,
+    var dateFormat: String? = DateConstants.DATE_FORMAT_WITH_TIME,
 
-    var locale: String? = ApiDateFormatter.LOCALE,
+    var locale: String? = DateConstants.LOCALE,
 ) : Parcelable

--- a/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/users/UserLocation.kt
+++ b/core/model/src/commonMain/kotlin/com/mifos/core/model/objects/users/UserLocation.kt
@@ -9,6 +9,8 @@
  */
 package com.mifos.core.model.objects.users
 
+import com.mifos.core.common.utils.ApiDateFormatter
+import com.mifos.core.common.utils.DateFormatPattern
 import com.mifos.core.model.utils.Parcelable
 import com.mifos.core.model.utils.Parcelize
 import kotlinx.serialization.Serializable
@@ -33,7 +35,7 @@ data class UserLocation(
 
     var endAddress: String? = null,
 
-    var dateFormat: String? = "dd MMMM yyyy HH:mm",
+    var dateFormat: String? = DateFormatPattern.FULL_MONTH_WITH_TIME.pattern,
 
-    var locale: String? = "en",
+    var locale: String? = ApiDateFormatter.LOCALE,
 ) : Parcelable

--- a/core/model/src/commonMain/kotlin/com/mifos/core/model/utils/DateConstants.kt
+++ b/core/model/src/commonMain/kotlin/com/mifos/core/model/utils/DateConstants.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/android-client/blob/master/LICENSE.md
+ */
+package com.mifos.core.model.utils
+
+/**
+ * Standard date format constants for Fineract API.
+ *
+ * These constants ensure consistency between the date strings sent to the API
+ * and the dateFormat parameter that specifies how they should be parsed.
+ */
+object DateConstants {
+    /**
+     * Standard date format for Fineract API: "dd MMMM yyyy"
+     * Example: "18 February 2026"
+     */
+    const val DATE_FORMAT = "dd MMMM yyyy"
+
+    /**
+     * Standard locale for Fineract API
+     */
+    const val LOCALE = "en"
+
+    /**
+     * Date format with time: "dd MMMM yyyy HH:mm"
+     * Example: "18 February 2026 14:30"
+     */
+    const val DATE_FORMAT_WITH_TIME = "dd MMMM yyyy HH:mm"
+}

--- a/core/network/src/commonMain/kotlin/com/mifos/core/network/datamanager/DataManagerClient.kt
+++ b/core/network/src/commonMain/kotlin/com/mifos/core/network/datamanager/DataManagerClient.kt
@@ -9,6 +9,7 @@
  */
 package com.mifos.core.network.datamanager
 
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.core.common.utils.DataState
 import com.mifos.core.common.utils.Page
 import com.mifos.core.common.utils.asDataStateFlow
@@ -501,8 +502,8 @@ class DataManagerClient(
                 destinationOfficeId = destinationOfficeId,
                 transferDate = transferDate,
                 note = note,
-                locale = "en",
-                dateFormat = "dd-MM-yyyy",
+                locale = ApiDateFormatter.LOCALE,
+                dateFormat = ApiDateFormatter.DATE_FORMAT,
             ),
         )
     }
@@ -517,8 +518,8 @@ class DataManagerClient(
             payload = ClientCloseRequest(
                 closureDate = closureDate,
                 closureReasonId = closureReasonId,
-                dateFormat = "dd-MM-yyyy",
-                locale = "en",
+                dateFormat = ApiDateFormatter.DATE_FORMAT,
+                locale = ApiDateFormatter.LOCALE,
             ),
         )
     }

--- a/core/network/src/commonMain/kotlin/com/mifos/core/network/model/DefaultPayload.kt
+++ b/core/network/src/commonMain/kotlin/com/mifos/core/network/model/DefaultPayload.kt
@@ -9,11 +9,13 @@
  */
 package com.mifos.core.network.model
 
+import com.mifos.core.common.utils.ApiDateFormatter
+
 /**
  * Created by ADMIN on 16-Jun-15.
  */
 
 data class DefaultPayload(
-    var dateFormat: String = "dd MMMM YYYY",
-    var locale: String = "en",
+    var dateFormat: String = ApiDateFormatter.DATE_FORMAT,
+    var locale: String = ApiDateFormatter.LOCALE,
 )

--- a/core/network/src/commonMain/kotlin/com/mifos/core/network/model/IndividualCollectionSheetPayload.kt
+++ b/core/network/src/commonMain/kotlin/com/mifos/core/network/model/IndividualCollectionSheetPayload.kt
@@ -9,6 +9,7 @@
  */
 package com.mifos.core.network.model
 
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.core.model.utils.Parcelable
 import com.mifos.core.model.utils.Parcelize
 import com.mifos.room.entities.noncore.BulkRepaymentTransactions
@@ -25,7 +26,7 @@ data class IndividualCollectionSheetPayload(
     var actualDisbursementDate: String? = null,
     var bulkDisbursementTransactions: List<BulkRepaymentTransactions> = ArrayList(),
     var bulkSavingsDueTransactions: List<BulkRepaymentTransactions> = ArrayList(),
-    var dateFormat: String = "dd MMMM YYYY",
-    var locale: String = "en",
+    var dateFormat: String = ApiDateFormatter.DATE_FORMAT,
+    var locale: String = ApiDateFormatter.LOCALE,
     var transactionDate: String? = null,
 ) : Parcelable

--- a/core/network/src/commonMain/kotlin/com/mifos/core/network/model/Payload.kt
+++ b/core/network/src/commonMain/kotlin/com/mifos/core/network/model/Payload.kt
@@ -9,13 +9,14 @@
  */
 package com.mifos.core.network.model
 
+import com.mifos.core.common.utils.ApiDateFormatter
 import kotlinx.serialization.Serializable
 
 // TODO Remove calendarId and TransactionDate from this Payload class;
 @Serializable
 open class Payload {
-    var dateFormat = "dd MMMM YYYY"
-    var locale = "en"
+    var dateFormat = ApiDateFormatter.DATE_FORMAT
+    var locale = ApiDateFormatter.LOCALE
     var calendarId: Long = 0
     var transactionDate: String? = null
     override fun toString(): String {

--- a/feature/activate/src/commonMain/kotlin/com/mifos/feature/activate/ActivateScreen.kt
+++ b/feature/activate/src/commonMain/kotlin/com/mifos/feature/activate/ActivateScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mifos.core.common.utils.ApiDateFormatter
+import com.mifos.core.common.utils.Constants
 import com.mifos.core.common.utils.DateHelper
 import com.mifos.core.common.utils.formatDate
 import com.mifos.core.designsystem.component.MifosButton

--- a/feature/activate/src/commonMain/kotlin/com/mifos/feature/activate/ActivateScreen.kt
+++ b/feature/activate/src/commonMain/kotlin/com/mifos/feature/activate/ActivateScreen.kt
@@ -44,7 +44,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.mifos.core.common.utils.Constants
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.core.common.utils.DateHelper
 import com.mifos.core.common.utils.formatDate
 import com.mifos.core.designsystem.component.MifosButton
@@ -195,8 +195,8 @@ private fun ActivateContent(
                 onActivate(
                     ActivatePayload(
                         activationDate = formatDate(activateDate),
-                        dateFormat = Constants.DATE_FORMAT_LONG,
-                        locale = Constants.LOCALE_EN,
+                        dateFormat = ApiDateFormatter.DATE_FORMAT,
+                        locale = ApiDateFormatter.LOCALE,
                     ),
                 )
             },

--- a/feature/center/src/commonMain/kotlin/com/mifos/feature/center/createCenter/CreateNewCenterScreen.kt
+++ b/feature/center/src/commonMain/kotlin/com/mifos/feature/center/createCenter/CreateNewCenterScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.core.common.utils.formatDate
 import com.mifos.core.designsystem.component.MifosButton
 import com.mifos.core.designsystem.component.MifosDatePickerTextField
@@ -295,8 +296,8 @@ private fun CreateNewCenterContent(
                                 null
                             },
                             officeId = officeId,
-                            dateFormat = "dd MMMM yyyy",
-                            locale = "en",
+                            dateFormat = ApiDateFormatter.DATE_FORMAT,
+                            locale = ApiDateFormatter.LOCALE,
                         ),
                     )
                 }

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditDetails/ClientEditDetailsScreen.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditDetails/ClientEditDetailsScreen.kt
@@ -90,8 +90,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
-import com.mifos.core.common.utils.DateHelper
 import com.mifos.core.common.utils.ApiDateFormatter
+import com.mifos.core.common.utils.DateHelper
 import com.mifos.core.common.utils.formatDate
 import com.mifos.core.designsystem.component.MifosDatePickerTextField
 import com.mifos.core.designsystem.component.MifosOutlinedTextField

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditDetails/ClientEditDetailsScreen.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientEditDetails/ClientEditDetailsScreen.kt
@@ -91,6 +91,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.mifos.core.common.utils.DateHelper
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.core.common.utils.formatDate
 import com.mifos.core.designsystem.component.MifosDatePickerTextField
 import com.mifos.core.designsystem.component.MifosOutlinedTextField
@@ -992,9 +993,6 @@ private fun createClientPayload(
     selectedClientClassificationId: Int,
     legalFormId: Int?,
 ): ClientPayloadEntity {
-    val dateFormat = "dd MMMM yyyy"
-    val locale = "en"
-
     var clientPayload = ClientPayloadEntity(
         // Mandatory fields
         firstname = firstName,
@@ -1007,8 +1005,8 @@ private fun createClientPayload(
         activationDate = formatDate(activationDate),
         submittedOnDate = formatDate(submissionDate),
         dateOfBirth = formatDate(dateOfBirth),
-        dateFormat = dateFormat,
-        locale = locale,
+        dateFormat = ApiDateFormatter.DATE_FORMAT,
+        locale = ApiDateFormatter.LOCALE,
     )
 
     if (PhoneNumberUtil.isGlobalPhoneNumber(mobileNumber)) {

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/createNewClient/CreateNewClientScreen.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/createNewClient/CreateNewClientScreen.kt
@@ -114,8 +114,8 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.rememberAsyncImagePainter
-import com.mifos.core.common.utils.DateHelper
 import com.mifos.core.common.utils.ApiDateFormatter
+import com.mifos.core.common.utils.DateHelper
 import com.mifos.core.common.utils.formatDate
 import com.mifos.core.designsystem.component.MifosDatePickerTextField
 import com.mifos.core.designsystem.component.MifosOutlinedTextField

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/createNewClient/CreateNewClientScreen.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/createNewClient/CreateNewClientScreen.kt
@@ -115,6 +115,7 @@ import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.rememberAsyncImagePainter
 import com.mifos.core.common.utils.DateHelper
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.core.common.utils.formatDate
 import com.mifos.core.designsystem.component.MifosDatePickerTextField
 import com.mifos.core.designsystem.component.MifosOutlinedTextField
@@ -825,9 +826,6 @@ private fun createClientPayload(
     countryId: Int,
     postalCode: String,
 ): ClientPayloadEntity {
-    val dateFormat = "dd MMMM yyyy"
-    val locale = "en"
-
     var clientPayload = ClientPayloadEntity(
         // Mandatory fields
         firstname = firstName,
@@ -839,8 +837,8 @@ private fun createClientPayload(
         active = isActive,
         activationDate = formatDate(activationDate),
         dateOfBirth = formatDate(dateOfBirth),
-        dateFormat = dateFormat,
-        locale = locale,
+        dateFormat = ApiDateFormatter.DATE_FORMAT,
+        locale = ApiDateFormatter.LOCALE,
     )
     if (isAddressEnabled) {
         val address = Address(

--- a/feature/collectionSheet/src/commonMain/kotlin/com/mifos/feature/individualCollectionSheet/newIndividualCollectionSheet/NewIndividualCollectionSheetScreen.kt
+++ b/feature/collectionSheet/src/commonMain/kotlin/com/mifos/feature/individualCollectionSheet/newIndividualCollectionSheet/NewIndividualCollectionSheetScreen.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.core.common.utils.DateHelper
 import com.mifos.core.designsystem.component.MifosBottomSheet
 import com.mifos.core.designsystem.component.MifosButton
@@ -95,8 +96,8 @@ internal fun NewIndividualCollectionSheetScreen(
                     officeId = id
                     transactionDate = date
                     staffId = idStaff
-                    locale = "en"
-                    dateFormat = "dd-MM-yyyy"
+                    locale = ApiDateFormatter.LOCALE
+                    dateFormat = ApiDateFormatter.DATE_FORMAT
                 },
             )
         },

--- a/feature/data-table/src/commonMain/kotlin/com/mifos/feature/dataTable/dataTableList/DataTableListViewModel.kt
+++ b/feature/data-table/src/commonMain/kotlin/com/mifos/feature/dataTable/dataTableList/DataTableListViewModel.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.core.common.utils.Constants
 import com.mifos.core.common.utils.DataState
 import com.mifos.core.data.repository.DataTableListRepository
@@ -200,8 +201,8 @@ class DataTableListViewModel(
 
     fun addDataTableInput(widgets: List<Any>): Map<String, Any> {
         val payload = mutableMapOf<String, Any>()
-        payload["dateFormat"] = "dd-mm-YYYY"
-        payload["locale"] = "en"
+        payload["dateFormat"] = ApiDateFormatter.DATE_FORMAT
+        payload["locale"] = ApiDateFormatter.LOCALE
 
         for (widget in widgets) {
             when (widget) {

--- a/feature/groups/src/commonMain/kotlin/com/mifos/feature/groups/createNewGroup/CreateNewGroupScreen.kt
+++ b/feature/groups/src/commonMain/kotlin/com/mifos/feature/groups/createNewGroup/CreateNewGroupScreen.kt
@@ -66,6 +66,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.core.common.utils.DateHelper
 import com.mifos.core.common.utils.formatDate
 import com.mifos.core.designsystem.component.MifosDatePickerTextField
@@ -385,8 +386,8 @@ private fun CreateNewGroupContent(
                             activationDate = activationDateInString,
                             submittedOnDate = submittedOnDateInString,
                             officeId = officeId,
-                            dateFormat = "dd MMMM yyyy",
-                            locale = "en",
+                            dateFormat = ApiDateFormatter.DATE_FORMAT,
+                            locale = ApiDateFormatter.LOCALE,
                         ),
                     )
                 }

--- a/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/groupLoanAccount/GroupLoanAccountScreen.kt
+++ b/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/groupLoanAccount/GroupLoanAccountScreen.kt
@@ -76,6 +76,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.core.common.utils.DateHelper
 import com.mifos.core.designsystem.component.MifosDatePickerTextField
 import com.mifos.core.designsystem.component.MifosOutlinedTextField
@@ -586,14 +587,14 @@ private fun GroupLoanAccountContent(
                     isAllowPartialPeriodInterestCalcualtion = selectedCalculateExactDaysIn
                     amortizationType = selectedAmortizationId
                     this.groupId = groupId
-                    dateFormat = "dd MMMM yyyy"
+                    dateFormat = ApiDateFormatter.DATE_FORMAT
                     expectedDisbursementDate =
                         DateHelper.getDateAsStringFromLong(
                             disbursementDate,
                         )
                     interestCalculationPeriodType = selectedInterestCalculationPeriodId
                     loanType = "individual"
-                    locale = "en"
+                    locale = ApiDateFormatter.LOCALE
                     numberOfRepayments = numberOfRepayment
                     principal = principalAmount
                     productId = selectedLoanProductId

--- a/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/loanChargeDialog/LoanChargeDialogScreen.kt
+++ b/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/loanChargeDialog/LoanChargeDialogScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.core.common.utils.DateHelper
 import com.mifos.core.designsystem.component.MifosDatePickerTextField
 import com.mifos.core.designsystem.component.MifosOutlinedTextField
@@ -276,12 +277,10 @@ internal fun LoanChargeDialogScreen(
                                     if (validateInput()) {
                                         val payload = ChargesPayload().apply {
                                             this.amount = amount
-                                            this.locale = locale
-                                            this.dateFormat = "dd-MM-yyyy"
+                                            this.locale = ApiDateFormatter.LOCALE
+                                            this.dateFormat = ApiDateFormatter.DATE_FORMAT
                                             this.chargeId = chargeId
-                                            this.dueDate = DateHelper.getDateAsStringFromLong(
-                                                dueDate,
-                                            )
+                                            this.dueDate = ApiDateFormatter.formatForApi(dueDate)
                                         }
                                         onCreate(payload)
                                     }

--- a/feature/offline/src/commonMain/kotlin/com/mifos/feature/offline/syncGroupPayloads/SyncGroupPayloadsUiState.kt
+++ b/feature/offline/src/commonMain/kotlin/com/mifos/feature/offline/syncGroupPayloads/SyncGroupPayloadsUiState.kt
@@ -13,6 +13,7 @@ import androidclient.feature.offline.generated.resources.Res
 import androidclient.feature.offline.generated.resources.feature_offline_all_groups_synced
 import androidclient.feature.offline.generated.resources.feature_offline_ic_assignment_turned_in_black_24dp
 import androidclient.feature.offline.generated.resources.feature_offline_no_group_payload_to_sync
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.room.entities.group.GroupPayloadEntity
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.StringResource
@@ -51,7 +52,7 @@ val dummyGroupPayloads = listOf(
         externalId = "EXT001",
         name = "Group 1",
         locale = "en",
-        dateFormat = "dd MMM yyyy",
+        dateFormat = ApiDateFormatter.DATE_FORMAT,
     ),
     GroupPayloadEntity(
         id = 2,
@@ -63,7 +64,7 @@ val dummyGroupPayloads = listOf(
         externalId = "EXT002",
         name = "Group 2",
         locale = "en",
-        dateFormat = "dd MMM yyyy",
+        dateFormat = ApiDateFormatter.DATE_FORMAT,
     ),
     GroupPayloadEntity(
         id = 3,
@@ -75,6 +76,6 @@ val dummyGroupPayloads = listOf(
         externalId = "EXT003",
         name = "Group 3",
         locale = "en",
-        dateFormat = "dd MMM yyyy",
+        dateFormat = ApiDateFormatter.DATE_FORMAT,
     ),
 )

--- a/feature/savings/src/commonMain/kotlin/com/mifos/feature/savings/savingsAccount/SavingsAccountScreen.kt
+++ b/feature/savings/src/commonMain/kotlin/com/mifos/feature/savings/savingsAccount/SavingsAccountScreen.kt
@@ -66,6 +66,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.core.common.utils.DateHelper
 import com.mifos.core.designsystem.component.MifosDatePickerTextField
 import com.mifos.core.designsystem.component.MifosOutlinedTextField
@@ -476,9 +477,9 @@ private fun SavingsAccountContent(
                 val savingsPayload = SavingsPayload()
 
                 savingsPayload.externalId = externalId
-                savingsPayload.locale = "en"
-                savingsPayload.submittedOnDate = DateHelper.getDateAsStringFromLong(submittedOnDate)
-                savingsPayload.dateFormat = "dd-MM-yyyy"
+                savingsPayload.locale = ApiDateFormatter.LOCALE
+                savingsPayload.submittedOnDate = ApiDateFormatter.formatForApi(submittedOnDate)
+                savingsPayload.dateFormat = ApiDateFormatter.DATE_FORMAT
                 if (isGroupAccount) {
                     savingsPayload.groupId = groupId
                 } else {

--- a/feature/savings/src/commonMain/kotlin/com/mifos/feature/savings/savingsAccountActivate/SavingsAccountActivateScreen.kt
+++ b/feature/savings/src/commonMain/kotlin/com/mifos/feature/savings/savingsAccountActivate/SavingsAccountActivateScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.core.common.utils.DateHelper
 import com.mifos.core.designsystem.component.MifosDatePickerTextField
 import com.mifos.core.designsystem.component.MifosOutlinedTextField
@@ -232,9 +233,9 @@ private fun SavingsAccountActivateContent(
                 .heightIn(46.dp),
             onClick = {
                 val hashMap = HashMap<String, String>()
-                hashMap["dateFormat"] = "dd MMMM yyyy"
+                hashMap["dateFormat"] = ApiDateFormatter.DATE_FORMAT
                 hashMap["activatedOnDate"] = approvalDate.toString()
-                hashMap["locale"] = "en"
+                hashMap["locale"] = ApiDateFormatter.LOCALE
 
                 activateSavings.invoke(hashMap)
             },

--- a/feature/savings/src/commonMain/kotlin/com/mifos/feature/savings/savingsAccountv2/SavingsAccountViewModel.kt
+++ b/feature/savings/src/commonMain/kotlin/com/mifos/feature/savings/savingsAccountv2/SavingsAccountViewModel.kt
@@ -17,6 +17,7 @@ import androidclient.feature.savings.generated.resources.step_terms_decimal_plac
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import com.mifos.core.common.utils.ApiDateFormatter
 import com.mifos.core.common.utils.DataState
 import com.mifos.core.common.utils.DateHelper
 import com.mifos.core.data.util.NetworkMonitor
@@ -145,8 +146,8 @@ internal class SavingsAccountViewModel(
 
     private fun submitSavingsApplication() {
         val savingsPayload = SavingsPayload().apply {
-            locale = "en"
-            dateFormat = "dd-MM-yyyy"
+            locale = ApiDateFormatter.LOCALE
+            dateFormat = ApiDateFormatter.DATE_FORMAT
             productId = state.savingProductOptions.getOrNull(state.savingsProductSelected)?.id
             clientId = state.clientId
             fieldOfficerId = state.fieldOfficerOptions.getOrNull(state.fieldOfficerIndex)?.id


### PR DESCRIPTION
## Summary

This PR introduces a centralized date formatting solution for the Fineract API to ensure consistent date handling across the entire codebase, fixing the issue where date format mismatches caused API validation errors.

### Problem
- The `formatDate()` function was returning dates in `dd/MM/yyyy` format (e.g., "18/02/2026")
- But the API requests specified `dateFormat` as `dd MMMM yyyy` (expecting "18 February 2026")
- This mismatch caused validation errors when creating/activating clients
- Additionally, some payload classes had `YYYY` instead of `yyyy` (wrong year pattern)

### Solution
Created a centralized date formatting system:
1. **`DateConstants`** in `core/model` - Single source of truth for date format strings
2. **`ApiDateFormatter`** in `core/common` - Utility for formatting dates to API-compatible strings
3. **`DateFormatPattern`** enum in `core/common` - All supported date format patterns

## Architecture

```
core/model (base module)
└── DateConstants.kt          # DATE_FORMAT = "dd MMMM yyyy", LOCALE = "en"

core/common (depends on core/model)
├── ApiDateFormatter.kt       # formatForApi(millis), references DateConstants
├── DateFormatPattern.kt      # Enum: FULL_MONTH, SHORT_MONTH, etc.
└── FormatDate.kt             # formatDate() function, delegates to ApiDateFormatter
```

## Changes

### New Files
| File | Module | Description |
|------|--------|-------------|
| `DateConstants.kt` | core/model | Constants: `DATE_FORMAT`, `LOCALE`, `DATE_FORMAT_WITH_TIME` |
| `ApiDateFormatter.kt` | core/common | Centralized date formatter with `formatForApi()` methods |
| `DateFormatPattern.kt` | core/common | Enum with all date format patterns |

### Updated Files (28 files)

#### Core Model (6 files)
- `CollectionSheetRequestPayload.kt` - Use `DateConstants`
- `LoanApproval.kt` - Use `DateConstants`
- `LoanApprovalRequest.kt` - Fixed `dd MM yyyy` → `dd MMMM yyyy`, use `DateConstants`
- `LoanDisbursement.kt` - Use `DateConstants`
- `SavingsApproval.kt` - Use `DateConstants`
- `UserLocation.kt` - Use `DateConstants.DATE_FORMAT_WITH_TIME`

#### Core Network (4 files)
- `Payload.kt` - Fixed `YYYY` → `yyyy`, use `ApiDateFormatter`
- `DefaultPayload.kt` - Fixed `YYYY` → `yyyy`, use `ApiDateFormatter`
- `IndividualCollectionSheetPayload.kt` - Fixed `YYYY` → `yyyy`, use `ApiDateFormatter`
- `DataManagerClient.kt` - Use `ApiDateFormatter`

#### Core Database (2 files)
- `CollectionSheetPayload.kt` - Use `ApiDateFormatter`
- `ProductiveCollectionSheetPayload.kt` - Use `ApiDateFormatter`

#### Feature Modules (14 files)
| Module | Files Updated |
|--------|---------------|
| **client** | `CreateNewClientScreen.kt`, `ClientEditDetailsScreen.kt` |
| **activate** | `ActivateScreen.kt` |
| **center** | `CreateNewCenterScreen.kt` |
| **groups** | `CreateNewGroupScreen.kt` |
| **loan** | `GroupLoanAccountScreen.kt`, `LoanChargeDialogScreen.kt` |
| **savings** | `SavingsAccountScreen.kt`, `SavingsAccountActivateScreen.kt`, `SavingsAccountViewModel.kt` |
| **collectionSheet** | `NewIndividualCollectionSheetScreen.kt` |
| **offline** | `SyncGroupPayloadsUiState.kt` |
| **data-table** | `DataTableListViewModel.kt` |

## Usage Example

```kotlin
// Before (inconsistent)
val payload = ClientPayload(
    activationDate = "18/02/2026",      // Wrong format
    dateFormat = "dd MMMM yyyy",         // Expected format
    locale = "en"
)

// After (consistent)
val payload = ClientPayload(
    activationDate = ApiDateFormatter.formatForApi(dateMillis),  // "18 February 2026"
    dateFormat = ApiDateFormatter.DATE_FORMAT,                    // "dd MMMM yyyy"
    locale = ApiDateFormatter.LOCALE                              // "en"
)

// Or using DateConstants directly in core/model
val payload = LoanApproval(
    dateFormat = DateConstants.DATE_FORMAT,
    locale = DateConstants.LOCALE
)
```

## Test Plan
- [ ] Create a new client with activation date - verify API accepts the request
- [ ] Activate a pending client - verify no date format validation errors
- [ ] Edit client details with date changes - verify API accepts the request
- [ ] Create a new group with activation date
- [ ] Create a new center with activation date
- [ ] Create a loan with disbursement date
- [ ] Create a savings account with submission date
- [ ] Verify collection sheet date handling

## Related Issue
Fixes: [MIFOSAC-704](https://mifosforge.jira.com/browse/MIFOSAC-704) - Wrong date format while creating a new client and activating it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MIFOSAC-704]: https://mifosforge.jira.com/browse/MIFOSAC-704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized date formatting utilities offering multiple standard patterns (full/short month, numeric dash/slash, ISO, with-time) and APIs to format dates from epoch, LocalDate, numeric components, or lists.

* **Refactor**
  * Unified default date format and locale across payloads and screens to use the centralized constants, ensuring consistent API-ready date values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->