### PR TITLE
fix: cmp-andorid.src.main.AndroidManifest XML parse failure

### DIFF
--- a/cmp-android/src/main/AndroidManifest.xml
+++ b/cmp-android/src/main/AndroidManifest.xml
@@ -49,7 +49,6 @@
         android:theme="@style/Theme.AndroidClientTheme"
         android:requestLegacyExternalStorage="true"
         android:localeConfig="@xml/locale_config">
-        >
 
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
fixes - https://mifosforge.jira.com/browse/MIFOSAC-710




Android Studio was issuing this warning because of an extra `>` in the Android manifest



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected XML formatting in configuration file to ensure proper system parsing and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->