### PR TITLE
Revise Slack channel and demo credentials information

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ One of the standout features of this application is its offline capability, allo
 > **We're moving towards to Jira for issue tracking. Please use [Jira](https://mifosforge.jira.com/jira/software/c/projects/MIFOSAC/issues/) for issue tracking.**
 > **And Join our [slack](https://join.slack.com/t/mifos/shared_invite/zt-2wvi9t82t-DuSBdqdQVOY9fsqsLjkKPA) community channel `mifos-x-field-officer-app` to discuss all things about Android Client development. Please keep discussions focused and avoid cross-posting across channels.**
 
-### Demo Credentials
+## Demo Credentials
 Access the Field Officer (Android Client) demo credentials on our [Jira Wiki page](https://mifosforge.jira.com/wiki/spaces/MP/pages/4537024513/Welcome+to+the+Mifos+Mobile+Apps+Community#%F0%9F%93%B1-Mifos-X-Field-Officer-App.1).
 
 ## How to Contribute

--- a/README.md
+++ b/README.md
@@ -23,15 +23,13 @@ One of the standout features of this application is its offline capability, allo
 
 > \[!Note]
 > **We're moving towards to Jira for issue tracking. Please use [Jira](https://mifosforge.jira.com/jira/software/c/projects/MIFOSAC/issues/) for issue tracking.**
-> **And Join our [slack](https://join.slack.com/t/mifos/shared_invite/zt-2wvi9t82t-DuSBdqdQVOY9fsqsLjkKPA) community channel `android-client` to discuss all things about Android Client development. Please keep discussions focused and avoid cross-posting across channels.**
+> **And Join our [slack](https://join.slack.com/t/mifos/shared_invite/zt-2wvi9t82t-DuSBdqdQVOY9fsqsLjkKPA) community channel `mifos-x-field-officer-app` to discuss all things about Android Client development. Please keep discussions focused and avoid cross-posting across channels.**
 
-## Demo credentials
-- **Fineract Instance**: `gsoc.mifos.community`
-- **Username**: `mifos`
-- **Password**: `password`
+### Demo Credentials
+Access the Field Officer (Android Client) demo credentials on our [Jira Wiki page](https://mifosforge.jira.com/wiki/spaces/MP/pages/4537024513/Welcome+to+the+Mifos+Mobile+Apps+Community#%F0%9F%93%B1-Mifos-X-Field-Officer-App.1).
 
 ## How to Contribute
-Thank you for your interest in contributing to the Mifos Mobile project by Mifos! We welcome all contributions and encourage you to follow these guidelines to ensure a smooth and efficient collaboration process.
+Thank you for your interest in contributing to the Field officer project by Mifos! We welcome all contributions and encourage you to follow these guidelines to ensure a smooth and efficient collaboration process.
 To get started, please refer to the [Contribution Guide](https://github.com/openMF/android-client/wiki/Contribution-Guide) for detailed instructions on how to contribute to the project.
 
 ## Branch Policy


### PR DESCRIPTION
Updated Slack community channel name and demo credentials section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Slack community channel reference to the Field Officer project
  * Renamed and replaced Demo Credentials content with a link to Field Officer demo credentials
  * Revised contribution intro and expanded contribution/branch workflow with development vs. master guidance, setup, committing, squashing, conflict resolution, code of conduct, wiki, license, and contributor info
  * Minor heading and style adjustments across the README
<!-- end of auto-generated comment: release notes by coderabbit.ai -->