### PR TITLE
feat(loan): Implement navigation from Loan Account Profile to sub-sections

### DIFF
--- a/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/loanAccountProfile/LoanAccountProfileNavigation.kt
+++ b/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/loanAccountProfile/LoanAccountProfileNavigation.kt
@@ -12,7 +12,6 @@ package com.mifos.feature.loan.loanAccountProfile
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
-import com.mifos.feature.loan.loanAccountProfile.components.LoanAccountProfileActionItem
 import com.mifos.room.entities.accounts.loans.LoanWithAssociationsEntity
 import kotlinx.serialization.Serializable
 
@@ -24,17 +23,23 @@ data class LoanAccountRoute(
 fun NavGraphBuilder.loanProfileAccountDestination(
     onNavigateBack: () -> Unit,
     navController: NavController,
+    navigateToRepaymentSchedule: (Int) -> Unit,
+    navigateToTransactions: (Int) -> Unit,
+    navigateToCharges: (Int) -> Unit,
+    navigateToDocuments: (Int) -> Unit,
     approveLoan: (Int, LoanWithAssociationsEntity) -> Unit,
     onRepaymentClick: (LoanWithAssociationsEntity) -> Unit,
-    onDetailItemClick: (LoanAccountProfileActionItem) -> Unit,
 ) {
     composable<LoanAccountRoute> {
         LoanAccountProfileScreen(
             onNavigateBack = onNavigateBack,
             navController = navController,
+            navigateToRepaymentSchedule = navigateToRepaymentSchedule,
+            navigateToTransactions = navigateToTransactions,
+            navigateToCharges = navigateToCharges,
+            navigateToDocuments = navigateToDocuments,
             approveLoan = approveLoan,
             onRepaymentClick = onRepaymentClick,
-            onDetailItemClick = onDetailItemClick,
         )
     }
 }

--- a/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/loanAccountProfile/LoanAccountProfileScreen.kt
+++ b/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/loanAccountProfile/LoanAccountProfileScreen.kt
@@ -79,7 +79,10 @@ internal fun LoanAccountProfileScreen(
     onNavigateBack: () -> Unit,
     approveLoan: (Int, LoanWithAssociationsEntity) -> Unit,
     onRepaymentClick: (LoanWithAssociationsEntity) -> Unit,
-    onDetailItemClick: (LoanAccountProfileActionItem) -> Unit,
+    navigateToRepaymentSchedule: (Int) -> Unit,
+    navigateToTransactions: (Int) -> Unit,
+    navigateToCharges: (Int) -> Unit,
+    navigateToDocuments: (Int) -> Unit,
     navController: NavController,
     modifier: Modifier = Modifier,
     viewModel: LoanAccountProfileViewModel = koinViewModel(),
@@ -100,7 +103,17 @@ internal fun LoanAccountProfileScreen(
                     }
                 }
             }
-            is LoanAccountEvent.NavigateToDetail -> onDetailItemClick(event.detailItem)
+            is LoanAccountEvent.NavigateToDetail -> {
+                val loanId = state.loanAccount?.id ?: -1
+
+                when (event.detailItem) {
+                    LoanAccountProfileActionItem.RepaymentSchedule -> navigateToRepaymentSchedule(loanId)
+                    LoanAccountProfileActionItem.Transactions -> navigateToTransactions(loanId)
+                    LoanAccountProfileActionItem.Charges -> navigateToCharges(loanId)
+                    LoanAccountProfileActionItem.Documents -> navigateToDocuments(loanId)
+                    else -> { }
+                }
+            }
             LoanAccountEvent.NavigateToAccountDetails -> {}
         }
     }

--- a/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/navigation/LoanNavigation.kt
+++ b/feature/loan/src/commonMain/kotlin/com/mifos/feature/loan/navigation/LoanNavigation.kt
@@ -79,7 +79,12 @@ fun NavGraphBuilder.loanDestination(
         navController = navController,
         approveLoan = navController::navigateToLoanApprovalScreen,
         onRepaymentClick = navController::navigateToLoanRepaymentScreen,
-        onDetailItemClick = { },
+        navigateToRepaymentSchedule = navController::navigateToLoanRepaymentScheduleScreen,
+        navigateToTransactions = navController::navigateToLoanTransactionScreen,
+        navigateToCharges = navController::navigateToLoanChargesScreen,
+        navigateToDocuments = { loanId ->
+            onDocumentsClicked(loanId, Constants.ENTITY_TYPE_LOANS)
+        },
     )
 }
 


### PR DESCRIPTION
Fixes - [Jira-#667](https://mifosforge.jira.com/browse/MIFOSAC-667)

Description -  This PR implements navigation from the new `LoanAccountProfileScreen` to Repayment Schedule, Transactions, Charges and Loan Documents sections. The navigation structure now follows the same pattern as the ClientProfile flow.

https://github.com/user-attachments/assets/6dde5072-2374-45f1-91d4-2269afc3bac8





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced navigation flow for loan account profiles with dedicated paths to repayment schedules, transactions, charges, and documents, replacing a generic callback with explicit navigation routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->