### PR TITLE
feat(client): add search functionality in client list screen

### DIFF
--- a/feature/client/src/androidMain/kotlin/com/mifos/feature/client/clientsList/ClientListScreen.android.kt
+++ b/feature/client/src/androidMain/kotlin/com/mifos/feature/client/clientsList/ClientListScreen.android.kt
@@ -12,8 +12,8 @@ package com.mifos.feature.client.clientsList
 import androidclient.feature.client.generated.resources.Res
 import androidclient.feature.client.generated.resources.feature_client_failed_to_fetch_clients
 import androidclient.feature.client.generated.resources.feature_client_failed_to_more_clients
-import androidclient.feature.client.generated.resources.feature_client_no_more_clients_available
 import androidclient.feature.client.generated.resources.feature_client_no_more_client_found_for_search_bar
+import androidclient.feature.client.generated.resources.feature_client_no_more_clients_available
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -81,7 +81,7 @@ internal actual fun LazyColumnForClientListApi(
                 // Reached end of pagination - show empty state
                 if (hasReachedEnd) {
                     val message = if (searchQuery.isNotEmpty()) {
-                        stringResource(Res.string.feature_client_no_more_client_found_for_search_bar)  + searchQuery
+                        stringResource(Res.string.feature_client_no_more_client_found_for_search_bar) + searchQuery
                     } else {
                         stringResource(Res.string.feature_client_no_more_clients_available)
                     }

--- a/feature/client/src/androidMain/kotlin/com/mifos/feature/client/clientsList/ClientListScreen.android.kt
+++ b/feature/client/src/androidMain/kotlin/com/mifos/feature/client/clientsList/ClientListScreen.android.kt
@@ -13,6 +13,7 @@ import androidclient.feature.client.generated.resources.Res
 import androidclient.feature.client.generated.resources.feature_client_failed_to_fetch_clients
 import androidclient.feature.client.generated.resources.feature_client_failed_to_more_clients
 import androidclient.feature.client.generated.resources.feature_client_no_more_clients_available
+import androidclient.feature.client.generated.resources.feature_client_no_more_client_found_for_search_bar
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -44,6 +45,8 @@ internal actual fun LazyColumnForClientListApi(
     modifier: Modifier,
     sort: SortTypes?,
     onUpdateOffices: (List<String?>) -> Unit,
+    isSearchActive: Boolean,
+    searchQuery: String,
 ) {
     val clientPagingList = pagingFlow.collectAsLazyPagingItems()
 
@@ -63,7 +66,38 @@ internal actual fun LazyColumnForClientListApi(
 
         is LoadState.Loading -> MifosProgressIndicator()
 
-        is LoadState.NotLoading -> Unit
+        is LoadState.NotLoading -> {
+            val isAppendLoading = clientPagingList.loadState.append is LoadState.Loading
+            val hasReachedEnd = clientPagingList.loadState.append.endOfPaginationReached
+
+            // If we have no items and are currently searching/filtering
+            if (clientPagingList.itemCount == 0 && (isSearchActive || searchQuery.isNotEmpty())) {
+                // Still loading more pages - show loading indicator
+                if (isAppendLoading) {
+                    MifosProgressIndicator()
+                    return
+                }
+
+                // Reached end of pagination - show empty state
+                if (hasReachedEnd) {
+                    val message = if (searchQuery.isNotEmpty()) {
+                        stringResource(Res.string.feature_client_no_more_client_found_for_search_bar)  + searchQuery
+                    } else {
+                        stringResource(Res.string.feature_client_no_more_clients_available)
+                    }
+
+                    Text(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(DesignToken.padding.extraExtraLarge),
+                        text = message,
+                        style = MifosTypography.bodyMedium,
+                        textAlign = TextAlign.Center,
+                    )
+                    return
+                }
+            }
+        }
     }
 
     if (sort != null) {

--- a/feature/client/src/commonMain/composeResources/values/strings.xml
+++ b/feature/client/src/commonMain/composeResources/values/strings.xml
@@ -666,5 +666,6 @@
     <string name="feature_client_status_overpaid">Overpaid</string>
     <string name="feature_client_status_waiting">Waiting for Disbursal</string>
     <string name="feature_client_status_pending">Pending Approval</string>
+    <string name="feature_client_no_more_client_found_for_search_bar">No clients found for </string>
 
 </resources>

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientsList/ClientListScreen.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientsList/ClientListScreen.kt
@@ -12,6 +12,8 @@ package com.mifos.feature.client.clientsList
 import androidclient.feature.client.generated.resources.Res
 import androidclient.feature.client.generated.resources.account_number_prefix
 import androidclient.feature.client.generated.resources.string_not_available
+import androidclient.feature.client.generated.resources.feature_client_no_more_client_found_for_search_bar
+import androidclient.feature.client.generated.resources.feature_client_no_more_clients_available
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -36,6 +38,7 @@ import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -55,6 +58,7 @@ import com.mifos.core.designsystem.theme.MifosTypography
 import com.mifos.core.ui.components.MifosEmptyCard
 import com.mifos.core.ui.components.MifosProgressIndicator
 import com.mifos.core.ui.components.MifosRowCard
+import com.mifos.core.ui.components.MifosSearchBar
 import com.mifos.core.ui.util.EventsEffect
 import com.mifos.core.ui.util.TextUtil
 import com.mifos.room.entities.client.ClientEntity
@@ -73,6 +77,13 @@ internal fun ClientListScreen(
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
+
+    // Clean up search state when leaving the screen
+    DisposableEffect(Unit) {
+        onDispose {
+            viewModel.trySendAction(ClientListAction.DismissSearch)
+        }
+    }
 
     if (state.isFilterVisible) {
         FilterBottomSheet(
@@ -149,42 +160,48 @@ private fun ClientActions(
                             .size(DesignToken.sizes.iconAverage),
                     )
                 }
-//                Icon(
-//                    imageVector = MifosIcons.Search,
-//                    contentDescription = null,
-//                    modifier = Modifier
-//                        .size(DesignToken.sizes.iconAverage)
-//                        .clickable{
-//                            onAction(ClientListAction.ActivateSearch)
-//                        },
-//                )
+                Spacer(Modifier.width(DesignToken.padding.medium))
+                Icon(
+                    imageVector = MifosIcons.Search,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(DesignToken.sizes.iconAverage)
+                        .clickable {
+                            onAction(ClientListAction.ActivateSearch)
+                        },
+                )
+            } else {
+                MifosSearchBar(
+                    query = state.searchQuery,
+                    onQueryChange = {
+                        onAction(ClientListAction.OnQueryChange(it))
+                    },
+                    onBackClick = {
+                        onAction(ClientListAction.DismissSearch)
+                    },
+                    onSearchClick = {
+                        // Search happens automatically on query change
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                )
             }
-//            else{
-//                MifosSearchBar(
-//                    query = state.searchQuery,
-//                    onQueryChange = {
-//                        onAction(ClientListAction.OnQueryChange(it))
-//                    },
-//                    onBackClick = {
-//                        onAction(ClientListAction.DismissSearch)
-//                    },
-//                    onSearchClick = {
-//
-//                    },
-//                    modifier = Modifier.fillMaxWidth()
-//                )
-//            }
         }
-        Spacer(Modifier.width(DesignToken.padding.largeIncreased))
-        Icon(
-            imageVector = MifosIcons.Filter,
-            contentDescription = null,
-            modifier = Modifier
-                .size(DesignToken.sizes.iconAverage)
-                .clickable {
-                    toggleFilterVisibility()
-                },
-        )
+        if (!state.isSearchActive) {
+            Spacer(Modifier.width(DesignToken.padding.largeIncreased))
+            val isFilterActive = state.selectedStatus.isNotEmpty() ||
+                                 state.selectedOffices.isNotEmpty() ||
+                                 state.sort != null
+            Icon(
+                imageVector = MifosIcons.Filter,
+                contentDescription = null,
+                tint = if (isFilterActive) KptTheme.colorScheme.primary else KptTheme.colorScheme.onSurface,
+                modifier = Modifier
+                    .size(DesignToken.sizes.iconAverage)
+                    .clickable {
+                        toggleFilterVisibility()
+                    },
+            )
+        }
     }
 }
 
@@ -237,10 +254,17 @@ private fun ClientListContentScreen(
                     images = state.clientImages,
                     sort = state.sort,
                     onUpdateOffices = onUpdateOffices,
+                    isSearchActive = state.isSearchActive,
+                    searchQuery = state.searchQuery,
                 )
             }
             else -> {
-                MifosEmptyCard("No clients found")
+                val message = if (state.isSearchActive && state.searchQuery.isNotEmpty()) {
+                    stringResource(Res.string.feature_client_no_more_client_found_for_search_bar)  + state.searchQuery
+                } else {
+                    stringResource(Res.string.feature_client_no_more_clients_available)
+                }
+                MifosEmptyCard(message)
             }
         }
     }
@@ -354,6 +378,8 @@ internal expect fun LazyColumnForClientListApi(
     modifier: Modifier = Modifier,
     sort: SortTypes?,
     onUpdateOffices: (List<String?>) -> Unit,
+    isSearchActive: Boolean = false,
+    searchQuery: String = "",
 )
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientsList/ClientListScreen.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientsList/ClientListScreen.kt
@@ -11,9 +11,9 @@ package com.mifos.feature.client.clientsList
 
 import androidclient.feature.client.generated.resources.Res
 import androidclient.feature.client.generated.resources.account_number_prefix
-import androidclient.feature.client.generated.resources.string_not_available
 import androidclient.feature.client.generated.resources.feature_client_no_more_client_found_for_search_bar
 import androidclient.feature.client.generated.resources.feature_client_no_more_clients_available
+import androidclient.feature.client.generated.resources.string_not_available
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -189,8 +189,8 @@ private fun ClientActions(
         if (!state.isSearchActive) {
             Spacer(Modifier.width(DesignToken.padding.largeIncreased))
             val isFilterActive = state.selectedStatus.isNotEmpty() ||
-                                 state.selectedOffices.isNotEmpty() ||
-                                 state.sort != null
+                state.selectedOffices.isNotEmpty() ||
+                state.sort != null
             Icon(
                 imageVector = MifosIcons.Filter,
                 contentDescription = null,
@@ -260,7 +260,7 @@ private fun ClientListContentScreen(
             }
             else -> {
                 val message = if (state.isSearchActive && state.searchQuery.isNotEmpty()) {
-                    stringResource(Res.string.feature_client_no_more_client_found_for_search_bar)  + state.searchQuery
+                    stringResource(Res.string.feature_client_no_more_client_found_for_search_bar) + state.searchQuery
                 } else {
                     stringResource(Res.string.feature_client_no_more_clients_available)
                 }

--- a/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientsList/ClientListViewModel.kt
+++ b/feature/client/src/commonMain/kotlin/com/mifos/feature/client/clientsList/ClientListViewModel.kt
@@ -65,16 +65,77 @@ internal class ClientListViewModel(
             }
             ClientListAction.DismissSearch -> {
                 updateState {
+                    // Only restore clients if there was an active search query
+                    val shouldRestoreClients = it.searchQuery.isNotEmpty()
+
                     it.copy(
                         isSearchActive = false,
+                        searchQuery = "",
+                        clients = if (shouldRestoreClients && it.unfilteredClients.isNotEmpty()) {
+                            // Reapply existing filters if any
+                            applyFilters(it.unfilteredClients, it.selectedStatus, it.selectedOffices)
+                        } else {
+                            it.clients
+                        },
+                        clientsFlow = if (shouldRestoreClients && it.unfilteredClientsFlow != null) {
+                            applyFiltersToFlow(it.unfilteredClientsFlow, it.selectedStatus, it.selectedOffices)
+                        } else {
+                            it.clientsFlow
+                        },
                     )
                 }
             }
             ClientListAction.NavigateToCreateClient -> sendEvent(ClientListEvent.NavigateToCreateClient)
             is ClientListAction.OnQueryChange -> {
                 updateState {
+                    val query = action.query.trim()
+                    val filteredClients = if (query.isEmpty()) {
+                        // Reapply existing filters if any
+                        if (it.selectedStatus.isNotEmpty() || it.selectedOffices.isNotEmpty()) {
+                            applyFilters(it.unfilteredClients, it.selectedStatus, it.selectedOffices)
+                        } else {
+                            it.unfilteredClients
+                        }
+                    } else {
+                        // Filter by search query first (only name and account number)
+                        val searchFiltered = it.unfilteredClients.filter { client ->
+                            val matchesName = client.displayName?.contains(query, ignoreCase = true) == true
+                            val matchesAccountNo = client.accountNo?.contains(query, ignoreCase = true) == true
+                            matchesName || matchesAccountNo
+                        }
+                        // Then apply existing filters if any
+                        if (it.selectedStatus.isNotEmpty() || it.selectedOffices.isNotEmpty()) {
+                            applyFilters(searchFiltered, it.selectedStatus, it.selectedOffices)
+                        } else {
+                            searchFiltered
+                        }
+                    }
+
+                    val filteredFlow = if (it.unfilteredClientsFlow != null) {
+                        if (query.isEmpty()) {
+                            applyFiltersToFlow(it.unfilteredClientsFlow, it.selectedStatus, it.selectedOffices)
+                        } else {
+                            it.unfilteredClientsFlow.map { pagingData ->
+                                pagingData.filter { client ->
+                                    val matchesName = client.displayName?.contains(query, ignoreCase = true) == true
+                                    val matchesAccountNo = client.accountNo?.contains(query, ignoreCase = true) == true
+                                    val matchesSearch = matchesName || matchesAccountNo
+
+                                    val matchesStatus = it.selectedStatus.isEmpty() || client.status?.value in it.selectedStatus
+                                    val matchesOffice = it.selectedOffices.isEmpty() || (client.officeName ?: "Null") in it.selectedOffices
+
+                                    matchesSearch && matchesStatus && matchesOffice
+                                }
+                            }
+                        }
+                    } else {
+                        null
+                    }
+
                     it.copy(
                         searchQuery = action.query,
+                        clients = filteredClients,
+                        clientsFlow = filteredFlow,
                     )
                 }
             }
@@ -275,6 +336,38 @@ internal class ClientListViewModel(
                 selectedStatus = emptyList(),
                 selectedOffices = emptyList(),
             )
+        }
+    }
+
+    /**
+     * Helper function to apply filters to a list of clients
+     */
+    private fun applyFilters(
+        clients: List<ClientEntity>,
+        selectedStatus: List<String>,
+        selectedOffices: List<String>,
+    ): List<ClientEntity> {
+        return clients.filter { client ->
+            val statusMatch = selectedStatus.isEmpty() || client.status?.value in selectedStatus
+            val officeMatch = selectedOffices.isEmpty() || (client.officeName ?: "Null") in selectedOffices
+            statusMatch && officeMatch
+        }
+    }
+
+    /**
+     * Helper function to apply filters to a Flow of PagingData
+     */
+    private fun applyFiltersToFlow(
+        flow: Flow<PagingData<ClientEntity>>,
+        selectedStatus: List<String>,
+        selectedOffices: List<String>,
+    ): Flow<PagingData<ClientEntity>> {
+        return flow.map { pagingData ->
+            pagingData.filter { client ->
+                val statusMatch = selectedStatus.isEmpty() || client.status?.value in selectedStatus
+                val officeMatch = selectedOffices.isEmpty() || (client.officeName ?: "Null") in selectedOffices
+                statusMatch && officeMatch
+            }
         }
     }
 }

--- a/feature/client/src/desktopMain/kotlin/com/mifos/feature/client/clientsList/ClientListScreen.desktop.kt
+++ b/feature/client/src/desktopMain/kotlin/com/mifos/feature/client/clientsList/ClientListScreen.desktop.kt
@@ -25,5 +25,7 @@ internal actual fun LazyColumnForClientListApi(
     modifier: Modifier,
     sort: SortTypes?,
     onUpdateOffices: (List<String?>) -> Unit,
+    isSearchActive: Boolean,
+    searchQuery: String,
 ) {
 }

--- a/feature/client/src/jsMain/kotlin/com/mifos/feature/client/clientsList/ClientListScreen.js.kt
+++ b/feature/client/src/jsMain/kotlin/com/mifos/feature/client/clientsList/ClientListScreen.js.kt
@@ -25,5 +25,7 @@ internal actual fun LazyColumnForClientListApi(
     modifier: Modifier,
     sort: SortTypes?,
     onUpdateOffices: (List<String?>) -> Unit,
+    isSearchActive: Boolean,
+    searchQuery: String,
 ) {
 }

--- a/feature/client/src/nativeMain/kotlin/com/mifos/feature/client/clientsList/ClientListScreen.native.kt
+++ b/feature/client/src/nativeMain/kotlin/com/mifos/feature/client/clientsList/ClientListScreen.native.kt
@@ -25,4 +25,6 @@ internal actual fun LazyColumnForClientListApi(
     modifier: Modifier,
     sort: SortTypes?,
     onUpdateOffices: (List<String?>) -> Unit,
+    isSearchActive: Boolean,
+    searchQuery: String,
 ) {}

--- a/feature/client/src/wasmJsMain/kotlin/com/mifos/feature/client/clientsList/ClientListScreen.wasmJs.kt
+++ b/feature/client/src/wasmJsMain/kotlin/com/mifos/feature/client/clientsList/ClientListScreen.wasmJs.kt
@@ -25,5 +25,7 @@ internal actual fun LazyColumnForClientListApi(
     modifier: Modifier,
     sort: SortTypes?,
     onUpdateOffices: (List<String?>) -> Unit,
+    isSearchActive: Boolean,
+    searchQuery: String,
 ) {
 }


### PR DESCRIPTION
Fixes - https://mifosforge.jira.com/browse/MIFOSAC-749

Screen record - https://mifos.slack.com/archives/C06FC73DZPW/p1772602125582799?thread_ts=1772601944.487369&cid=C06FC73DZPW

## Summary by CodeRabbit

* **New Features**
  * Added search functionality to the client list with a dedicated search bar.
  * Search queries filter clients by name or account number and work seamlessly with existing status and office filters.
  * Filter icon visibility toggles based on search state for improved UX.
  * Introduced search-specific empty state messaging when no matching clients are found.
