### PR TITLE
Rename Android Client to Mifos X Field Officer Application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 <img src="https://user-images.githubusercontent.com/37406965/51083189-d5dc3a80-173b-11e9-8ca0-28015e0893ac.png" alt="Android Client" />
 
-# Android-Client Android Application for MifosX
+# Mifos X Field Officer Application for MifosX
 
 This Android application is built on the powerful [MifosX](https://mifosforge.jira.com/wiki/spaces/MIFOSX/overview) platform and written in Kotlin. MifosX is a comprehensive core banking platform designed for field officers to efficiently process transactions, manage client data, track center records, group details, and handle various types of accounts such as loans, savings, and recurring accounts. The application's primary goal is to streamline field operations, making them easier and more efficient.
 
@@ -12,11 +12,11 @@ One of the standout features of this application is its offline capability, allo
 ![Android](https://img.shields.io/badge/Android-3DDC84?style=flat-square&logo=android&logoColor=white)
 
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
-[![License](https://img.shields.io/github/license/openMF/android-client)](https://github.com/openMF/android-client/blob/main/)
-[![Release](https://img.shields.io/github/v/release/openMF/android-client)](https://github.com/openMF/android-client/releases)
+[![License](https://img.shields.io/github/license/openMF/mifos-x-field-officer-app)](https://github.com/openMF/mifos-x-field-officer-app/blob/main/)
+[![Release](https://img.shields.io/github/v/release/openMF/mifos-x-field-officer-app)](https://github.com/openMF/mifos-x-field-officer-app/releases)
 
 
-[![PR Checks](https://github.com/openMF/android-client/actions/workflows/pr-check-android.yml/badge.svg)](https://github.com/openMF/android-client/actions/workflows/pr-check-android.yml)
+[![PR Checks](https://github.com/openMF/mifos-x-field-officer-app/actions/workflows/pr-check-android.yml/badge.svg)](https://github.com/openMF/mifos-x-field-officer-app/actions/workflows/pr-check-android.yml)
 [![Slack](https://img.shields.io/badge/Slack-4A154B?style=flat-square&logo=slack&logoColor=white)](https://join.slack.com/t/mifos/shared_invite/zt-2wvi9t82t-DuSBdqdQVOY9fsqsLjkKPA)
 [![Jira](https://img.shields.io/badge/jira-%230A0FFF.svg?style=flat-square&logo=jira&logoColor=white)](https://mifosforge.jira.com/jira/software/c/projects/MIFOSAC/issues/?filter=allissues&jql=project%20%3D%20%22MM%22%20ORDER%20BY%20created%20DESC)
 </div>
@@ -30,40 +30,40 @@ Access the Field Officer (Android Client) demo credentials on our [Jira Wiki pag
 
 ## How to Contribute
 Thank you for your interest in contributing to the Field officer project by Mifos! We welcome all contributions and encourage you to follow these guidelines to ensure a smooth and efficient collaboration process.
-To get started, please refer to the [Contribution Guide](https://github.com/openMF/android-client/wiki/Contribution-Guide) for detailed instructions on how to contribute to the project.
+To get started, please refer to the [Contribution Guide](https://github.com/openMF/mifos-x-field-officer-app/wiki/Contribution-Guide) for detailed instructions on how to contribute to the project.
 
 ## Branch Policy
 For development purposes, always pull from the **development** branch, as all contributions and updates are merged into this branch. Upon completion of development, changes are subsequently merged into the **master** branch, which represents the stable and bug-free version of the code
 
 ## Development Setup
-Please refer to the  [Development Setup Guide](https://github.com/openMF/android-client/wiki/Set-up-an-environment) for detailed instructions on configuring the development environment.
+Please refer to the  [Development Setup Guide](https://github.com/openMF/mifos-x-field-officer-app/wiki/Set-up-an-environment) for detailed instructions on configuring the development environment.
 
 ## Committing Your Changes
 After making changes in your local repository, you will need to commit them to your GitHub repository.
-If you are unfamiliar with the process of committing changes, please refer to the [Committing Your Changes](https://github.com/openMF/android-client/wiki/Committing-Your-Changes) guide.
+If you are unfamiliar with the process of committing changes, please refer to the [Committing Your Changes](https://github.com/openMF/mifos-x-field-officer-app/wiki/Committing-Your-Changes) guide.
 
 ## Squashing Your Commits
-To ensure a clean and organized Git history, contributors are encouraged to squash their commits before merging. Instructions on how to squash commits can be found in the [Squashing Your Commits](https://github.com/openMF/android-client/wiki/Squashing-Your-Commits) guide.
+To ensure a clean and organized Git history, contributors are encouraged to squash their commits before merging. Instructions on how to squash commits can be found in the [Squashing Your Commits](https://github.com/openMF/mifos-x-field-officer-app/wiki/Squashing-Your-Commits) guide.
 
 ## Resolving Merge Conflicts
 Occasionally, merge conflicts may arise when your pull request is being reviewed. These conflicts need to be resolved manually.
-To learn how to resolve merge conflicts, please refer to the [Solving Merge Conflicts](https://github.com/openMF/android-client/wiki/Solving-Merge-Conflicts) guide
+To learn how to resolve merge conflicts, please refer to the [Solving Merge Conflicts](https://github.com/openMF/mifos-x-field-officer-app/wiki/Solving-Merge-Conflicts) guide
 
 ## Code of Conduct
 Mifos has adopted a Code of Conduct that we expect project participants to adhere to. Please read [the full text](CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
 
 ## Wiki
 
-Please visit our [Wiki](https://github.com/openMF/android-client/wiki) page for a detailed overview of the project's architecture and guidelines. Explore further to gain a deeper understanding of our project.
+Please visit our [Wiki](https://github.com/openMF/mifos-x-field-officer-app/wiki) page for a detailed overview of the project's architecture and guidelines. Explore further to gain a deeper understanding of our project.
 
 ## License
 
-This project is licensed under the open source [MPL V2](https://github.com/openMF/android-client/blob/master/LICENSE.md).
+This project is licensed under the open source [MPL V2](https://github.com/openMF/mifos-x-field-officer-app/blob/master/LICENSE.md).
 
 ## Contributors
 
 Special thanks to the incredible code contributors who continue to drive this project forward.
 
-<a href="https://github.com/openMF/android-client/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=openMF/android-client" />
+<a href="https://github.com/openMF/mifos-x-field-officer-app/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=openMF/mifos-x-field-officer-app" />
 </a>


### PR DESCRIPTION
Updated project references from 'Android Client' to 'Mifos X Field Officer Application'.

Fixes - [Jira-#MIFOSAC-748](https://mifosforge.jira.com/browse/MIFOSAC-748)

Didn't create a Jira ticket, click [here](https://mifosforge.jira.com/jira/software/c/projects/MIFOSAC/issues/) to create new.

Please Add Screenshots If there are any UI changes.

| Before                                     | After                                  |
|--------------------------------------------|----------------------------------------|
|                                            |                                        |

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the static analysis check `./gradlew check` or `ci-prepush.sh` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.