### PR TITLE
chore: add CodeRabbitAI review configuration with mifos-specific rules

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,278 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: 'en-US'
+early_access: false
+
+chat:
+  auto_reply: true
+
+reviews:
+  poem: false
+  profile: "chill"
+  high_level_summary: false
+  review_status: true
+  commit_status: true
+  collapse_walkthrough: false
+
+  path_filters:
+    - '**/*'
+    - '!.github/**'
+    - '!**/*.svg'
+
+  auto_title_placeholder: "@coderabbitai"
+  auto_title_instructions: |
+    Generate a title following: <type>(<scope>): <subject>
+    Types: feat, fix, docs, refactor, test, chore, misc
+    Rules: present tense, lowercase, no Jira IDs, scope reflects module/feature.
+
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    drafts: false
+    base_branches: ['development']
+    ignore_title_keywords: ['WIP', 'Draft']
+    labels: ['!skip-ai-review']
+    ignore_usernames: ['dependabot[bot]', 'renovate[bot]']
+
+  pre_merge_checks:
+    issue_assessment:
+      mode: "off"
+
+    docstrings:
+      mode: "warning"
+
+    title:
+      mode: error
+      requirements: |
+        Follow commit message format: <type>(<scope>): <subject>
+          Types: feat, fix, docs, refactor, test, chore, misc
+          - Use present tense, lowercase, concise
+          - Scope should reflect module/feature (loan, auth, ui) if identifiable
+          - Do NOT include JIRA ticket numbers/IDs (e.g., MIFOSAC-123) in the title
+        
+        If the title is not meaningful or not in the correct format:
+          - Suggest a better title
+          - Base it on:
+              - code changes in the PR
+              - Jira ticket title (if available, use only for context, not inclusion)
+
+    description:
+      mode: error
+
+    custom_checks:
+      - name: Jira link and Before/After sections
+        mode: error
+        instructions: |
+          PR description must include:
+          1. A valid Jira link (e.g., https://mifosforge.jira.com/browse/MIFOSAC-1234)
+          2. Non-empty "Before:" and "After:" sections, each with media (image/video)
+          Required even for domain/data/refactor changes. Flag missing Jira link,
+          missing/empty sections, or sections without media.
+
+  path_instructions:
+    - path: "**/*ViewModel.kt"
+      instructions: |
+        MVI architecture rules:
+        
+        - All new features must follow MVI
+        - ViewModel must extend BaseViewModel
+        - The ViewModel MUST maintain a single UI state (e.g., a single StateFlow<FeatureState>) 
+          instead of multiple separate state variables.
+        
+        Required:
+        - Use *State, *Event, *Action
+        - Naming must be consistent (FeatureViewModel, FeatureState, FeatureEvent, FeatureAction)
+        - Follow unidirectional flow:
+          Action → ViewModel → State → UI
+        
+        Flag:
+        - Missing *State / *Event / *Action
+        - ViewModel not extending BaseViewModel
+        - Multiple separate state flows/variables in a single ViewModel.
+
+    - path: "**/*Screen.kt"
+      instructions: |
+        Screen architecture rules:
+        
+        Each screen must follow 2-layer structure:
+        1. Layer 1 (Stateless/Entry Overload):
+           - Function Name: Typically `*Screen`.
+           - Responsibilities: Inject ViewModel (e.g., `koinViewModel`), take navigation lambdas, and collect the `StateFlow`.
+           - Logic: Should only handle ViewModel interaction, state collection, and triggering navigation in response to ViewModel events.
+
+        2. Layer 2 (Stateful/Content Overload):
+           - Function Name: `*Screen` or `*ScreenContent`.
+           - Parameters: MUST only take `state` (the UI state object) and a single `onAction` lambda (e.g., `onAction: (FeatureAction) -> Unit`).
+           - Responsibilities: Render the UI based strictly on the provided `state`.
+           - Rule: Avoid passing multiple separate lambda functions for different UI interactions; consolidate them into the single `onAction`.
+           - Constraint: Must NOT contain any business logic or ViewModel/Navigation references.
+        
+        UI consistency:
+        - Avoid hardcoded values (dp, sp, padding, fontSize, colors)
+        - Use DesignToken, KptTheme, AppColors, MifosTypography for spacing, typography, and colors
+        
+        Code quality:
+        - Keep Composables small and readable
+        - Avoid deeply nested UI
+
+        Flag:
+        - Missing ScreenContent separation
+        - Passing multiple separate lambda functions for different UI interactions; consolidate them into the single `onAction` for Layer 2 (Stateful/Content Overload).
+        - UI logic inside *Screen
+        - Business logic inside Composables
+        - Hardcoded strings instead of using string resources
+        - Hardcoded dp/sp values
+        - Direct styling instead of using DesignToken or KptTheme
+
+    - path: "**/composeResources/values*/strings.xml"
+      instructions: |
+        String resource conventions:
+        
+        Naming:
+        - All keys must follow:
+          feature_{feature_name}_{ui_text_in_snake_case}
+        
+        Examples:
+          "In Advance" → feature_loan_in_advance
+          "Outstanding" → feature_loan_outstanding
+        
+        - Avoid generic names like: title, text1, label
+        - The suffix should be a short, readable representation of the UI text
+        - Avoid multiple keys representing the same UI text
+        - Keys must be lowercase and use snake_case
+        
+        Flag:
+        - Incorrect naming pattern
+        - Generic or unclear key names
+        - Duplicate keys for same UI text
+
+    - path: "**/*.kt"
+      instructions: |
+        Additional Code Review Guidelines:
+
+        1. Null Safety & Stability
+        - Avoid using `!!` operator
+        - Handle null cases explicitly using safe calls or proper state handling
+        - Do not assume values are always non-null without guarantees
+        
+        2. Architecture Boundaries
+        - ViewModel must not depend on specific network/library implementations
+        - Avoid exposing low-level exceptions (e.g., Ktor exceptions) to UI layer
+        - Ensure proper separation between data, domain, and presentation layers
+        - Do not format data (currency, dates, calculations) inside the UI layer
+        - All formatting must be handled in the ViewModel and exposed via state (e.g., StateFlow)
+        
+        3. Performance Considerations
+        - Avoid unnecessary recompositions in Compose
+        - Do not attach heavy logic to frequently changing states (e.g., scrollState)
+        - Prefer lifting state up instead of recomputing in child composables
+        
+        4. Compose & Navigation Best Practices
+        - NEVER trigger navigation functions or side-effects directly during composition
+        - Always wrap navigation calls inside `LaunchedEffect` or `EventsEffect` to avoid repeated execution on recomposition
+        - Avoid triggering intensive side-effects during recomposition
+        
+        5. UI Structure
+        - Dialogs must be separated into their own composables
+        - Do not embed dialogs inline within complex main screens
+        
+        6. Localization Consistency
+        - Ensure all supported languages are updated consistently across modules
+        - Verify translations exist for newly added UI strings
+        
+        7. Code Cleanliness
+        - Avoid unnecessary inline comments unless critical
+        - Remove leftover debug or commented code
+        
+        8. Focus on correctness, readability, and maintainability over cosmetic nitpicks.
+        - Avoid reviewing README, config, or asset files.
+        - Prioritize identifying bugs, performance issues, and architectural concerns.
+        
+        9. Naming & Intent Rules:
+        - Follow the official Kotlin Coding Conventions:
+          https://kotlinlang.org/docs/coding-conventions.html
+        - Use self-explanatory names:
+          Names should clearly convey purpose and content without needing additional explanation.
+        - Avoid explanatory comments for names:
+          If a variable or function requires a comment to clarify its meaning, rename it.
+        - Prefer clarity over brevity:
+          Do not use cryptic or non-standard abbreviations.
+        - Ensure consistency:
+          Naming should be uniform across the codebase and align with Kotlin standards.
+        
+        10. Type-Safe Navigation
+        - Navigation routes must be type-safe.
+        - Ensure all route classes or objects used for navigation are annotated with `@Serializable`.
+
+    - path: "**/network/**/*.kt"
+      instructions: |
+        Network Layer API Guidelines:
+        - One-shot API calls MUST use `suspend`, return raw response `T`, and MUST NOT use Flow or DataState.
+        - Streaming APIs MUST return `Flow<T>` and MUST NOT use `suspend` or DataState.
+
+    - path: "**/data/repository/**/*.kt"
+      instructions: |
+        Repository Interface Guidelines:
+        - One-shot operations MUST use `suspend fun` and return `DataState<T>`. MUST NOT use Flow.
+        - Streaming operations MUST return `Flow<DataState<T>>` and MUST NOT use `suspend`.
+        - Repository interfaces must consistently return Domain models (from :core:model) wrapped in `DataState` or `Flow`.
+        - Flag: Any interface method that returns a DTO or an Entity.
+
+    - path: "**/data/repositoryImp/**/*.kt"
+      instructions: |
+        Repository Implementation Guidelines:
+        - MUST convert `T` -> `DataState<T>` for one-shot APIs, and `Flow<T>` -> `Flow<DataState<T>>` using `.asDataStateFlow()`.
+        - MUST perform network availability checks, handle exceptions, and apply appropriate dispatchers.
+        - Repositories act as the boundary translator. They MUST use mappers to convert DTOs (from network) and Entities (from database) into Domain Models (from :core:model) before returning data.
+        - Flag: If a repository implementation returns a raw DTO or Entity directly to the caller instead of a Domain model.
+
+    - path: "**/data/mappers/**/*.kt"
+      instructions: |
+        Mapper Consistency Rules (:core:data:mappers):
+        - All mapping logic MUST be centralized in this directory.
+        - Allowed mappings:
+          1. DTO -> Domain Model
+          2. Entity <-> Domain Model
+        - Flag: Any mapper functions found in any module outside of `:core:data:mappers`.
+
+    - path: "**/core/model/**/*.kt"
+      instructions: |
+        Domain Model Rules (:core:model):
+        - Classes defined in this module are strictly Domain Models.
+        - They must be plain Kotlin data classes.
+        - They MUST NOT contain network-specific annotations (e.g., `@Serializable`) or database-specific annotations (e.g., `@Entity`).
+        - Rule: These are the ONLY models that should be passed to or used within ViewModels and UI Screens.
+        - Flag: If a Domain model is used directly as an API request/response body or a Room database table.
+
+    - path: "**/network/dto/**/*.kt"
+      instructions: |
+        DTO Rules (:core:network:dto):
+        - Classes here are Data Transfer Objects (DTOs) used strictly for API communication.
+        - Rule: DTOs MUST NOT be used in ViewModels, Screens, or the Domain layer.
+        - Flag: If a DTO is returned directly by a Repository interface or used in UI state.
+
+    - path: "**/database/entities/**/*.kt"
+      instructions: |
+        Entity Rules (:core:database:entities):
+        - Classes here are Room Database Entities.
+        - Entities MUST NOT be serializable (do not use `@Serializable` or implement `Serializable`).
+        - Rule: Entities MUST NOT be used in ViewModels, Screens, or the Network layer.
+        - Flag: If an Entity is exposed directly to the UI layer or returned by a Repository Interface.
+
+    - path: "core-base/**"
+      instructions: |
+        Critical Module Change Detection:
+        - Changes in `core-base` module must be treated as high-impact.
+        - Flag any PR that modifies files inside `core-base` for careful review.
+        - Ensure changes follow existing architecture and do not introduce breaking or cross-layer dependencies.
+        - Verify that modifications in `core-base` are necessary and minimal.
+
+        Output:
+        - Clearly highlight that `core-base` is a shared foundational module and requires extra review attention.
+
+    - path: "**/*Database.kt"
+      instructions: |
+        Room Database Migration Rules:
+        - If there is any change to a Room schema (fields added, removed, or modified in any `@Entity` class), the `version` number in the `@Database` annotation MUST be incremented.
+        - Verify if a migration strategy (e.g., `Migration` or `autoMigrations`) has been implemented for the version bump.
+        - Flag schema changes that do not accompany a database version increment to prevent runtime crashes.


### PR DESCRIPTION
[Jira-#759](https://mifosforge.jira.com/browse/MIFOSAC-759)

This PR has been replaced by #2672 .
It was accidentally closed, and subsequent commit amendments changed the commit history (SHAs), which prevented reopening it. A new PR has been created with the same changes to continue the review process.
Please refer to the new PR for further discussion and updates.


To derive meaningful review guidelines based on actual maintainer feedback, I analyzed recent pull requests across three repositories: mifos-pay, mifos-mobile, and mifos-x-field-officer-app.

A PowerShell script was used to fetch review comments and discussions from the latest 40 merged PRs of each repository (total ~120 PRs). The collected data was exported into a CSV file for easier processing.

This dataset was then analyzed using ChatGPT and Gemini Pro to identify recurring patterns in feedback. Based on these patterns, a set of practical and repo-specific CodeRabbit instructions were generated to improve automated review quality and align it with maintainer expectations.

CSV exported by shell script: 
[reviews.csv](https://github.com/user-attachments/files/26932942/reviews.csv)

Shell script used: 
```
$repos = @(
    "openMF/mifos-pay",
    "openMF/mifos-x-field-officer-app",
    "openMF/mifos-mobile"
)

$headers = @{
    Authorization = "Bearer Token"
    "User-Agent"  = "PowerShell"
}

$allData = @()

foreach ($repo in $repos) {

    Write-Host "`n===== Processing Repo: $repo ====="

    # Get last 40 merged PRs
    $prs = (Invoke-RestMethod -Headers $headers "https://api.github.com/repos/$repo/pulls?state=closed&per_page=100") |
        Where-Object { $_.merged_at -ne $null } |
        Select-Object -First 40

    foreach ($pr in $prs) {
        $prNumber = $pr.number
        Write-Host "Processing PR #$prNumber ($repo)"

        try {
            # Reviews
            $reviews = Invoke-RestMethod -Headers $headers "https://api.github.com/repos/$repo/pulls/$prNumber/reviews"

            # Inline comments
            $reviewComments = Invoke-RestMethod -Headers $headers "https://api.github.com/repos/$repo/pulls/$prNumber/comments"

            # Issue comments
            $issueComments = Invoke-RestMethod -Headers $headers "https://api.github.com/repos/$repo/issues/$prNumber/comments"

            $combined = @($reviews + $reviewComments + $issueComments)

            $filtered = $combined |
                Where-Object { $_.user.login -notin @("coderabbitai","coderabbitai[bot]","github-actions","dependabot[bot]") } |
                Where-Object { $_.body -and $_.body.Trim() -ne "" } |
                Where-Object { $_.body -notmatch "CodeRabbit|auto-generated|Suggested fix|Prompt for AI Agents|analysis chain|same here|please review|LGTM|looks good" } |
                Where-Object { $_.body -notmatch "^(ok|okay|done|thanks|great|will|i will|fixed|updated|resolved)\b" } |
                Where-Object { $_.body.Length -gt 20 } |
                ForEach-Object {
                    [PSCustomObject]@{
                        repo = $repo
                        pr   = $prNumber
                        user = $_.user.login
                        body = $_.body
                    }
                }

            $allData += $filtered
        }
        catch {
            Write-Host "⚠️ Error on PR #$prNumber ($repo)"
        }

        # Prevent secondary rate limiting
        Start-Sleep -Milliseconds 250
    }
}

# Final output
$allData | Select-Object repo, pr, user, body | Export-Csv -Path "reviews.csv" -NoTypeInformation -Encoding UTF8
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated chat auto-replies and PR review summaries with commit/status reporting.

* **Chores**
  * Enforced strict PR title format and pre-merge validation.
  * Required PR descriptions to include a valid Jira link and non-empty Before/After sections that contain image/video media (validated).
  * Introduced path-scoped guidance for Kotlin/Compose architecture, UI layering, naming and performance/side‑effect practices.
  * Marked core/base-area changes as high‑impact for extra review care.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->