### PR TITLE
chore(infra): bootstrap template sync-dirs + retarget to store5Migration

### DIFF
--- a/.github/workflows/sync-dirs.yaml
+++ b/.github/workflows/sync-dirs.yaml
@@ -56,6 +56,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
           # Declare directories and files to sync
           DIRS=(
             "cmp-android"
@@ -66,33 +67,38 @@ jobs:
             "core-base"
             "build-logic"
             "fastlane"
+            "fastlane-config"
             "scripts"
             "config"
             ".github"
             ".run"
           )
-          
+
           FILES=(
             "Gemfile"
             "Gemfile.lock"
             "ci-prepush.bat"
             "ci-prepush.sh"
           )
-          
+
           # Define exclusions
+          # Consumer-branded assets and project-specific configs are preserved across syncs.
           declare -A EXCLUSIONS=(
             ["cmp-android"]="src/main/res dependencies src/main/ic_launcher-playstore.png google-services.json"
-            ["cmp-web"]="src/jsMain/resources src/wasmJsMain/resources"
-            ["cmp-desktop"]="icons"
             ["cmp-ios"]="iosApp/Assets.xcassets"
+            ["cmp-web"]="src/jsMain/resources src/wasmJsMain/resources"
+            ["cmp-desktop"]="icons build.gradle.kts"
+            ["fastlane-config"]="project_config.rb extract_config.rb"
+            [".github"]="workflows/sync-dirs.yaml"
+            ["build-logic"]="convention/src/main/kotlin/local"
             ["root"]="secrets.env"
           )
-          
+
           # Function to check if path should be excluded
           should_exclude() {
             local dir=$1
             local path=$2
-          
+
             # Check for root exclusions (when dir is "." or "root")
             if [[ "$dir" == "." || "$dir" == "root" ]] && [[ -v "EXCLUSIONS[root]" ]]; then
               local root_excluded_paths
@@ -103,7 +109,7 @@ jobs:
                 fi
               done
             fi
-          
+
             # Check directory-specific exclusions
             if [[ -v "EXCLUSIONS[$dir]" ]]; then
               local excluded_paths
@@ -116,7 +122,7 @@ jobs:
             fi
             return 1
           }
-          
+
           # Function to preserve excluded paths
           preserve_excluded() {
             local dir=$1
@@ -134,7 +140,7 @@ jobs:
               done
             fi
           }
-          
+
           # Function to restore excluded paths
           restore_excluded() {
             local dir=$1
@@ -153,7 +159,7 @@ jobs:
               done
             fi
           }
-          
+
           # Function to preserve root-level excluded files
           preserve_root_files() {
             if [[ -v "EXCLUSIONS[root]" ]]; then
@@ -168,7 +174,7 @@ jobs:
               done
             fi
           }
-          
+
           # Function to restore root-level excluded files
           restore_root_files() {
             if [[ -v "EXCLUSIONS[root]" ]]; then
@@ -182,35 +188,37 @@ jobs:
               done
             fi
           }
-          
+
           # Create temp directory for exclusions
           mkdir -p temp_excluded
-          
+
           # Preserve root-level exclusions before sync
           preserve_root_files
-          
+
           # Switch to dev branch
           git checkout dev
-          
+
           # Sync directories
           for dir in "${DIRS[@]}"; do
-            if [ ! -d "$dir" ]; then
+            if [[ ! -d "$dir" ]]; then
               echo "Creating $dir..."
               mkdir -p "$dir"
             fi
-          
+
             # Preserve excluded paths before sync
             if [[ -d "$dir" ]]; then
               preserve_excluded "$dir"
             fi
-          
+
             echo "Syncing $dir..."
-            git checkout "${{ env.TEMP_BRANCH }}" -- "$dir" || exit 1
-          
+            if ! git checkout "${{ env.TEMP_BRANCH }}" -- "$dir" 2>/dev/null; then
+              echo "Warning: Could not sync directory $dir (may not exist in upstream)"
+            fi
+
             # Restore excluded paths after sync
             restore_excluded "$dir"
           done
-          
+
           # Sync files
           for file in "${FILES[@]}"; do
             file_dir=$(dirname "$file")
@@ -225,20 +233,20 @@ jobs:
             elif should_exclude "$file_dir" "$file"; then
               echo "Skipping excluded file: $file"
               continue
-              fi
-    
-              echo "Syncing $file..."
-              if ! git checkout "${{ env.TEMP_BRANCH }}" -- "$file" 2>/dev/null; then
-                echo "Warning: Could not sync file $file (may not exist in upstream)"
+            fi
+
+            echo "Syncing $file..."
+            if ! git checkout "${{ env.TEMP_BRANCH }}" -- "$file" 2>/dev/null; then
+              echo "Warning: Could not sync file $file (may not exist in upstream)"
             fi
           done
-          
+
           # Restore root-level excluded files
           restore_root_files
-          
+
           # Cleanup temp directory
           rm -rf temp_excluded
-          
+
           echo "Sync completed successfully!"
 
       - name: Clean up temporary branch
@@ -266,32 +274,33 @@ jobs:
           title: "chore: Sync directories and files from upstream"
           body: |
             Automated sync of directories and files from upstream repository.
-            
+
             Changes included in this sync:
-            
-            **Directories**:
-            - cmp-android (excluding src/main/res, dependencies, ic_launcher-playstore.png, google-services.json)
-            - cmp-desktop (excluding icons)
+
+            **Directories:**
+            - cmp-android (excluding src/main/res, dependencies, src/main/ic_launcher-playstore.png, google-services.json)
+            - cmp-desktop (excluding icons, build.gradle.kts)
             - cmp-ios (excluding iosApp/Assets.xcassets)
             - cmp-web (excluding src/jsMain/resources, src/wasmJsMain/resources)
             - cmp-shared
             - core-base
-            - build-logic
+            - build-logic (excluding convention/src/main/kotlin/local — consumer flavor extension point)
             - fastlane
+            - fastlane-config (excluding project_config.rb, extract_config.rb)
             - scripts
             - config
-            - .github
+            - .github (excluding workflows/sync-dirs.yaml — self-overwrite guard)
             - .run
-            
-            **Files**:
+
+            **Files:**
             - Gemfile
             - Gemfile.lock
             - ci-prepush.bat
             - ci-prepush.sh
-            
-            **Root-level exclusions**:
+
+            **Root-level exclusions:**
             - secrets.env
-            
+
             ---
             Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           branch: sync-dirs-${{ github.run_number }}

--- a/.github/workflows/sync-dirs.yaml
+++ b/.github/workflows/sync-dirs.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: dev
+          ref: store5Migration
 
       - name: Setup Git config
         run: |
@@ -195,8 +195,8 @@ jobs:
           # Preserve root-level exclusions before sync
           preserve_root_files
 
-          # Switch to dev branch
-          git checkout dev
+          # Switch to integration branch (store5Migration for this epic)
+          git checkout store5Migration
 
           # Sync directories
           for dir in "${DIRS[@]}"; do
@@ -308,4 +308,4 @@ jobs:
           labels: |
             sync
             automated pr
-          base: dev
+          base: store5Migration

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.iml
 .gradle
 /local.properties
+secrets.env
+secrets/
 /.idea/workspace.xml
 /.idea/libraries
 /build

--- a/sync-dirs.sh
+++ b/sync-dirs.sh
@@ -31,6 +31,7 @@ SYNC_DIRS=(
     "core-base"
     "build-logic"
     "fastlane"
+    "fastlane-config"
     "scripts"
     "config"
     ".github"
@@ -49,11 +50,23 @@ SYNC_FILES=(
 # type can be 'dir' or 'file'
 # Use "root" key for files in the root directory
 declare -A EXCLUSIONS=(
+    # Android — consumer-branded resources (drawables, strings, mipmaps), Firebase config,
+    # launcher icon, and the dependency-guard baseline directory are preserved across syncs.
     ["cmp-android"]="src/main/res:dir dependencies:dir src/main/ic_launcher-playstore.png:file google-services.json:file"
-    ["cmp-web"]="src/jsMain/resources:dir src/wasmJsMain/resources:dir"
-    ["cmp-desktop"]="icons:dir"
+    # iOS — consumer-branded asset catalog (app icon, color palette) preserved across syncs.
     ["cmp-ios"]="iosApp/Assets.xcassets:dir"
+    ["cmp-web"]="src/jsMain/resources:dir src/wasmJsMain/resources:dir"
+    ["cmp-desktop"]="icons:dir build.gradle.kts:file"
+    ["fastlane-config"]="project_config.rb:file extract_config.rb:file"
+    [".github"]="workflows/sync-dirs.yaml:file"
     ["root"]="secrets.env:file"
+    # DO NOT REMOVE — preserves consumer-specific flavor extensions across syncs.
+    # Each downstream consumer app (mifos-mobile, mifos-pay, mifos-x-field-officer-app,
+    # mifos-x-group-banking, mifos-x-open-banking, reels-downloader-new, ...) may
+    # create build-logic/convention/src/main/kotlin/local/LocalFlavors.kt to add
+    # their own flavors / dimensions / overrides on top of the synced base.
+    # See docs/FLAVORS_EXTENSION.md for the pattern.
+    ["build-logic"]="convention/src/main/kotlin/local:dir"
 )
 
 # Display help information


### PR DESCRIPTION
## Summary

Bootstrap field-officer's infra-sync mechanism by adopting the latest `kmp-project-template` sync workflow (post `openMF/kmp-project-template#158`) and retargeting the consumer-side ref / PR base from `dev` → `store5Migration` so the epic's integration branch is the merge target for every subsequent sync.

This is the **prerequisite** for triggering the first GitHub-Action sync run, which will open a separate PR titled "chore: Sync directories and files from upstream" against `store5Migration` with the actual infra payload — `core-base/store`, `core-base/ui`, `build-logic/convention`, `cmp-android/src` non-branded structure, `cmp-ios/iosApp`, `fastlane-config`, `scripts`, etc.

## Changes

| File | Diff | Purpose |
|---|---|---|
| `.github/workflows/sync-dirs.yaml` | +93 / -45 | Adopt template SOT (adds `fastlane-config` to DIRS, adds workflow self-overwrite guard exclusion, adds `cmp-desktop/build.gradle.kts` exclusion, adds `build-logic/convention/src/main/kotlin/local` flavor-extension exclusion, drops trailing whitespace). Three additional edits retarget `ref: dev` → `ref: store5Migration`, `git checkout dev` → `git checkout store5Migration`, `base: dev` → `base: store5Migration`. |
| `sync-dirs.sh` | +19 / -2 | Mirror the workflow YAML changes in the local bash script with explicit `:dir` / `:file` type tags. (Note: local script's hardcoded `BASE_BRANCH="dev"` is a known mismatch with field-officer's `development` default; we use the workflow, not the local script, for syncs going forward.) |
| `.gitignore` | +2 | Add `secrets.env` and `secrets/` (referenced by `keystore-manager.sh` and by the workflow's root EXCLUSIONS list). |

## Integration-branch model

All sub-phase PRs of the Store5-adoption epic target `store5Migration` on `openMF/mifos-x-field-officer-app`:
- Phase A (this PR + auto-generated sync PR)
- Phase B (core/store seam + AppDatabase v5)
- Phase C (20 features across 9 waves)
- Phase D (cleanup)

The final merge `store5Migration` → `development` happens only after Phase D's acceptance gate is green.

## Next step (post-merge)

Once this PR is merged into `store5Migration`, trigger the sync workflow on openMF:
```bash
gh workflow run sync-dirs.yaml -R openMF/mifos-x-field-officer-app --ref store5Migration
```
The workflow will open a second PR with the actual infra payload, also targeting `store5Migration`.

## Test plan

- [ ] Workflow YAML lints cleanly (GitHub renders without errors)
- [ ] `gh workflow list -R openMF/mifos-x-field-officer-app` shows "Sync CMP Directories" once this is merged
- [ ] Dry-run trigger of the workflow on `store5Migration` opens a sync PR (no payload — file additions only, no breaking changes to existing source)
- [ ] Sync PR diff respects all EXCLUSIONS (consumer-branded `src/main/res`, `google-services.json`, `Assets.xcassets`, etc. unchanged)

## Related

- Template SOT PR: `openMF/kmp-project-template#158` (merged 2026-05-21)