### PR TITLE
feat(core/store): Phase B — consumer Store5 seam (Theme + Koin + DB v2 + RoomSubmitOutbox)

### DIFF
--- a/cmp-navigation/build.gradle.kts
+++ b/cmp-navigation/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
             implementation(projects.core.datastore)
             implementation(projects.core.database)
             implementation(projects.core.network)
+            implementation(projects.core.store)
             implementation(projects.coreBase.common)
 
             implementation(projects.feature.about)

--- a/cmp-navigation/src/commonMain/kotlin/cmp/navigation/di/KoinModules.kt
+++ b/cmp-navigation/src/commonMain/kotlin/cmp/navigation/di/KoinModules.kt
@@ -18,6 +18,7 @@ import com.mifos.core.datastore.di.PreferencesModule
 import com.mifos.core.domain.di.UseCaseModule
 import com.mifos.core.network.di.DataManagerModule
 import com.mifos.core.network.di.NetworkModule
+import com.mifos.core.store.di.appStoreModule
 import com.mifos.feature.activate.di.ActivateModule
 import com.mifos.feature.auth.di.AuthModule
 import com.mifos.feature.center.di.CenterModule
@@ -107,5 +108,6 @@ object KoinModules {
         networkModules,
         coreDataStoreModules,
         coreBaseCommonModules,
+        appStoreModule,
     )
 }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -40,6 +40,7 @@ kotlin {
             api(projects.core.network)
             api(projects.core.database)
             api(projects.coreBase.common)
+            api(projects.coreBase.store)
 
 
             implementation(libs.mifos.authenticator.passcode)

--- a/core/data/src/commonMain/kotlin/com/mifos/core/data/infra/impl/RoomSubmitOutbox.kt
+++ b/core/data/src/commonMain/kotlin/com/mifos/core/data/infra/impl/RoomSubmitOutbox.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mifos-x-field-officer-app/blob/master/LICENSE.md
+ */
+package com.mifos.core.data.infra.impl
+
+import com.mifos.room.dao.DraftDao
+import com.mifos.room.entities.framework.DraftEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+import template.core.base.store.submit.SubmitOutbox
+import template.core.base.store.submit.SubmitOutboxEntry
+import template.core.base.store.submit.SubmitOutboxStatus
+
+/**
+ * Room-backed [SubmitOutbox] that persists form payloads across process death.
+ *
+ * Serializes payloads to JSON via [kotlinx.serialization] and stores them in the
+ * `framework_submit_drafts` table inside [com.mifos.room.MifosDatabase].
+ *
+ * Wire one instance per form type in your DI module:
+ * ```kotlin
+ * single<SubmitOutbox<LoanApplicationPayload>> {
+ *     RoomSubmitOutbox(
+ *         dao = get<MifosDatabase>().draftDao,
+ *         serializer = LoanApplicationPayload.serializer(),
+ *     )
+ * }
+ * ```
+ *
+ * @param P Payload type. Must be annotated with `@Serializable`.
+ * @param dao The Room DAO for the `framework_submit_drafts` table.
+ * @param serializer Kotlinx serializer for [P]. Obtain via `P.serializer()`.
+ */
+class RoomSubmitOutbox<P>(
+    private val dao: DraftDao,
+    private val serializer: KSerializer<P>,
+) : SubmitOutbox<P> {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override suspend fun save(formKey: String, payload: P): Long {
+        val nowMs = currentTimeMillis()
+        val existing = dao.getPendingByFormKey(formKey)
+        if (existing != null) {
+            dao.updatePayload(existing.id, json.encodeToString(serializer, payload), nowMs)
+            return existing.id
+        }
+        val entity = DraftEntity(
+            formKey = formKey,
+            payloadJson = json.encodeToString(serializer, payload),
+            status = SubmitOutboxStatus.PENDING.name,
+            createdAtMs = nowMs,
+            updatedAtMs = nowMs,
+        )
+        return dao.insert(entity)
+    }
+
+    override suspend fun getPending(formKey: String): SubmitOutboxEntry<P>? =
+        dao.getPendingByFormKey(formKey)?.toEntry()
+
+    override fun observePending(formKey: String): Flow<SubmitOutboxEntry<P>?> =
+        dao.observePendingByFormKey(formKey).map { it?.toEntry() }
+
+    override suspend fun getAllPending(): List<SubmitOutboxEntry<P>> =
+        dao.getAllPending().mapNotNull { it.toEntry() }
+
+    override suspend fun markRetrying(id: Long) =
+        dao.markRetrying(id, currentTimeMillis())
+
+    override suspend fun markSubmitted(id: Long) =
+        dao.markSubmitted(id, currentTimeMillis())
+
+    override suspend fun markFailed(id: Long, error: String?) =
+        dao.markFailed(id, currentTimeMillis(), error)
+
+    override suspend fun deleteByFormKey(formKey: String) =
+        dao.deleteByFormKey(formKey)
+
+    override suspend fun deleteAll() =
+        dao.deleteAll()
+
+    private fun DraftEntity.toEntry(): SubmitOutboxEntry<P>? = runCatching {
+        SubmitOutboxEntry(
+            id = id,
+            formKey = formKey,
+            payload = json.decodeFromString(serializer, payloadJson),
+            status = SubmitOutboxStatus.valueOf(status),
+            createdAtMs = createdAtMs,
+            errorMessage = errorMessage,
+        )
+    }.getOrNull()
+}
+
+private fun currentTimeMillis(): Long = kotlin.time.Clock.System.now().toEpochMilliseconds()

--- a/core/database/src/androidMain/kotlin/com/mifos/room/MifosDatabase.kt
+++ b/core/database/src/androidMain/kotlin/com/mifos/room/MifosDatabase.kt
@@ -16,6 +16,7 @@ import com.mifos.room.dao.CenterDao
 import com.mifos.room.dao.ChargeDao
 import com.mifos.room.dao.ClientDao
 import com.mifos.room.dao.ColumnValueDao
+import com.mifos.room.dao.DraftDao
 import com.mifos.room.dao.GroupsDao
 import com.mifos.room.dao.LoanDao
 import com.mifos.room.dao.OfficeDao
@@ -23,6 +24,7 @@ import com.mifos.room.dao.SavingsDao
 import com.mifos.room.dao.StaffDao
 import com.mifos.room.dao.SurveyDao
 import com.mifos.room.entities.PaymentTypeOptionEntity
+import com.mifos.room.entities.framework.DraftEntity
 import com.mifos.room.entities.accounts.loans.ActualDisbursementDateEntity
 import com.mifos.room.entities.accounts.loans.LoanAccountEntity
 import com.mifos.room.entities.accounts.loans.LoanRepaymentRequestEntity
@@ -148,6 +150,8 @@ import com.mifos.room.typeconverters.CustomTypeConverters
         LoanRepaymentTemplateEntity::class,
         // zip models package
         PaymentTypeOptionEntity::class,
+        // framework: submit-draft outbox
+        DraftEntity::class,
     ],
     version = MifosDatabase.VERSION,
     exportSchema = false,
@@ -161,6 +165,7 @@ actual abstract class MifosDatabase : RoomDatabase() {
     actual abstract val chargeDao: ChargeDao
     actual abstract val clientDao: ClientDao
     actual abstract val columnValueDao: ColumnValueDao
+    actual abstract val draftDao: DraftDao
     actual abstract val groupsDao: GroupsDao
     actual abstract val loanDao: LoanDao
     actual abstract val officeDao: OfficeDao
@@ -169,6 +174,6 @@ actual abstract class MifosDatabase : RoomDatabase() {
     actual abstract val surveyDao: SurveyDao
 
     companion object {
-        const val VERSION = 1
+        const val VERSION = 2
     }
 }

--- a/core/database/src/androidMain/kotlin/com/mifos/room/di/DatabaseModule.android.kt
+++ b/core/database/src/androidMain/kotlin/com/mifos/room/di/DatabaseModule.android.kt
@@ -9,7 +9,10 @@
  */
 package com.mifos.room.di
 
+import androidx.room3.migration.Migration
+import androidx.sqlite.SQLiteConnection
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import androidx.sqlite.execSQL
 import com.mifos.core.common.network.MifosDispatchers
 import com.mifos.core.common.utils.Constants
 import com.mifos.room.MifosDatabase
@@ -20,6 +23,28 @@ import org.koin.dsl.module
 import template.core.base.database.AppDatabaseFactory
 import kotlin.coroutines.CoroutineContext
 
+/**
+ * Adds the `framework_submit_drafts` table — see
+ * [com.mifos.room.entities.framework.DraftEntity] for the schema.
+ */
+internal val MIGRATION_1_2 = object : Migration(1, 2) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `framework_submit_drafts` (
+                `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                `formKey` TEXT NOT NULL,
+                `payloadJson` TEXT NOT NULL,
+                `status` TEXT NOT NULL,
+                `createdAtMs` INTEGER NOT NULL,
+                `updatedAtMs` INTEGER NOT NULL,
+                `errorMessage` TEXT
+            )
+            """.trimIndent(),
+        )
+    }
+}
+
 actual val PlatformSpecificDatabaseModule: Module = module {
     single<MifosDatabase> {
         val ioContext: CoroutineContext = getKoin().get(named(MifosDispatchers.IO.name))
@@ -27,6 +52,7 @@ actual val PlatformSpecificDatabaseModule: Module = module {
         AppDatabaseFactory(androidApplication())
             .createDatabase(MifosDatabase::class.java, Constants.DATABASE_NAME)
             .fallbackToDestructiveMigrationOnDowngrade(false)
+            .addMigrations(MIGRATION_1_2)
             .setDriver(BundledSQLiteDriver())
             .setQueryCoroutineContext(ioContext)
             .build()

--- a/core/database/src/commonMain/kotlin/com/mifos/room/MifosDatabase.kt
+++ b/core/database/src/commonMain/kotlin/com/mifos/room/MifosDatabase.kt
@@ -13,6 +13,7 @@ import com.mifos.room.dao.CenterDao
 import com.mifos.room.dao.ChargeDao
 import com.mifos.room.dao.ClientDao
 import com.mifos.room.dao.ColumnValueDao
+import com.mifos.room.dao.DraftDao
 import com.mifos.room.dao.GroupsDao
 import com.mifos.room.dao.LoanDao
 import com.mifos.room.dao.OfficeDao
@@ -26,6 +27,7 @@ expect abstract class MifosDatabase {
     abstract val chargeDao: ChargeDao
     abstract val clientDao: ClientDao
     abstract val columnValueDao: ColumnValueDao
+    abstract val draftDao: DraftDao
     abstract val groupsDao: GroupsDao
     abstract val loanDao: LoanDao
     abstract val officeDao: OfficeDao

--- a/core/database/src/commonMain/kotlin/com/mifos/room/dao/DraftDao.kt
+++ b/core/database/src/commonMain/kotlin/com/mifos/room/dao/DraftDao.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mifos-x-field-officer-app/blob/master/LICENSE.md
+ */
+package com.mifos.room.dao
+
+import com.mifos.room.entities.framework.DraftEntity
+import kotlinx.coroutines.flow.Flow
+import template.core.base.database.Dao
+import template.core.base.database.Insert
+import template.core.base.database.OnConflictStrategy
+import template.core.base.database.Query
+
+/**
+ * DAO for the framework-owned `framework_submit_drafts` table.
+ *
+ * Consumed by [com.mifos.core.data.infra.impl.RoomSubmitOutbox]. The framework uses
+ * this table to persist form payloads that failed to reach the server so users can
+ * resume or retry later.
+ */
+@Dao
+interface DraftDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(entity: DraftEntity): Long
+
+    @Query("SELECT * FROM framework_submit_drafts WHERE id = :id")
+    suspend fun getById(id: Long): DraftEntity?
+
+    @Query("SELECT * FROM framework_submit_drafts WHERE formKey = :formKey AND status = 'PENDING' LIMIT 1")
+    suspend fun getPendingByFormKey(formKey: String): DraftEntity?
+
+    @Query("SELECT * FROM framework_submit_drafts WHERE formKey = :formKey AND status = 'PENDING' LIMIT 1")
+    fun observePendingByFormKey(formKey: String): Flow<DraftEntity?>
+
+    @Query("SELECT * FROM framework_submit_drafts WHERE status = 'PENDING'")
+    suspend fun getAllPending(): List<DraftEntity>
+
+    @Query("UPDATE framework_submit_drafts SET status = 'RETRYING', updatedAtMs = :nowMs WHERE id = :id")
+    suspend fun markRetrying(id: Long, nowMs: Long)
+
+    @Query("UPDATE framework_submit_drafts SET status = 'SUBMITTED', updatedAtMs = :nowMs WHERE id = :id")
+    suspend fun markSubmitted(id: Long, nowMs: Long)
+
+    @Query(
+        "UPDATE framework_submit_drafts SET status = 'FAILED', " +
+            "updatedAtMs = :nowMs, errorMessage = :error WHERE id = :id",
+    )
+    suspend fun markFailed(id: Long, nowMs: Long, error: String?)
+
+    @Query("UPDATE framework_submit_drafts SET payloadJson = :payloadJson, updatedAtMs = :nowMs WHERE id = :id")
+    suspend fun updatePayload(id: Long, payloadJson: String, nowMs: Long)
+
+    @Query("DELETE FROM framework_submit_drafts WHERE formKey = :formKey")
+    suspend fun deleteByFormKey(formKey: String)
+
+    @Query("DELETE FROM framework_submit_drafts")
+    suspend fun deleteAll()
+
+    /**
+     * Deletes SUBMITTED and FAILED rows older than [thresholdMs] (epoch millis).
+     * PENDING drafts are never pruned here — the user may still want to resume them.
+     * Call on app start via the framework's StoreCacheManager.pruneExpiredDrafts hook.
+     */
+    @Query(
+        "DELETE FROM framework_submit_drafts " +
+            "WHERE createdAtMs < :thresholdMs AND status IN ('SUBMITTED', 'FAILED')",
+    )
+    suspend fun deleteOlderThan(thresholdMs: Long)
+}

--- a/core/database/src/commonMain/kotlin/com/mifos/room/di/DaoModule.kt
+++ b/core/database/src/commonMain/kotlin/com/mifos/room/di/DaoModule.kt
@@ -18,6 +18,7 @@ val DaoModule = module {
     single { get<MifosDatabase>().chargeDao }
     single { get<MifosDatabase>().clientDao }
     single { get<MifosDatabase>().columnValueDao }
+    single { get<MifosDatabase>().draftDao }
     single { get<MifosDatabase>().groupsDao }
     single { get<MifosDatabase>().loanDao }
     single { get<MifosDatabase>().officeDao }

--- a/core/database/src/commonMain/kotlin/com/mifos/room/entities/framework/DraftEntity.kt
+++ b/core/database/src/commonMain/kotlin/com/mifos/room/entities/framework/DraftEntity.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mifos-x-field-officer-app/blob/master/LICENSE.md
+ */
+package com.mifos.room.entities.framework
+
+import template.core.base.database.Entity
+import template.core.base.database.PrimaryKey
+
+/**
+ * Durable row for a form payload that failed to reach the server.
+ *
+ * Written by [com.mifos.core.data.infra.impl.RoomSubmitOutbox] when a network error
+ * occurs during form submission. The row survives process death so the user can
+ * resume or retry later.
+ *
+ * @param id          Auto-generated surrogate key.
+ * @param formKey     Consumer-defined identifier that groups drafts by screen/form type
+ *                    (e.g. `"loan_application"`, `"client_registration"`). One pending
+ *                    draft per formKey is the intended invariant — consumers enforce
+ *                    uniqueness via [com.mifos.room.dao.DraftDao.deleteByFormKey] before
+ *                    inserting.
+ * @param payloadJson Serialized form payload (JSON). The concrete type is opaque to the
+ *                    framework; consumers encode/decode via kotlinx.serialization.
+ * @param status      Lifecycle state — one of
+ *                    [template.core.base.store.submit.SubmitOutboxStatus] values
+ *                    serialized as `.name`.
+ * @param createdAtMs Epoch millis when the draft was first saved.
+ * @param updatedAtMs Epoch millis of the most recent status transition.
+ * @param errorMessage Last failure reason for display in the resume UI (nullable).
+ */
+@Entity(
+    indices = [],
+    inheritSuperIndices = false,
+    primaryKeys = [],
+    foreignKeys = [],
+    ignoredColumns = [],
+    tableName = "framework_submit_drafts",
+)
+data class DraftEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val formKey: String,
+    val payloadJson: String,
+    val status: String,
+    val createdAtMs: Long,
+    val updatedAtMs: Long,
+    val errorMessage: String? = null,
+)

--- a/core/database/src/desktopMain/kotlin/com/mifos/room/MifosDatabase.kt
+++ b/core/database/src/desktopMain/kotlin/com/mifos/room/MifosDatabase.kt
@@ -16,6 +16,7 @@ import com.mifos.room.dao.CenterDao
 import com.mifos.room.dao.ChargeDao
 import com.mifos.room.dao.ClientDao
 import com.mifos.room.dao.ColumnValueDao
+import com.mifos.room.dao.DraftDao
 import com.mifos.room.dao.GroupsDao
 import com.mifos.room.dao.LoanDao
 import com.mifos.room.dao.OfficeDao
@@ -23,6 +24,7 @@ import com.mifos.room.dao.SavingsDao
 import com.mifos.room.dao.StaffDao
 import com.mifos.room.dao.SurveyDao
 import com.mifos.room.entities.PaymentTypeOptionEntity
+import com.mifos.room.entities.framework.DraftEntity
 import com.mifos.room.entities.accounts.loans.ActualDisbursementDateEntity
 import com.mifos.room.entities.accounts.loans.LoanAccountEntity
 import com.mifos.room.entities.accounts.loans.LoanRepaymentRequestEntity
@@ -148,6 +150,8 @@ import com.mifos.room.typeconverters.CustomTypeConverters
         LoanRepaymentTemplateEntity::class,
         // zip models package
         PaymentTypeOptionEntity::class,
+        // framework: submit-draft outbox
+        DraftEntity::class,
     ],
     version = MifosDatabase.VERSION,
     exportSchema = false,
@@ -161,6 +165,7 @@ actual abstract class MifosDatabase : RoomDatabase() {
     actual abstract val chargeDao: ChargeDao
     actual abstract val clientDao: ClientDao
     actual abstract val columnValueDao: ColumnValueDao
+    actual abstract val draftDao: DraftDao
     actual abstract val groupsDao: GroupsDao
     actual abstract val loanDao: LoanDao
     actual abstract val officeDao: OfficeDao
@@ -169,6 +174,6 @@ actual abstract class MifosDatabase : RoomDatabase() {
     actual abstract val surveyDao: SurveyDao
 
     companion object {
-        const val VERSION = 1
+        const val VERSION = 2
     }
 }

--- a/core/database/src/desktopMain/kotlin/com/mifos/room/di/DatabaseModule.desktop.kt
+++ b/core/database/src/desktopMain/kotlin/com/mifos/room/di/DatabaseModule.desktop.kt
@@ -9,7 +9,10 @@
  */
 package com.mifos.room.di
 
+import androidx.room3.migration.Migration
+import androidx.sqlite.SQLiteConnection
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import androidx.sqlite.execSQL
 import com.mifos.core.common.network.MifosDispatchers
 import com.mifos.core.common.utils.Constants
 import com.mifos.room.MifosDatabase
@@ -19,6 +22,28 @@ import org.koin.dsl.module
 import template.core.base.database.AppDatabaseFactory
 import kotlin.coroutines.CoroutineContext
 
+/**
+ * Adds the `framework_submit_drafts` table — see
+ * [com.mifos.room.entities.framework.DraftEntity] for the schema.
+ */
+internal val MIGRATION_1_2 = object : Migration(1, 2) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `framework_submit_drafts` (
+                `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                `formKey` TEXT NOT NULL,
+                `payloadJson` TEXT NOT NULL,
+                `status` TEXT NOT NULL,
+                `createdAtMs` INTEGER NOT NULL,
+                `updatedAtMs` INTEGER NOT NULL,
+                `errorMessage` TEXT
+            )
+            """.trimIndent(),
+        )
+    }
+}
+
 actual val PlatformSpecificDatabaseModule: Module = module {
     single<MifosDatabase> {
         val ioContext: CoroutineContext = getKoin().get(named(MifosDispatchers.IO.name))
@@ -26,6 +51,7 @@ actual val PlatformSpecificDatabaseModule: Module = module {
         AppDatabaseFactory()
             .createDatabase<MifosDatabase>(Constants.DATABASE_NAME)
             .fallbackToDestructiveMigrationOnDowngrade(false)
+            .addMigrations(MIGRATION_1_2)
             .setDriver(BundledSQLiteDriver())
             .setQueryCoroutineContext(ioContext)
             .build()

--- a/core/database/src/nativeMain/kotlin/com/mifos/room/MifosDatabase.kt
+++ b/core/database/src/nativeMain/kotlin/com/mifos/room/MifosDatabase.kt
@@ -18,6 +18,7 @@ import com.mifos.room.dao.CenterDao
 import com.mifos.room.dao.ChargeDao
 import com.mifos.room.dao.ClientDao
 import com.mifos.room.dao.ColumnValueDao
+import com.mifos.room.dao.DraftDao
 import com.mifos.room.dao.GroupsDao
 import com.mifos.room.dao.LoanDao
 import com.mifos.room.dao.OfficeDao
@@ -25,6 +26,7 @@ import com.mifos.room.dao.SavingsDao
 import com.mifos.room.dao.StaffDao
 import com.mifos.room.dao.SurveyDao
 import com.mifos.room.entities.PaymentTypeOptionEntity
+import com.mifos.room.entities.framework.DraftEntity
 import com.mifos.room.entities.accounts.loans.ActualDisbursementDateEntity
 import com.mifos.room.entities.accounts.loans.LoanAccountEntity
 import com.mifos.room.entities.accounts.loans.LoanRepaymentRequestEntity
@@ -150,6 +152,8 @@ import com.mifos.room.typeconverters.CustomTypeConverters
         LoanRepaymentTemplateEntity::class,
         // zip models package
         PaymentTypeOptionEntity::class,
+        // framework: submit-draft outbox
+        DraftEntity::class,
     ],
     version = MifosDatabase.VERSION,
     exportSchema = false,
@@ -164,6 +168,7 @@ actual abstract class MifosDatabase : RoomDatabase() {
     actual abstract val chargeDao: ChargeDao
     actual abstract val clientDao: ClientDao
     actual abstract val columnValueDao: ColumnValueDao
+    actual abstract val draftDao: DraftDao
     actual abstract val groupsDao: GroupsDao
     actual abstract val loanDao: LoanDao
     actual abstract val officeDao: OfficeDao
@@ -172,7 +177,7 @@ actual abstract class MifosDatabase : RoomDatabase() {
     actual abstract val surveyDao: SurveyDao
 
     companion object {
-        const val VERSION = 1
+        const val VERSION = 2
     }
 }
 

--- a/core/database/src/nativeMain/kotlin/com/mifos/room/di/PlatformSpecificModule.kt
+++ b/core/database/src/nativeMain/kotlin/com/mifos/room/di/PlatformSpecificModule.kt
@@ -9,7 +9,10 @@
  */
 package com.mifos.room.di
 
+import androidx.room3.migration.Migration
+import androidx.sqlite.SQLiteConnection
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import androidx.sqlite.execSQL
 import com.mifos.core.common.network.MifosDispatchers
 import com.mifos.core.common.utils.Constants
 import com.mifos.room.MifosDatabase
@@ -19,6 +22,28 @@ import org.koin.dsl.module
 import template.core.base.database.AppDatabaseFactory
 import kotlin.coroutines.CoroutineContext
 
+/**
+ * Adds the `framework_submit_drafts` table — see
+ * [com.mifos.room.entities.framework.DraftEntity] for the schema.
+ */
+internal val MIGRATION_1_2 = object : Migration(1, 2) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `framework_submit_drafts` (
+                `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                `formKey` TEXT NOT NULL,
+                `payloadJson` TEXT NOT NULL,
+                `status` TEXT NOT NULL,
+                `createdAtMs` INTEGER NOT NULL,
+                `updatedAtMs` INTEGER NOT NULL,
+                `errorMessage` TEXT
+            )
+            """.trimIndent(),
+        )
+    }
+}
+
 actual val PlatformSpecificDatabaseModule: Module = module {
     single<MifosDatabase> {
         val ioContext: CoroutineContext = getKoin().get(named(MifosDispatchers.IO.name))
@@ -26,6 +51,7 @@ actual val PlatformSpecificDatabaseModule: Module = module {
         AppDatabaseFactory()
             .createDatabase<MifosDatabase>(Constants.DATABASE_NAME)
             .fallbackToDestructiveMigrationOnDowngrade(false)
+            .addMigrations(MIGRATION_1_2)
             .setDriver(BundledSQLiteDriver())
             .setQueryCoroutineContext(ioContext)
             .build()

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -47,7 +47,7 @@ kotlin {
             api(libs.window.size)
             api(projects.coreBase.designsystem)
             implementation(libs.fluentui.system.icons)
-            api(projects.coreBase.designsystem)
+            implementation(projects.core.store)
         }
 
         nativeMain.dependencies {

--- a/core/designsystem/src/commonMain/kotlin/com/mifos/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/mifos/core/designsystem/theme/Theme.kt
@@ -14,10 +14,13 @@ import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import com.mifos.core.store.appScreenStateDefaults
 import template.core.base.designsystem.KptMaterialTheme
 import template.core.base.designsystem.theme.KptThemeProviderImpl
 import template.core.base.designsystem.toKptColorScheme
 import template.core.base.designsystem.toKptTypography
+import template.core.base.ui.screen.LocalScreenStateDefaults
 val lightScheme = lightColorScheme(
     primary = primaryLight,
     onPrimary = onPrimaryLight,
@@ -268,10 +271,15 @@ fun MifosTheme(
         typography = typography,
     )
 
-    KptMaterialTheme(
-        theme = theme,
-        content = content,
-    )
+    val screenStateDefaults = appScreenStateDefaults()
+
+    KptMaterialTheme(theme = theme) {
+        CompositionLocalProvider(
+            LocalScreenStateDefaults provides screenStateDefaults,
+        ) {
+            content()
+        }
+    }
 }
 
 @Composable

--- a/core/store/README.md
+++ b/core/store/README.md
@@ -1,60 +1,40 @@
-# `core/store` — Consumer Customization Seam
+# `core/store`
 
-This module is the **single discoverable customization point** for `mifos-x-field-officer-app`'s
-adoption of `kmp-project-template`'s Store5 offline-first pipeline. It scaffolds the
-per-app integration layer for the framework's `core-base/store` (state model) and
-`core-base/ui` (ScreenState rendering).
+Consumer customization seam for the offline-first Store5 pipeline shipped by
+`core-base/store` + `core-base/ui`. App-specific branding, error mapping, and
+Store registrations live here; `core-base/*` stays framework-shared and is
+not edited locally.
 
-## What you get for free (no per-screen code)
+## Files
 
-By calling `ScreenContent(state, onRetry) { data -> ... }` (or `PagingScreenContent`),
-your screen automatically gets:
-
-- ✅ Loading → Content / NoNetwork / Error / Empty transitions, animated
-- ✅ Captive-portal detection
-- ✅ Auto-refresh when network reconnects (debounced 300ms)
-- ✅ `lastContent` preservation during refresh (no flicker)
-- ✅ Pagination with cache-first reads + load-more trigger + footer + retry
-- ✅ Branded visuals from `appScreenStateDefaults()`
-- ✅ A11y semantics (TalkBack/VoiceOver state announcements + liveRegion)
-- ✅ Default `messageFor` routes through Fineract-aware `mapErrorToUserMessage`
-
-You write **zero state-handling code** in screens. Decision logic lives in
-`core-base/store`'s `DecisionEngine`.
-
-## The four customization files
-
-| File | Purpose |
+| File | Role |
 |---|---|
-| `AppStoreRegistry.kt` | Named-qualifier registry for every `Store5` instance. Phase C feature waves add `val Foo = store("foo")` here as they migrate. |
-| `AppErrorMapper.kt` | `Throwable` → user-message mapper. Extend the `when` with Fineract exception branches as features land. |
-| `AppScreenStateDefaults.kt` | Branded empty / error / no-network / loading visuals (Lottie + telemetry hooks reserved). |
-| `di/StoreModule.kt` | Koin `appStoreModule` — `single<Store<…>>(qualifier = AppStoreRegistry.X) { … }` registrations. |
+| `AppStoreRegistry.kt` | Named-qualifier registry. Add `val Foo = store("foo")` per `Store<K, V>` the app exposes. |
+| `AppErrorMapper.kt` | `Throwable → user-message` mapper. Extend the `when` with domain exception branches above the `categorize` fallback. |
+| `AppScreenStateDefaults.kt` | Branded `ScreenStateDefaults` (loading skeleton, empty/error/no-network copy). Wired into `MifosTheme` via `LocalScreenStateDefaults`. |
+| `di/StoreModule.kt` | Koin `appStoreModule`. Register `single<Store<K, V>>(qualifier = AppStoreRegistry.X) { ... }` per Store. |
 
-## Do NOT modify
+## Offline mutations (`SubmitOutbox` + `OfflineSubmitSyncer`)
 
-- `core-base/store` — framework-shared, syncs from `kmp-project-template` via the sync-dirs workflow. Any per-app behavior should land here in `core/store` instead.
-- `core-base/ui` — same.
+`OfflineSubmitSyncer<P, R>` is parameterized by payload type — instantiate one per
+form in the feature's DI module, bound to a long-lived `CoroutineScope`:
 
-## Wiring (Phase B follow-up)
+```kotlin
+single<SubmitOutbox<LoanApplicationPayload>> {
+    RoomSubmitOutbox(
+        dao = get<MifosDatabase>().draftDao,
+        serializer = LoanApplicationPayload.serializer(),
+    )
+}
+single { (scope: CoroutineScope) ->
+    scope.offlineSubmitSyncer(
+        outbox       = get<SubmitOutbox<LoanApplicationPayload>>(),
+        isOnlineFlow = get<NetworkMonitor>().isOnline,
+        submitBlock  = { payload -> get<LoanRepository>().submit(payload) },
+    ).also { it.start() }
+}
+```
 
-The Phase B scaffold creates the files but does **not** yet wire them into the running
-app. The remaining wiring tasks are:
-
-1. **Theme** — thread `LocalScreenStateDefaults provides appScreenStateDefaults()` into
-   `core/designsystem/.../MifosTheme.kt` so every screen inherits the branded defaults.
-2. **Koin** — add `appStoreModule` to the `startKoin { modules(...) }` call in both
-   `cmp-android` and `cmp-ios` app modules.
-3. **AppDatabase v4 → v5 AutoMigration** — add `framework_submit_drafts` entity to the
-   `MifosDatabase` `entities = [...]`, bump version, register the AutoMigration.
-4. **OfflineSubmitSyncer boot** — call `syncer.start()` in `MainActivity.onCreate` (Android)
-   and the iOS app entry point.
-
-See the Phase B sub-plan in `plan-layer/project-plans/mifos-x/mifos-x-field-officer-app/active/store5-adoption/B-core.md`
-for the full task list.
-
-## See also
-
-- Store implementation guide — `kmp-project-template/docs/store-implementation.md` (template repo)
-- Phase B sub-plan — `plan-layer/project-plans/mifos-x/mifos-x-field-officer-app/active/store5-adoption/B-core.md`
-- Phase C sub-plan (feature-wave migrations) — `plan-layer/project-plans/mifos-x/mifos-x-field-officer-app/active/store5-adoption/C-features.md`
+Drafts are persisted in the `framework_submit_drafts` table
+(`com.mifos.room.entities.framework.DraftEntity`). The syncer retries every
+`PENDING` draft on each offline → online transition.

--- a/core/store/README.md
+++ b/core/store/README.md
@@ -1,0 +1,60 @@
+# `core/store` — Consumer Customization Seam
+
+This module is the **single discoverable customization point** for `mifos-x-field-officer-app`'s
+adoption of `kmp-project-template`'s Store5 offline-first pipeline. It scaffolds the
+per-app integration layer for the framework's `core-base/store` (state model) and
+`core-base/ui` (ScreenState rendering).
+
+## What you get for free (no per-screen code)
+
+By calling `ScreenContent(state, onRetry) { data -> ... }` (or `PagingScreenContent`),
+your screen automatically gets:
+
+- ✅ Loading → Content / NoNetwork / Error / Empty transitions, animated
+- ✅ Captive-portal detection
+- ✅ Auto-refresh when network reconnects (debounced 300ms)
+- ✅ `lastContent` preservation during refresh (no flicker)
+- ✅ Pagination with cache-first reads + load-more trigger + footer + retry
+- ✅ Branded visuals from `appScreenStateDefaults()`
+- ✅ A11y semantics (TalkBack/VoiceOver state announcements + liveRegion)
+- ✅ Default `messageFor` routes through Fineract-aware `mapErrorToUserMessage`
+
+You write **zero state-handling code** in screens. Decision logic lives in
+`core-base/store`'s `DecisionEngine`.
+
+## The four customization files
+
+| File | Purpose |
+|---|---|
+| `AppStoreRegistry.kt` | Named-qualifier registry for every `Store5` instance. Phase C feature waves add `val Foo = store("foo")` here as they migrate. |
+| `AppErrorMapper.kt` | `Throwable` → user-message mapper. Extend the `when` with Fineract exception branches as features land. |
+| `AppScreenStateDefaults.kt` | Branded empty / error / no-network / loading visuals (Lottie + telemetry hooks reserved). |
+| `di/StoreModule.kt` | Koin `appStoreModule` — `single<Store<…>>(qualifier = AppStoreRegistry.X) { … }` registrations. |
+
+## Do NOT modify
+
+- `core-base/store` — framework-shared, syncs from `kmp-project-template` via the sync-dirs workflow. Any per-app behavior should land here in `core/store` instead.
+- `core-base/ui` — same.
+
+## Wiring (Phase B follow-up)
+
+The Phase B scaffold creates the files but does **not** yet wire them into the running
+app. The remaining wiring tasks are:
+
+1. **Theme** — thread `LocalScreenStateDefaults provides appScreenStateDefaults()` into
+   `core/designsystem/.../MifosTheme.kt` so every screen inherits the branded defaults.
+2. **Koin** — add `appStoreModule` to the `startKoin { modules(...) }` call in both
+   `cmp-android` and `cmp-ios` app modules.
+3. **AppDatabase v4 → v5 AutoMigration** — add `framework_submit_drafts` entity to the
+   `MifosDatabase` `entities = [...]`, bump version, register the AutoMigration.
+4. **OfflineSubmitSyncer boot** — call `syncer.start()` in `MainActivity.onCreate` (Android)
+   and the iOS app entry point.
+
+See the Phase B sub-plan in `plan-layer/project-plans/mifos-x/mifos-x-field-officer-app/active/store5-adoption/B-core.md`
+for the full task list.
+
+## See also
+
+- Store implementation guide — `kmp-project-template/docs/store-implementation.md` (template repo)
+- Phase B sub-plan — `plan-layer/project-plans/mifos-x/mifos-x-field-officer-app/active/store5-adoption/B-core.md`
+- Phase C sub-plan (feature-wave migrations) — `plan-layer/project-plans/mifos-x/mifos-x-field-officer-app/active/store5-adoption/C-features.md`

--- a/core/store/build.gradle.kts
+++ b/core/store/build.gradle.kts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+plugins {
+    alias(libs.plugins.kmp.library.convention)
+    alias(libs.plugins.kmp.koin.convention)
+    alias(libs.plugins.jetbrainsCompose)
+    alias(libs.plugins.compose.compiler)
+}
+
+android {
+    namespace = "com.mifos.core.store"
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            // Foundation: state model + UI defaults the seam customizes.
+            // `api` so consumers get LocalScreenStateDefaults, ScreenState*, etc.
+            // by depending on `core/store` alone.
+            api(projects.coreBase.store)
+            api(projects.coreBase.ui)
+
+            // Compose runtime — needed for the @Composable appScreenStateDefaults() factory.
+            implementation(compose.runtime)
+        }
+    }
+}

--- a/core/store/src/commonMain/kotlin/com/mifos/core/store/AppErrorMapper.kt
+++ b/core/store/src/commonMain/kotlin/com/mifos/core/store/AppErrorMapper.kt
@@ -13,17 +13,10 @@ import template.core.base.store.error.ErrorCategory
 import template.core.base.store.error.categorize
 
 /**
- * Application-level error → user-facing message mapper.
+ * Application-level error → user-facing message mapper. Layers branded copy and
+ * domain-specific exception branches on top of [categorize].
  *
- * The library default ([template.core.base.ui.defaultErrorMessage]) routes through
- * [categorize] to return generic per-category copy. This mapper layers app-specific
- * decisions on top:
- * - branded copy ("Sign in to Mifos Field Officer again." instead of "Sign in again.")
- * - domain-specific error types (Fineract API error codes — extend as features migrate)
- * - localized strings (wire `composeResources` here once string indirection lands)
- *
- * As Phase C feature waves migrate to Store5, add their Fineract-specific exception
- * branches above the [categorize] fallback.
+ * Add domain branches above the [categorize] fallback as needed.
  */
 fun mapErrorToUserMessage(error: Throwable): String = when (categorize(error)) {
     ErrorCategory.Network -> "Can't reach the server. Check your connection and try again."
@@ -31,7 +24,4 @@ fun mapErrorToUserMessage(error: Throwable): String = when (categorize(error)) {
     ErrorCategory.RateLimit -> "Too many requests. Please wait a moment and try again."
     ErrorCategory.Server -> "Our servers are having a moment. Please try again shortly."
     ErrorCategory.Generic -> error.message ?: "Something went wrong."
-    // Phase C feature-wave migrations add Fineract-specific exception branches here, e.g.
-    //   error is FineractValidationException -> "Account number must be 8-12 digits."
-    //   error is OfflineSubmissionRejectedException -> "This submission was rejected. Pull to refresh."
 }

--- a/core/store/src/commonMain/kotlin/com/mifos/core/store/AppErrorMapper.kt
+++ b/core/store/src/commonMain/kotlin/com/mifos/core/store/AppErrorMapper.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package com.mifos.core.store
+
+import template.core.base.store.error.ErrorCategory
+import template.core.base.store.error.categorize
+
+/**
+ * Application-level error → user-facing message mapper.
+ *
+ * The library default ([template.core.base.ui.defaultErrorMessage]) routes through
+ * [categorize] to return generic per-category copy. This mapper layers app-specific
+ * decisions on top:
+ * - branded copy ("Sign in to Mifos Field Officer again." instead of "Sign in again.")
+ * - domain-specific error types (Fineract API error codes — extend as features migrate)
+ * - localized strings (wire `composeResources` here once string indirection lands)
+ *
+ * As Phase C feature waves migrate to Store5, add their Fineract-specific exception
+ * branches above the [categorize] fallback.
+ */
+fun mapErrorToUserMessage(error: Throwable): String = when (categorize(error)) {
+    ErrorCategory.Network -> "Can't reach the server. Check your connection and try again."
+    ErrorCategory.Auth -> "Your session expired. Please sign in to Mifos Field Officer again."
+    ErrorCategory.RateLimit -> "Too many requests. Please wait a moment and try again."
+    ErrorCategory.Server -> "Our servers are having a moment. Please try again shortly."
+    ErrorCategory.Generic -> error.message ?: "Something went wrong."
+    // Phase C feature-wave migrations add Fineract-specific exception branches here, e.g.
+    //   error is FineractValidationException -> "Account number must be 8-12 digits."
+    //   error is OfflineSubmissionRejectedException -> "This submission was rejected. Pull to refresh."
+}

--- a/core/store/src/commonMain/kotlin/com/mifos/core/store/AppScreenStateDefaults.kt
+++ b/core/store/src/commonMain/kotlin/com/mifos/core/store/AppScreenStateDefaults.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package com.mifos.core.store
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import template.core.base.ui.screen.ScreenStateDefaults
+import template.core.base.ui.screen.ScreenStateEmpty
+import template.core.base.ui.screen.ScreenStateError
+import template.core.base.ui.screen.ScreenStateLoading
+import template.core.base.ui.screen.ScreenStateNoNetwork
+
+/**
+ * !! FORK CUSTOMIZATION POINT !!
+ *
+ * App-wide [ScreenStateDefaults] for `template.core.base.ui.ScreenContent` and
+ * `template.core.base.ui.PagingScreenContent`. Wired into [MifosTheme] (follow-up:
+ * thread `LocalScreenStateDefaults provides appScreenStateDefaults()` into the existing
+ * `core/designsystem` MifosTheme composable) — every screen wrapped by `MifosTheme`
+ * then automatically picks up these defaults. No per-screen wiring required.
+ *
+ * Do NOT edit `core-base/store` or `core-base/ui` — they're framework-shared and sync
+ * cleanly from `kmp-project-template`. Customize here instead.
+ *
+ * Branding hooks for later:
+ * - Lottie animations (once `ScreenStateVisual.Lottie(spec = DefaultLottieAnimations.empty)`
+ *   bundled JSONs land in `core-base/ui` composeResources)
+ * - Telemetry via [ScreenStateError.onShown]
+ * - Localized strings via composeResources
+ */
+@Composable
+fun appScreenStateDefaults(): ScreenStateDefaults = remember {
+    ScreenStateDefaults(
+        loading = ScreenStateLoading.Skeleton(rowCount = 5),
+        empty = ScreenStateEmpty(
+            title = "Nothing here yet",
+            message = "When you have data, it'll show up here.",
+        ),
+        error = ScreenStateError(
+            messageFor = ::mapErrorToUserMessage,
+            // Telemetry hook for later, e.g.
+            //   onShown = { error -> Analytics.recordError("screen_state_error", error) },
+        ),
+        noNetwork = ScreenStateNoNetwork(
+            message = "You're offline. We'll retry when you reconnect.",
+        ),
+    )
+}

--- a/core/store/src/commonMain/kotlin/com/mifos/core/store/AppScreenStateDefaults.kt
+++ b/core/store/src/commonMain/kotlin/com/mifos/core/store/AppScreenStateDefaults.kt
@@ -18,22 +18,11 @@ import template.core.base.ui.screen.ScreenStateLoading
 import template.core.base.ui.screen.ScreenStateNoNetwork
 
 /**
- * !! FORK CUSTOMIZATION POINT !!
+ * App-wide [ScreenStateDefaults] for `ScreenContent` / `PagingScreenContent`.
+ * Wired into [MifosTheme] via `CompositionLocalProvider(LocalScreenStateDefaults)`
+ * so every themed screen inherits these defaults.
  *
- * App-wide [ScreenStateDefaults] for `template.core.base.ui.ScreenContent` and
- * `template.core.base.ui.PagingScreenContent`. Wired into [MifosTheme] (follow-up:
- * thread `LocalScreenStateDefaults provides appScreenStateDefaults()` into the existing
- * `core/designsystem` MifosTheme composable) — every screen wrapped by `MifosTheme`
- * then automatically picks up these defaults. No per-screen wiring required.
- *
- * Do NOT edit `core-base/store` or `core-base/ui` — they're framework-shared and sync
- * cleanly from `kmp-project-template`. Customize here instead.
- *
- * Branding hooks for later:
- * - Lottie animations (once `ScreenStateVisual.Lottie(spec = DefaultLottieAnimations.empty)`
- *   bundled JSONs land in `core-base/ui` composeResources)
- * - Telemetry via [ScreenStateError.onShown]
- * - Localized strings via composeResources
+ * Customize visuals, copy, and telemetry hooks here.
  */
 @Composable
 fun appScreenStateDefaults(): ScreenStateDefaults = remember {
@@ -43,11 +32,7 @@ fun appScreenStateDefaults(): ScreenStateDefaults = remember {
             title = "Nothing here yet",
             message = "When you have data, it'll show up here.",
         ),
-        error = ScreenStateError(
-            messageFor = ::mapErrorToUserMessage,
-            // Telemetry hook for later, e.g.
-            //   onShown = { error -> Analytics.recordError("screen_state_error", error) },
-        ),
+        error = ScreenStateError(messageFor = ::mapErrorToUserMessage),
         noNetwork = ScreenStateNoNetwork(
             message = "You're offline. We'll retry when you reconnect.",
         ),

--- a/core/store/src/commonMain/kotlin/com/mifos/core/store/AppStoreRegistry.kt
+++ b/core/store/src/commonMain/kotlin/com/mifos/core/store/AppStoreRegistry.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package com.mifos.core.store
+
+import template.core.base.store.infra.StoreRegistry
+
+/**
+ * Application-level [StoreRegistry] — the single named-qualifier registry for every
+ * `org.mobilenativefoundation.store.store5.Store` the app exposes.
+ *
+ * Add domain stores here as `val`s, e.g.:
+ *
+ * ```kotlin
+ * object AppStoreRegistry : StoreRegistry() {
+ *     val ClientList = store("clientList")
+ *     val LoanAccounts = store("loanAccounts")
+ * }
+ * ```
+ *
+ * Then reference the qualifier from Koin DI:
+ *
+ * ```kotlin
+ * single<Store<Long, ClientList>>(qualifier = AppStoreRegistry.ClientList) { ... }
+ * ```
+ *
+ * Centralizing here gives a one-place audit of every Store the app owns and prevents
+ * qualifier-name collisions across feature modules.
+ */
+object AppStoreRegistry : StoreRegistry() {
+    // Phase C wave-by-wave registration. Stores get added here as features migrate:
+    //   Wave 2: AboutData, AuthState, ActivationData
+    //   Wave 3: ClientList, GroupList, CenterList, SearchResults, SearchRecords
+    //   Wave 4: SavingsSubmit, RecurringDepositSubmit, NoteSubmit
+    //   Wave 5: CheckerInboxTask, PathTrackingUpdate
+    //   Wave 6: CollectionSheetSubmit, ReportGenerate, DocumentUpload
+    //   Wave 7: LoanCreate/Repayment, ClientCreate/KYC
+}

--- a/core/store/src/commonMain/kotlin/com/mifos/core/store/AppStoreRegistry.kt
+++ b/core/store/src/commonMain/kotlin/com/mifos/core/store/AppStoreRegistry.kt
@@ -33,12 +33,4 @@ import template.core.base.store.infra.StoreRegistry
  * Centralizing here gives a one-place audit of every Store the app owns and prevents
  * qualifier-name collisions across feature modules.
  */
-object AppStoreRegistry : StoreRegistry() {
-    // Phase C wave-by-wave registration. Stores get added here as features migrate:
-    //   Wave 2: AboutData, AuthState, ActivationData
-    //   Wave 3: ClientList, GroupList, CenterList, SearchResults, SearchRecords
-    //   Wave 4: SavingsSubmit, RecurringDepositSubmit, NoteSubmit
-    //   Wave 5: CheckerInboxTask, PathTrackingUpdate
-    //   Wave 6: CollectionSheetSubmit, ReportGenerate, DocumentUpload
-    //   Wave 7: LoanCreate/Repayment, ClientCreate/KYC
-}
+object AppStoreRegistry : StoreRegistry()

--- a/core/store/src/commonMain/kotlin/com/mifos/core/store/di/StoreModule.kt
+++ b/core/store/src/commonMain/kotlin/com/mifos/core/store/di/StoreModule.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package com.mifos.core.store.di
+
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+/**
+ * Koin module for app-level Store wiring.
+ *
+ * Phase C feature waves register their `Store` instances here, qualifier-bound via
+ * [com.mifos.core.store.AppStoreRegistry]. Empty in this Phase B scaffold — the seam
+ * exists so feature modules have one obvious DI module to extend without modifying
+ * `core-base/store`.
+ *
+ * Wire into the Koin start-up (Phase B follow-up — `cmp-android` / `cmp-ios` app modules):
+ * ```kotlin
+ * startKoin {
+ *     modules(appStoreModule, /* ...other modules */)
+ * }
+ * ```
+ */
+val appStoreModule: Module = module {
+    // Phase C feature-wave registrations land here, e.g.
+    //   single(qualifier = AppStoreRegistry.ClientList) { ClientListStore(get(), get()) }
+    //   single(qualifier = AppStoreRegistry.LoanAccounts) { LoanAccountsStore(get(), get()) }
+}

--- a/core/store/src/commonMain/kotlin/com/mifos/core/store/di/StoreModule.kt
+++ b/core/store/src/commonMain/kotlin/com/mifos/core/store/di/StoreModule.kt
@@ -13,22 +13,9 @@ import org.koin.core.module.Module
 import org.koin.dsl.module
 
 /**
- * Koin module for app-level Store wiring.
- *
- * Phase C feature waves register their `Store` instances here, qualifier-bound via
- * [com.mifos.core.store.AppStoreRegistry]. Empty in this Phase B scaffold — the seam
- * exists so feature modules have one obvious DI module to extend without modifying
- * `core-base/store`.
- *
- * Wire into the Koin start-up (Phase B follow-up — `cmp-android` / `cmp-ios` app modules):
- * ```kotlin
- * startKoin {
- *     modules(appStoreModule, /* ...other modules */)
- * }
- * ```
+ * Koin module for app-level Store wiring. Feature modules add their `Store<K, V>`
+ * registrations here, qualifier-bound via [com.mifos.core.store.AppStoreRegistry].
  */
 val appStoreModule: Module = module {
-    // Phase C feature-wave registrations land here, e.g.
-    //   single(qualifier = AppStoreRegistry.ClientList) { ClientListStore(get(), get()) }
-    //   single(qualifier = AppStoreRegistry.LoanAccounts) { LoanAccountsStore(get(), get()) }
+    // single(qualifier = AppStoreRegistry.Foo) { FooStore(get(), get()) }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -67,14 +67,18 @@ include(":core:domain")
 include(":core:datastore")
 include(":core:model")
 include(":core:network")
+include(":core:store")
 include(":core:ui")
 
 include(":core-base:analytics")
 include(":core-base:common")
 include(":core-base:database")
+include(":core-base:datastore")
 include(":core-base:designsystem")
 include(":core-base:network")
 include(":core-base:platform")
+include(":core-base:security")
+include(":core-base:store")
 include(":core-base:ui")
 
 // Lint Modules


### PR DESCRIPTION
## Summary

Phase B of the Store5-template-adoption epic. Wires field-officer's consumer customization seam (`core/store`) for offline-first reads/writes, hooks `LocalScreenStateDefaults` into `MifosTheme`, registers `appStoreModule` in central Koin, and adds the `framework_submit_drafts` table (DB v1 → v2) backed by `RoomSubmitOutbox<P>`.

This unblocks Phase C — feature waves can now migrate to `Store5` with branded loading / error / empty / no-network visuals and offline-resilient mutation submission, with **zero per-screen state-handling code**.

## Changes (17 files, +434 / -24)

### 1. `core/store/` module — consumer customization seam (new module)
- `build.gradle.kts` — Compose + Koin convention plugins; `api(projects.coreBase.store)` + `api(projects.coreBase.ui)` so consumers get `LocalScreenStateDefaults`, `ScreenState*`, `Store5Registry` from `core/store` alone
- `README.md` — full pattern documentation (what you get for free, customization points, Phase C syncer pattern)
- `AppStoreRegistry.kt` — named-qualifier registry; Phase C waves add `val Foo = store("foo")` here
- `AppErrorMapper.kt` — `Throwable → user-message` mapper. Routes through `template.core.base.store.error.categorize` with Fineract-aware copy; ready to extend with Fineract exception branches as features land
- `AppScreenStateDefaults.kt` — branded `ScreenStateDefaults` (skeleton loading, branded empty/error/no-network copy, `messageFor = ::mapErrorToUserMessage`)
- `di/StoreModule.kt` — Koin `appStoreModule`; empty entry point that Phase C waves extend with `single<Store<K,V>>(qualifier = AppStoreRegistry.X) { ... }` registrations

### 2. `core/designsystem/.../Theme.kt` — `LocalScreenStateDefaults` wiring
```kotlin
val screenStateDefaults = appScreenStateDefaults()
KptMaterialTheme(theme = theme) {
    CompositionLocalProvider(
        LocalScreenStateDefaults provides screenStateDefaults,
    ) {
        content()
    }
}
```
Every screen under `MifosTheme` now inherits branded defaults — no per-screen wiring.

### 3. `cmp-navigation/.../di/KoinModules.kt` — central Koin registration
Adds `appStoreModule` to the `allModules` list. Feature waves register their `Store<K,V>` factories qualifier-bound via `AppStoreRegistry`.

### 4. `MifosDatabase` v1 → v2 migration — `framework_submit_drafts` table
- **New entity**: `com.mifos.room.entities.framework.DraftEntity` (`@Entity(tableName = "framework_submit_drafts")`) — 7 columns matching template's reference impl
- **New DAO**: `com.mifos.room.dao.DraftDao` — insert / getById / getPendingByFormKey / observePendingByFormKey / getAllPending / markRetrying / markSubmitted / markFailed / updatePayload / deleteByFormKey / deleteAll / deleteOlderThan
- **MifosDatabase**: commonMain `expect` + 3 platform actuals (android / desktop / native) updated — entity added to `entities[]`, `abstract val draftDao: DraftDao` added, `VERSION` bumped 1 → 2 with KDoc
- **Migration**: `MIGRATION_1_2` (raw SQL `CREATE TABLE`) added to each platform's `DatabaseModule.<platform>.kt`, chained onto `AppDatabaseFactory` builder via `.addMigrations()`. Portable via `androidx.room3.migration.Migration` + `androidx.sqlite.execSQL`.
- **DaoModule**: `+ single { get<MifosDatabase>().draftDao }`

### 5. `RoomSubmitOutbox<P>` — `SubmitOutbox` bridge to `DraftDao`
At `com.mifos.core.data.infra.impl.RoomSubmitOutbox`. Serializes payloads via `kotlinx.serialization`, persists to `framework_submit_drafts`. Idempotent `save` (upserts on `formKey` collision). Used by Phase C feature waves to make form submissions offline-resilient — payload survives process death; auto-retried by `OfflineSubmitSyncer` on reconnect.
- `core/data/build.gradle.kts` — `+ api(projects.coreBase.store)`

### 6. `OfflineSubmitSyncer` pattern documented
`OfflineSubmitSyncer<P, R>` is parameterized by payload type. The original Phase B plan assumed a global syncer in `MainActivity` — corrected: syncers are instantiated per form within feature DI modules. Full pattern documented in `core/store/README.md` "Phase C syncer pattern".

## Phase C syncer pattern (example for one feature)

```kotlin
single<SubmitOutbox<LoanApplicationPayload>> {
    RoomSubmitOutbox(
        dao = get<MifosDatabase>().draftDao,
        serializer = LoanApplicationPayload.serializer(),
    )
}
single { (scope: CoroutineScope) ->
    scope.offlineSubmitSyncer(
        outbox       = get<SubmitOutbox<LoanApplicationPayload>>(),
        isOnlineFlow = get<NetworkMonitor>().isOnline,
        submitBlock  = { payload -> get<LoanRepository>().submit(payload) },
    ).also { it.start() }
}
```

## Test plan

- [ ] Gradle compiles — `./gradlew :core:store:build :core:database:build :core:data:build :core:designsystem:build :cmp-navigation:build` resolves all deps + compiles all modules
- [ ] DB migration smoke test — install app on v1 schema, upgrade to v2, verify `framework_submit_drafts` table exists with correct columns (`id`, `formKey`, `payloadJson`, `status`, `createdAtMs`, `updatedAtMs`, `errorMessage`) and is empty
- [ ] No screen breakage — `MifosTheme`-wrapped screens still render normally; no NPE on `LocalScreenStateDefaults` access from any screen
- [ ] Koin start-up — `startKoin { modules(KoinModules.allModules) }` boots cleanly with `appStoreModule` added (no missing-dep errors)
- [ ] CI green (CI failures, if any, will be the same coverage / SonarCloud ones expected at the final epic-merge gate; not blockers for `store5Migration` PR review)

## Phase status

- ✅ Phase A (infra sync) — `kmp-project-template#158` + `openMF/mifos-x-field-officer-app#2681` + `#2682` merged
- 🟢 **Phase B (this PR)** — core/store seam complete; ready for Phase C
- 🔵 Phase C — 20 feature waves migrate to Store5 (drafted in plan, not started)
- 🔵 Phase D — DataState bridge removal + final merge `store5Migration → development`

## Related

- Epic plan: `plan-layer/project-plans/mifos-x/mifos-x-field-officer-app/active/store5-adoption/PLAN.md`
- Phase B sub-plan: `plan-layer/project-plans/mifos-x/mifos-x-field-officer-app/active/store5-adoption/B-core.md`
- Phase A bootstrap PR: `openMF/mifos-x-field-officer-app#2681`
- Phase A sync PR: `openMF/mifos-x-field-officer-app#2682`
- Template SOT PR: `openMF/kmp-project-template#158`