### PR TITLE
feat(feature/activate): migrate ActivateViewModel to SubmitHandler<Unit>

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -40,7 +40,7 @@ kotlin {
             api(projects.core.network)
             api(projects.core.database)
             api(projects.coreBase.common)
-            api(projects.coreBase.store)
+            api(projects.core.store)
 
 
             implementation(libs.mifos.authenticator.passcode)

--- a/core/data/src/commonMain/kotlin/com/mifos/core/data/store/SubmitTypes.kt
+++ b/core/data/src/commonMain/kotlin/com/mifos/core/data/store/SubmitTypes.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mifos-x-field-officer-app/blob/master/LICENSE.md
+ */
+package com.mifos.core.data.store
+
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * App-facing re-exports of the offline-first submission primitives.
+ *
+ * Feature modules import these from `com.mifos.core.data.store` and never reach into
+ * `template.core.base.store.*` directly. The dependency direction is enforced:
+ *   core-base/store → core/store → core/data → feature/*
+ */
+
+typealias SubmitHandler<R> = template.core.base.store.submit.SubmitHandler<R>
+typealias SubmitState<R> = template.core.base.store.submit.SubmitState<R>
+
+/** Creates a [SubmitHandler] bound to this [CoroutineScope] (typically `viewModelScope`). */
+fun <R> CoroutineScope.submitHandler(): SubmitHandler<R> =
+    template.core.base.store.submit.submitHandler()

--- a/feature/activate/build.gradle.kts
+++ b/feature/activate/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
             implementation(compose.material3)
             implementation(compose.components.resources)
             implementation(compose.ui)
+            implementation(projects.core.data)
             implementation(projects.core.domain)
             implementation(compose.components.uiToolingPreview)
         }

--- a/feature/activate/src/commonMain/kotlin/com/mifos/feature/activate/ActivateViewModel.kt
+++ b/feature/activate/src/commonMain/kotlin/com/mifos/feature/activate/ActivateViewModel.kt
@@ -21,13 +21,18 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.mifos.core.common.utils.DataState
+import com.mifos.core.data.store.SubmitState
+import com.mifos.core.data.store.submitHandler
 import com.mifos.core.domain.useCases.ActivateCenterUseCase
 import com.mifos.core.domain.useCases.ActivateClientUseCase
 import com.mifos.core.domain.useCases.ActivateGroupUseCase
 import com.mifos.core.model.objects.clients.ActivatePayload
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import org.jetbrains.compose.resources.StringResource
 
 class ActivateViewModel(
     private val activateClientUseCase: ActivateClientUseCase,
@@ -39,56 +44,51 @@ class ActivateViewModel(
     val id = savedStateHandle.toRoute<ActivateRoute>().id
     val activateType = savedStateHandle.toRoute<ActivateRoute>().type
 
-    private val _activateUiState = MutableStateFlow<ActivateUiState>(ActivateUiState.Initial)
-    val activateUiState = _activateUiState.asStateFlow()
+    private val submit = viewModelScope.submitHandler<Unit>()
+    private var successMessage: StringResource = Res.string.feature_activate_client
+    private var failureMessage: StringResource = Res.string.feature_activate_failed_to_activate_client
 
-    fun activateClient(clientId: Int, clientPayload: ActivatePayload) =
-        viewModelScope.launch {
-            activateClientUseCase(clientId, clientPayload).collect { result ->
-                when (result) {
-                    is DataState.Error ->
-                        _activateUiState.value =
-                            ActivateUiState.Error(Res.string.feature_activate_failed_to_activate_client)
-
-                    is DataState.Loading -> _activateUiState.value = ActivateUiState.Loading
-
-                    is DataState.Success ->
-                        _activateUiState.value =
-                            ActivateUiState.ActivatedSuccessfully(Res.string.feature_activate_client)
-                }
+    val activateUiState: StateFlow<ActivateUiState> = submit.state
+        .map { state ->
+            when (state) {
+                is SubmitState.Idle -> ActivateUiState.Initial
+                is SubmitState.Submitting -> ActivateUiState.Loading
+                is SubmitState.Submitted<*> -> ActivateUiState.ActivatedSuccessfully(successMessage)
+                is SubmitState.Failed -> ActivateUiState.Error(failureMessage)
             }
         }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = ActivateUiState.Initial,
+        )
 
-    fun activateCenter(centerId: Int, centerPayload: ActivatePayload) =
-        viewModelScope.launch {
-            activateCenterUseCase(centerId, centerPayload).collect { result ->
-                when (result) {
-                    is DataState.Error ->
-                        _activateUiState.value =
-                            ActivateUiState.Error(Res.string.feature_activate_failed_to_activate_center)
-
-                    is DataState.Loading -> _activateUiState.value = ActivateUiState.Loading
-
-                    is DataState.Success ->
-                        _activateUiState.value =
-                            ActivateUiState.ActivatedSuccessfully(Res.string.feature_activate_center)
-                }
-            }
+    fun activateClient(clientId: Int, clientPayload: ActivatePayload) {
+        successMessage = Res.string.feature_activate_client
+        failureMessage = Res.string.feature_activate_failed_to_activate_client
+        submit.submit {
+            val terminal = activateClientUseCase(clientId, clientPayload)
+                .first { it !is DataState.Loading }
+            if (terminal is DataState.Error) throw terminal.exception
         }
+    }
 
-    fun activateGroup(groupId: Int, groupPayload: ActivatePayload) =
-        viewModelScope.launch {
-            val result = activateGroupUseCase(groupId, groupPayload)
-            when (result) {
-                is DataState.Error ->
-                    _activateUiState.value =
-                        ActivateUiState.Error(Res.string.feature_activate_failed_to_activate_group)
-
-                DataState.Loading -> Unit // unreachable
-
-                is DataState.Success ->
-                    _activateUiState.value =
-                        ActivateUiState.ActivatedSuccessfully(Res.string.feature_activate_group)
-            }
+    fun activateCenter(centerId: Int, centerPayload: ActivatePayload) {
+        successMessage = Res.string.feature_activate_center
+        failureMessage = Res.string.feature_activate_failed_to_activate_center
+        submit.submit {
+            val terminal = activateCenterUseCase(centerId, centerPayload)
+                .first { it !is DataState.Loading }
+            if (terminal is DataState.Error) throw terminal.exception
         }
+    }
+
+    fun activateGroup(groupId: Int, groupPayload: ActivatePayload) {
+        successMessage = Res.string.feature_activate_group
+        failureMessage = Res.string.feature_activate_failed_to_activate_group
+        submit.submit {
+            val terminal = activateGroupUseCase(groupId, groupPayload)
+            if (terminal is DataState.Error) throw terminal.exception
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Phase C **Wave 1** — first feature migration to Store5, establishing the dependency-chain pattern for all 19 subsequent mutation-feature migrations.

Adds the **`com.mifos.core.data.store`** re-export layer so feature modules consume Store5 submission primitives through `core/data` and **never reach into `template.core.base.store.*` directly**. Then migrates `ActivateViewModel` as the proof-of-pattern.

## Dependency-chain contract (enforced)

```
core-base/store → core/store → core/data → feature/*
```

- `core-base/store` — framework primitives (`template.core.base.store.*`), not directly importable from features
- `core/store` — app-level customization seam (already exposed `api(coreBase.store)` in Phase B)
- `core/data` — re-exports Store5 abstractions under `com.mifos.core.data.store.*`. **Now correctly routes through `api(projects.core.store)` instead of `api(projects.coreBase.store)`**
- `feature/*` — depends only on `core/data` (`implementation(projects.core.data)`) and imports `com.mifos.core.data.store.*`

## Changes (4 files, +76 / -48)

| File | Change |
|---|---|
| `core/data/build.gradle.kts` | `api(projects.coreBase.store)` → `api(projects.core.store)` |
| `core/data/.../store/SubmitTypes.kt` | NEW — typealias `SubmitHandler<R>` / `SubmitState<R>` + `CoroutineScope.submitHandler<R>()` re-export |
| `feature/activate/build.gradle.kts` | `+ implementation(projects.core.data)` (no `coreBase.store`) |
| `feature/activate/.../ActivateViewModel.kt` | Manual `DataState.collect` → `SubmitHandler<Unit>` (imported from `com.mifos.core.data.store`). `ActivateUiState` and Screen untouched. |

## Migration template for subsequent waves

1. `feature/<name>/build.gradle.kts`: `implementation(projects.core.data)` (no `coreBase.store`)
2. Import `com.mifos.core.data.store.SubmitHandler` / `SubmitState` / `submitHandler` (no `template.core.base.store.*`)
3. Replace manual `DataState.collect` with `viewModelScope.submitHandler<R>()`
4. Map `submit.state` to existing UiState via `.map.stateIn` to keep the Screen stable
5. Bridge use-case returns through `.first { !Loading }` (Flow) or direct check (suspend) + throw on Error

## Test plan

- [ ] No `template.core.base.store.*` imports anywhere under `feature/*`
- [ ] No `implementation(projects.coreBase.store)` in any `feature/*/build.gradle.kts`
- [ ] Activate-client / Center / Group flows behave identically to pre-PR
- [ ] Rapid double-tap is idempotent; sequential calls cancel prior in-flight job

## Related

- Phase B PR: `#2683` (merged)
- Wave 2 follow-up: `feat/store5-c2-auth` (chained on this branch)