### PR TITLE
feat(feature/auth): migrate LoginViewModel to SubmitHandler

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -40,7 +40,7 @@ kotlin {
             api(projects.core.network)
             api(projects.core.database)
             api(projects.coreBase.common)
-            api(projects.coreBase.store)
+            api(projects.core.store)
 
 
             implementation(libs.mifos.authenticator.passcode)

--- a/core/data/src/commonMain/kotlin/com/mifos/core/data/store/SubmitTypes.kt
+++ b/core/data/src/commonMain/kotlin/com/mifos/core/data/store/SubmitTypes.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mifos-x-field-officer-app/blob/master/LICENSE.md
+ */
+package com.mifos.core.data.store
+
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * App-facing re-exports of the offline-first submission primitives.
+ *
+ * Feature modules import these from `com.mifos.core.data.store` and never reach into
+ * `template.core.base.store.*` directly. The dependency direction is enforced:
+ *   core-base/store → core/store → core/data → feature/*
+ */
+
+typealias SubmitHandler<R> = template.core.base.store.submit.SubmitHandler<R>
+typealias SubmitState<R> = template.core.base.store.submit.SubmitState<R>
+
+/** Creates a [SubmitHandler] bound to this [CoroutineScope] (typically `viewModelScope`). */
+fun <R> CoroutineScope.submitHandler(): SubmitHandler<R> =
+    template.core.base.store.submit.submitHandler()

--- a/feature/activate/build.gradle.kts
+++ b/feature/activate/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
             implementation(compose.material3)
             implementation(compose.components.resources)
             implementation(compose.ui)
+            implementation(projects.core.data)
             implementation(projects.core.domain)
             implementation(compose.components.uiToolingPreview)
         }

--- a/feature/activate/src/commonMain/kotlin/com/mifos/feature/activate/ActivateViewModel.kt
+++ b/feature/activate/src/commonMain/kotlin/com/mifos/feature/activate/ActivateViewModel.kt
@@ -21,13 +21,18 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.mifos.core.common.utils.DataState
+import com.mifos.core.data.store.SubmitState
+import com.mifos.core.data.store.submitHandler
 import com.mifos.core.domain.useCases.ActivateCenterUseCase
 import com.mifos.core.domain.useCases.ActivateClientUseCase
 import com.mifos.core.domain.useCases.ActivateGroupUseCase
 import com.mifos.core.model.objects.clients.ActivatePayload
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import org.jetbrains.compose.resources.StringResource
 
 class ActivateViewModel(
     private val activateClientUseCase: ActivateClientUseCase,
@@ -39,56 +44,51 @@ class ActivateViewModel(
     val id = savedStateHandle.toRoute<ActivateRoute>().id
     val activateType = savedStateHandle.toRoute<ActivateRoute>().type
 
-    private val _activateUiState = MutableStateFlow<ActivateUiState>(ActivateUiState.Initial)
-    val activateUiState = _activateUiState.asStateFlow()
+    private val submit = viewModelScope.submitHandler<Unit>()
+    private var successMessage: StringResource = Res.string.feature_activate_client
+    private var failureMessage: StringResource = Res.string.feature_activate_failed_to_activate_client
 
-    fun activateClient(clientId: Int, clientPayload: ActivatePayload) =
-        viewModelScope.launch {
-            activateClientUseCase(clientId, clientPayload).collect { result ->
-                when (result) {
-                    is DataState.Error ->
-                        _activateUiState.value =
-                            ActivateUiState.Error(Res.string.feature_activate_failed_to_activate_client)
-
-                    is DataState.Loading -> _activateUiState.value = ActivateUiState.Loading
-
-                    is DataState.Success ->
-                        _activateUiState.value =
-                            ActivateUiState.ActivatedSuccessfully(Res.string.feature_activate_client)
-                }
+    val activateUiState: StateFlow<ActivateUiState> = submit.state
+        .map { state ->
+            when (state) {
+                is SubmitState.Idle -> ActivateUiState.Initial
+                is SubmitState.Submitting -> ActivateUiState.Loading
+                is SubmitState.Submitted<*> -> ActivateUiState.ActivatedSuccessfully(successMessage)
+                is SubmitState.Failed -> ActivateUiState.Error(failureMessage)
             }
         }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = ActivateUiState.Initial,
+        )
 
-    fun activateCenter(centerId: Int, centerPayload: ActivatePayload) =
-        viewModelScope.launch {
-            activateCenterUseCase(centerId, centerPayload).collect { result ->
-                when (result) {
-                    is DataState.Error ->
-                        _activateUiState.value =
-                            ActivateUiState.Error(Res.string.feature_activate_failed_to_activate_center)
-
-                    is DataState.Loading -> _activateUiState.value = ActivateUiState.Loading
-
-                    is DataState.Success ->
-                        _activateUiState.value =
-                            ActivateUiState.ActivatedSuccessfully(Res.string.feature_activate_center)
-                }
-            }
+    fun activateClient(clientId: Int, clientPayload: ActivatePayload) {
+        successMessage = Res.string.feature_activate_client
+        failureMessage = Res.string.feature_activate_failed_to_activate_client
+        submit.submit {
+            val terminal = activateClientUseCase(clientId, clientPayload)
+                .first { it !is DataState.Loading }
+            if (terminal is DataState.Error) throw terminal.exception
         }
+    }
 
-    fun activateGroup(groupId: Int, groupPayload: ActivatePayload) =
-        viewModelScope.launch {
-            val result = activateGroupUseCase(groupId, groupPayload)
-            when (result) {
-                is DataState.Error ->
-                    _activateUiState.value =
-                        ActivateUiState.Error(Res.string.feature_activate_failed_to_activate_group)
-
-                DataState.Loading -> Unit // unreachable
-
-                is DataState.Success ->
-                    _activateUiState.value =
-                        ActivateUiState.ActivatedSuccessfully(Res.string.feature_activate_group)
-            }
+    fun activateCenter(centerId: Int, centerPayload: ActivatePayload) {
+        successMessage = Res.string.feature_activate_center
+        failureMessage = Res.string.feature_activate_failed_to_activate_center
+        submit.submit {
+            val terminal = activateCenterUseCase(centerId, centerPayload)
+                .first { it !is DataState.Loading }
+            if (terminal is DataState.Error) throw terminal.exception
         }
+    }
+
+    fun activateGroup(groupId: Int, groupPayload: ActivatePayload) {
+        successMessage = Res.string.feature_activate_group
+        failureMessage = Res.string.feature_activate_failed_to_activate_group
+        submit.submit {
+            val terminal = activateGroupUseCase(groupId, groupPayload)
+            if (terminal is DataState.Error) throw terminal.exception
+        }
+    }
 }

--- a/feature/auth/src/commonMain/kotlin/com/mifos/feature/auth/login/LoginViewModel.kt
+++ b/feature/auth/src/commonMain/kotlin/com/mifos/feature/auth/login/LoginViewModel.kt
@@ -17,6 +17,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import com.mifos.core.common.utils.DataState
+import com.mifos.core.data.store.SubmitState
+import com.mifos.core.data.store.submitHandler
 import com.mifos.core.datastore.UserPreferencesRepository
 import com.mifos.core.domain.useCases.LoginUseCase
 import com.mifos.core.domain.useCases.PasswordValidationUseCase
@@ -25,11 +27,9 @@ import com.mifos.core.model.objects.users.User
 import com.mifos.core.network.model.PostAuthenticationResponse
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
-
-/**
- * Created by Aditya Gupta on 06/08/23.
- */
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 class LoginViewModel(
     private val prefManager: UserPreferencesRepository,
@@ -40,6 +40,31 @@ class LoginViewModel(
 
     private val _loginUiState = MutableStateFlow<LoginUiState>(LoginUiState.Empty)
     val loginUiState = _loginUiState.asStateFlow()
+
+    private val submit = viewModelScope.submitHandler<PostAuthenticationResponse>()
+    private var pendingCredentials: Pair<String, String>? = null
+
+    init {
+        submit.state
+            .onEach { state ->
+                when (state) {
+                    is SubmitState.Idle -> Unit
+                    is SubmitState.Submitting -> {
+                        _loginUiState.value = LoginUiState.ShowProgress
+                    }
+                    is SubmitState.Submitted -> {
+                        val (username, password) = pendingCredentials ?: return@onEach
+                        persistUserAndContinue(state.result, username, password)
+                    }
+                    is SubmitState.Failed -> {
+                        _loginUiState.value =
+                            LoginUiState.ShowError(Res.string.feature_auth_error_login_failed)
+                        Logger.d("@@@", state.error)
+                    }
+                }
+            }
+            .launchIn(viewModelScope)
+    }
 
     suspend fun validateUserInputs(username: String, password: String) {
         val usernameValidationResult = usernameValidationUseCase(username)
@@ -55,60 +80,43 @@ class LoginViewModel(
             )
             return
         }
-        viewModelScope.launch {
-            login(username, password)
-        }
-    }
 
-    private fun login(username: String, password: String) {
-        viewModelScope.launch {
-            loginUseCase(username, password).collect { result ->
-                when (result) {
-                    is DataState.Error -> {
-                        _loginUiState.value =
-                            LoginUiState.ShowError(Res.string.feature_auth_error_login_failed)
-                        Logger.d("@@@", Throwable("login: ${result.data}"))
-                    }
-
-                    is DataState.Loading -> {
-                        _loginUiState.value = LoginUiState.ShowProgress
-                    }
-
-                    is DataState.Success -> {
-                        if (result.data.authenticated == true) {
-                            onLoginSuccessful(result.data, username, password)
-                        } else {
-                            _loginUiState.value =
-                                LoginUiState.ShowError(Res.string.feature_auth_error_login_failed)
-
-                            Logger.d("@@@", Throwable("login: ${result.data}"))
-                        }
-                    }
+        pendingCredentials = username to password
+        submit.submit {
+            val terminal = loginUseCase(username, password)
+                .first { it !is DataState.Loading }
+            when (terminal) {
+                is DataState.Error -> throw terminal.exception
+                is DataState.Success -> {
+                    val response = terminal.data
+                    if (response.authenticated == true) response
+                    else throw LoginRejectedException(response)
                 }
+                is DataState.Loading -> error("Unreachable: filtered above")
             }
         }
     }
 
-    private fun onLoginSuccessful(
+    private suspend fun persistUserAndContinue(
         user: PostAuthenticationResponse,
         username: String,
         password: String,
     ) {
-        viewModelScope.launch {
-            prefManager.updateUser(
-                User(
-                    username = username,
-                    password = password,
-                    userId = user.userId!!,
-                    base64EncodedAuthenticationKey = user.base64EncodedAuthenticationKey,
-                    isAuthenticated = user.authenticated ?: false,
-                    officeId = user.officeId!!,
-                    officeName = user.officeName,
-                    permissions = user.permissions!!,
-                ),
-            )
-        }
-
+        prefManager.updateUser(
+            User(
+                username = username,
+                password = password,
+                userId = user.userId!!,
+                base64EncodedAuthenticationKey = user.base64EncodedAuthenticationKey,
+                isAuthenticated = user.authenticated ?: false,
+                officeId = user.officeId!!,
+                officeName = user.officeName,
+                permissions = user.permissions!!,
+            ),
+        )
         _loginUiState.value = LoginUiState.PassCodeActivityIntent
     }
 }
+
+private class LoginRejectedException(val response: PostAuthenticationResponse) :
+    RuntimeException("Login rejected: authenticated=${response.authenticated}")


### PR DESCRIPTION
## Summary

Phase C **Wave 2** — migrates `LoginViewModel` to `SubmitHandler<PostAuthenticationResponse>`, consuming Store5 primitives through `com.mifos.core.data.store` re-exports (the architectural pattern established in Wave 1 #2684).

**Chained on Wave 1 #2684** — merge that first. This PR contains only the auth-specific change.

## Changes (1 file, +57 / -49)

`feature/auth/.../login/LoginViewModel.kt`:
- Single `SubmitHandler<PostAuthenticationResponse>` (via `com.mifos.core.data.store.submitHandler`) replaces `viewModelScope.launch { ... .collect { ... } }`
- `submit.state` collected in `init { ... }` via `launchIn(viewModelScope)` + `onEach` — maps `SubmitState` to `LoginUiState`:
  - `Submitting` → `ShowProgress`
  - `Submitted<PostAuthenticationResponse>` → persists user via `prefManager.updateUser`, then `PassCodeActivityIntent`
  - `Failed` → `ShowError` (logs the actual error throwable)
- Validation logic untouched (it's a pre-submit gate, sets `ShowValidationError` directly)
- `LoginUseCase` `Flow<DataState<T>>` bridged via `.first { it !is DataState.Loading }`:
  - `DataState.Error` → throw `terminal.exception`
  - `DataState.Success` with `authenticated == true` → return response
  - `DataState.Success` with `authenticated != true` → throw sentinel `LoginRejectedException`
- No `feature/auth/build.gradle.kts` changes needed — the `implementation(projects.core.data)` dep already present exposes the `com.mifos.core.data.store.*` re-exports

## What this PR does NOT change

- `LoginUiState.kt` — sealed-class definition unchanged (Empty, ShowProgress, ShowError, ShowValidationError, PassCodeActivityIntent)
- `LoginScreen.kt` — Screen-side consumer code unchanged
- `LoginUseCase` / `UsernameValidationUseCase` / `PasswordValidationUseCase` — domain layer untouched
- Any other feature module — pure feature/auth scoped change

## Pattern proven on second feature

Wave 1 established the pattern on `activate` (3 isolated submit methods with `ActivateUiState` mapping). Wave 2 validates the same pattern on `auth` with extra complexity:
- Single submit method that produces a typed response (`PostAuthenticationResponse`) consumed in `Submitted` handler for a follow-up side effect (`prefManager.updateUser`)
- Mixed-source UiState — `ShowValidationError` set outside `SubmitHandler.state` flow (pre-submit gate), `ShowProgress` / `ShowError` / `PassCodeActivityIntent` driven by `SubmitHandler` state

This validates that the re-export layer + `SubmitHandler` are flexible enough for both "fire-and-forget" (activate) and "act-on-success-response" (auth) flows.

## Test plan

- [ ] `./gradlew :feature:auth:build` compiles cleanly
- [ ] No `template.core.base.store.*` imports in `feature/auth/**`
- [ ] Login happy path: validate → progress → success → navigation
- [ ] Login failure path: validate → progress → ShowError
- [ ] Validation-only failure: ShowValidationError without entering SubmitHandler
- [ ] Auth-rejected case (`authenticated != true`): ShowError (sentinel exception path)

## Phase status

- ✅ Phase A · ✅ Phase B
- 🟢 Phase C Wave 1 (`#2684` — `activate`)
- 🟢 **Phase C Wave 2 (this PR — `auth`)**
- 🔵 Phase C Waves 3–7
- 🔵 Phase D

## Related

- Wave 1 PR: `#2684` (must merge first — this branch is chained on it)